### PR TITLE
Correct AES Salt Generation

### DIFF
--- a/Rubeus/Commands/Asktgt.cs
+++ b/Rubeus/Commands/Asktgt.cs
@@ -45,7 +45,7 @@ namespace Rubeus.Commands
             {
                 password = arguments["/password"];
 
-                string salt = String.Format("{0}{1}", domain.ToUpper(), user.ToLower());
+                string salt = String.Format("{0}{1}", domain.ToUpper(), user);
                 encType = Interop.KERB_ETYPE.rc4_hmac; //default is non /enctype is specified
 
                 if (arguments.ContainsKey("/enctype"))

--- a/Rubeus/lib/Bruteforcer.cs
+++ b/Rubeus/lib/Bruteforcer.cs
@@ -72,7 +72,7 @@ namespace Rubeus
         private void GetUsernamePasswordTGT(string username, string password)
         {
             Interop.KERB_ETYPE encType = Interop.KERB_ETYPE.aes256_cts_hmac_sha1;
-            string salt = String.Format("{0}{1}", domain.ToUpper(), username.ToLower());
+            string salt = String.Format("{0}{1}", domain.ToUpper(), username);
             string hash = Crypto.KerberosPasswordHash(encType, password, salt);
 
             byte[] TGT = Ask.InnerTGT(username, domain, hash, encType, false, this.dc);

--- a/Rubeus/lib/Crypto.cs
+++ b/Rubeus/lib/Crypto.cs
@@ -16,7 +16,7 @@ namespace Rubeus
 
             Console.WriteLine("[*] Input password             : {0}", password);
 
-            string salt = String.Format("{0}{1}", domainName.ToUpper(), userName.ToLower());
+            string salt = String.Format("{0}{1}", domainName.ToUpper(), userName);
 
             if (!String.IsNullOrEmpty(userName) && !String.IsNullOrEmpty(domainName))
             {


### PR DESCRIPTION
It was my flawed understanding (and I assume many people's as well), that the salt for AES types in Kerberos was `FQDN.Upper() + Username.Lower()`. However this is not the case.

I believe Kevin Robertson details it the clearest in [Get-KerberosAESKey](
https://gist.github.com/Kevin-Robertson/9e0f8bfdbf4c1e694e6ff4197f0a4372#file-get-kerberosaeskey-ps1-L19)

```powershell
.PARAMETER Salt
[String] Concatenated string containing the realm and username/hostname.
AD username format = uppercase realm + case sensitive username (e.g., TEST.LOCALusername, TEST.LOCALAdministrator)
AD hostname format = uppercase realm + the word host + lowercase hostname without the trailing '$' + . + lowercase realm (e.g., TEST.LOCALhostwks1.test.local)
```

This came as such a surprise that I wondered how Windows determines the correct salt when supplying any username for authentication. The secret lies in an initial AS-REQ without a `PA-ENC-TIMESTAMP` section and with `PrincipalName` set to the case-insensitive username. The KDC will then respond with an `KRB5_ERR_PREAUTH_REQUIRED` containing a `PA_ETYPE_INFO2`, which supplies the encryption type + **the correct salt**. As per usual, impacket already has this figured out:

https://github.com/SecureAuthCorp/impacket/blob/d65c0d220a9613ae74db42adc9362a7947acdd66/impacket/krb5/kerberosv5.py#L200

So what to do? Well the extra back/forth might not be ideal in some scenarios (brute-forcing), but I'd be happy to implement it just to have it. Maybe a separate command like `getsalt`? It could also be added as part of the `hash` command which I rather like. It does open itself up to a fair bit of complexity like extra flags, specifying whether the username is already cased properly, etc. 

Of course these steps are generally unnecessary if you just use the `samaccountname` from AD (machine accounts aside). Therefore I've started by just removing any `ToLower()` calls when calculating the salt. This might also be best paired with some help/notes that indicate the username is case sensitive.

Let me know what your thoughts are and I'd be happy to oblige.