### PR TITLE
Renew command PTT bug fix proposal

### DIFF
--- a/Rubeus/lib/Renew.cs
+++ b/Rubeus/lib/Renew.cs
@@ -165,17 +165,13 @@ namespace Rubeus
                     {
                         Console.WriteLine("      {0}", line);
                     }
-                    if (ptt)
-                    {
-                        // pass-the-ticket -> import into LSASS
-                        LSA.ImportTicket(kirbiBytes);
-                    }
-                    return kirbiBytes;
                 }
-                else
+                if (ptt)
                 {
-                    return kirbiBytes;
+                    // pass-the-ticket -> import into LSASS
+                    LSA.ImportTicket(kirbiBytes);
                 }
+                return kirbiBytes;
             }
             else if (responseTag == 30)
             {


### PR DESCRIPTION
The renew command accepts both the /display and /ptt parameters. However using the /ptt parameter from the command line doesn't trigger LSA.ImportTicket method call unless the /display parameter is also passed to the command line.