### PR TITLE
Bug Fix : TicketFlags display in LSA.ListKerberosDataAllUsers

### DIFF
--- a/Rubeus/lib/LSA.cs
+++ b/Rubeus/lib/LSA.cs
@@ -607,7 +607,7 @@ namespace Rubeus
                                                 Int64 timeSkew = response.Ticket.TimeSkew;
                                                 Int32 encodedTicketSize = response.Ticket.EncodedTicketSize;
 
-                                                string ticketFlags = ((Interop.TicketFlags)ticket.TicketFlags).ToString();
+                                                string ticketFlags = ((Interop.TicketFlags)response.Ticket.TicketFlags).ToString();
 
                                                 // extract the ticket and base64 encode it
                                                 byte[] encodedTicket = new byte[encodedTicketSize];


### PR DESCRIPTION
The LSA.ListKerberosDataAllUsers incorrectly displays the TicketFlags property using value in ticket retrieved from cache, instead of using the ticket retrieved from LsaCallAuthenticationPackage.

This pull request provides a fix.