### PR TITLE
Fixes for name resolution issues from non domain machines

### DIFF
--- a/Rubeus/lib/Networking.cs
+++ b/Rubeus/lib/Networking.cs
@@ -1,5 +1,6 @@
 using System;
 using System.ComponentModel;
+using System.DirectoryServices;
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 
@@ -7,7 +8,7 @@ namespace Rubeus
 {
     public class Networking
     {
-        public static string GetDCName()
+        public static string GetDCName(string domainName = "")
         {
             // retrieves the current domain controller name
 
@@ -16,7 +17,7 @@ namespace Rubeus
             const int ERROR_SUCCESS = 0;
             IntPtr pDCI = IntPtr.Zero;
 
-            int val = Interop.DsGetDcName("", "", 0, "",
+            int val = Interop.DsGetDcName("", domainName, 0, "",
                 Interop.DSGETDCNAME_FLAGS.DS_DIRECTORY_SERVICE_REQUIRED |
                 Interop.DSGETDCNAME_FLAGS.DS_RETURN_DNS_NAME |
                 Interop.DSGETDCNAME_FLAGS.DS_IP_REQUIRED, out pDCI);
@@ -37,11 +38,11 @@ namespace Rubeus
             }
         }
 
-        public static string GetDCIP(string DCName, bool display = true)
+        public static string GetDCIP(string DCName, bool display = true, string domainName = "")
         {
             if (String.IsNullOrEmpty(DCName))
             {
-                DCName = GetDCName();
+                DCName = GetDCName(domainName);
             }
             Match match = Regex.Match(DCName, @"([0-9A-Fa-f]{1,4}:){7}[0-9A-Fa-f]{1,4}|(\d{1,3}\.){3}\d{1,3}");
             if (match.Success)
@@ -56,6 +57,12 @@ namespace Rubeus
             {
                 try
                 {
+                    // If we call GetHostAddresses with an empty string, it will return IP addresses for localhost instead of DC
+                    if (String.IsNullOrEmpty(DCName)) 
+                    {
+                        Console.WriteLine("[X] Error: No domain controller could be located");
+                        return null;
+                    }
                     System.Net.IPAddress[] dcIPs = System.Net.Dns.GetHostAddresses(DCName);
 
                     foreach (System.Net.IPAddress dcIP in dcIPs)
@@ -160,6 +167,101 @@ namespace Rubeus
 
             return response;
         }
+
+        public static DirectoryEntry GetLdapSearchRoot(System.Net.NetworkCredential cred, string OUName, string domainController, string domain)
+        {
+            DirectoryEntry directoryObject = null;
+            string ldapPrefix = "";
+            string ldapOu = "";
+
+            //If we have a DC then use that instead of the domain name so that this works if user doesn't have
+            //name resolution working but specified the IP of a DC
+            if (!String.IsNullOrEmpty(domainController))
+            {
+                ldapPrefix = domainController;
+            }
+            else if (!String.IsNullOrEmpty(domain)) //If we don't have a DC then use the domain name (if we have one)
+            {
+                ldapPrefix = domain;
+            }
+            else if (cred != null) //If we don't have a DC or a domain name but have credentials, get domain name from them
+            {
+                ldapPrefix = cred.Domain;
+            }
+
+            if (!String.IsNullOrEmpty(OUName))
+            {
+                ldapOu = OUName.Replace("ldap", "LDAP").Replace("LDAP://", "");
+            }
+            else if (!String.IsNullOrEmpty(domain))
+            {
+                ldapOu = String.Format("DC={0}", domain.Replace(".", ",DC="));
+            }
+
+            //If no DC, domain, credentials, or OU were specified
+            if (String.IsNullOrEmpty(ldapPrefix) && String.IsNullOrEmpty(ldapOu))
+            {
+                directoryObject = new DirectoryEntry();
+            }
+            else //If we have a prefix (DC or domain), an OU path, or both
+            {
+                string bindPath = "";
+                if (!String.IsNullOrEmpty(ldapPrefix))
+                {
+                    bindPath = String.Format("LDAP://{0}", ldapPrefix);
+                }
+                if (!String.IsNullOrEmpty(ldapOu))
+                {
+                    if (!String.IsNullOrEmpty(bindPath))
+                    {
+                        bindPath = String.Format("{0}/{1}", bindPath, ldapOu);
+                    }
+                    else
+                    {
+                        bindPath = String.Format("LDAP://{1]", ldapOu);
+                    }
+                }
+
+                directoryObject = new DirectoryEntry(bindPath);
+            }
+            
+            if (cred != null)
+            {
+                // if we're using alternate credentials for the connection
+                string userDomain = String.Format("{0}\\{1}", cred.Domain, cred.UserName);
+                directoryObject.Username = userDomain;
+                directoryObject.Password = cred.Password;
+             
+                // Removed credential validation check because it just caused problems and doesn't gain us anything (if invalid
+                // credentials are specified, the LDAP search will fail with "Logon failure: bad username or password" anyway)
+
+                //string contextTarget = "";
+                //if (!string.IsNullOrEmpty(domainController))
+                //{
+                //    contextTarget = domainController;
+                //}
+                //else
+                //{
+                //    contextTarget = cred.Domain;
+                //}
+
+                //using (PrincipalContext pc = new PrincipalContext(ContextType.Domain, contextTarget))
+                //{
+                //    if (!pc.ValidateCredentials(cred.UserName, cred.Password))
+                //    {
+                //        throw new Exception(String.Format("\r\n[X] Credentials supplied for '{0}' are invalid!", userDomain));
+                //    }
+                //    else
+                //    {
+                //        Console.WriteLine("[*] Using alternate creds  : {0}", userDomain);
+                //    }
+                //}
+            }
+            return directoryObject;
+        }
+
+
+
     }
 }
 


### PR DESCRIPTION
fixes #33  and fixes #53 

When using alternate credentials for asreproasting or kerberoasting, if name resolution is not working then even if a DC IP address was specified with `/dc` there were 2 places where the domain name still got used and caused this to fail (see issue #33). 

Changed this to use the DC IP (if specified) instead of domain name and although this worked fine for one part of the code, it was extremely slow during the credential validation stage. So removed the credential validation because it doesn't really gain us anything. All we use it for is to output a nice message if creds are bad, but if we continue with bad creds we still get a pretty nice "logon failure: bad username or password" message from the LDAP bind attempt anyway.

There was a big chunk of identical code repeated in both ASREPRoast and Kerberoast functions and both needed the same changes to fix the issue mentioned above, so I've moved the code to a shared function in the Networking helper class and now both functions call this. 

As part of this move I changed the LDAP bind path building so that it works in more scenarios and has less repeated code. Also added an optional domain name argument to the GetDCName function so that it can work from a machine not joined to the target domain (as long as name resolution is working). In combination with an additional safety check to make sure we don't call GetHostAddresses with an empty string (as that returns the local machine's IP addresses), this fixes #53 as well.

