### PR TITLE
Added runfor flag

### DIFF
--- a/Rubeus/Commands/HarvestCommand.cs
+++ b/Rubeus/Commands/HarvestCommand.cs
@@ -17,6 +17,7 @@ namespace Rubeus.Commands
             int displayInterval = 1200; // how often to display the working set of TGTs
             string registryBasePath = null;
             bool nowrap = false;
+            int runFor = 0;
 
             if (arguments.ContainsKey("/nowrap"))
             {
@@ -47,15 +48,24 @@ namespace Rubeus.Commands
             {
                 registryBasePath = arguments["/registry"];
             }
+            if (arguments.ContainsKey("/runfor"))
+            {
+                runFor = Int32.Parse(arguments["/runfor"]);
+            }
 
             if (!String.IsNullOrEmpty(targetUser))
             {
                 Console.WriteLine("[*] Target user     : {0:x}", targetUser);
             }
             Console.WriteLine("[*] Monitoring every {0} seconds for new TGTs", monitorInterval);
-            Console.WriteLine("[*] Displaying the working TGT cache every {0} seconds\r\n", displayInterval);
+            Console.WriteLine("[*] Displaying the working TGT cache every {0} seconds", displayInterval);
+            if (runFor > 0)
+            {
+                Console.WriteLine("[*] Running collection for {0} seconds", runFor);
+            }
+            Console.WriteLine("");
 
-            var harvester = new Harvest(monitorInterval, displayInterval, true, targetUser, registryBasePath, nowrap);
+            var harvester = new Harvest(monitorInterval, displayInterval, true, targetUser, registryBasePath, nowrap, runFor);
             harvester.HarvestTicketGrantingTickets();
         }
     }

--- a/Rubeus/Commands/Monitor.cs
+++ b/Rubeus/Commands/Monitor.cs
@@ -16,6 +16,7 @@ namespace Rubeus.Commands
             int interval = 60;
             string registryBasePath = null;
             bool nowrap = false;
+            int runFor = 0;
 
             if (arguments.ContainsKey("/nowrap"))
             {
@@ -41,14 +42,23 @@ namespace Rubeus.Commands
             {
                 registryBasePath = arguments["/registry"];
             }
+            if (arguments.ContainsKey("/runfor"))
+            {
+                runFor = Int32.Parse(arguments["/runfor"]);
+            }
 
-            if(!String.IsNullOrEmpty(targetUser))
+            if (!String.IsNullOrEmpty(targetUser))
             {
                 Console.WriteLine("[*] Target user     : {0:x}", targetUser);
             }
-            Console.WriteLine("[*] Monitoring every {0} seconds for new TGTs\r\n", interval);
+            Console.WriteLine("[*] Monitoring every {0} seconds for new TGTs", interval);
+            if (runFor > 0)
+            {
+                Console.WriteLine("[*] Running collection for {0} seconds", runFor);
+            }
+            Console.WriteLine("");
 
-            var harvester = new Harvest(interval, interval, false, targetUser, registryBasePath, nowrap);
+            var harvester = new Harvest(interval, interval, false, targetUser, registryBasePath, nowrap, runFor);
             harvester.HarvestTicketGrantingTickets();
         }
     }

--- a/Rubeus/Domain/Info.cs
+++ b/Rubeus/Domain/Info.cs
@@ -73,10 +73,10 @@ namespace Rubeus.Domain
         Rubeus.exe tgtdeleg [/target:SPN]
 
     Monitor every /interval SECONDS (default 60) for new TGTs:
-        Rubeus.exe monitor [/interval:SECONDS] [/targetuser:USER] [/nowrap] [/registry:SOFTWARENAME]
+        Rubeus.exe monitor [/interval:SECONDS] [/targetuser:USER] [/nowrap] [/registry:SOFTWARENAME] [/runfor:SECONDS]
 
     Monitor every /monitorinterval SECONDS (default 60) for new TGTs, auto-renew TGTs, and display the working cache every /displayinterval SECONDS (default 1200):
-        Rubeus.exe harvest [/monitorinterval:SECONDS] [/displayinterval:SECONDS] [/targetuser:USER] [/nowrap] [/registry:SOFTWARENAME]
+        Rubeus.exe harvest [/monitorinterval:SECONDS] [/displayinterval:SECONDS] [/targetuser:USER] [/nowrap] [/registry:SOFTWARENAME] [/runfor:SECONDS]
 
 
  Roasting:


### PR DESCRIPTION
Added runfor flag to the monitor & harvest commands.  When set, Rubeus will gracefully exit after the given length of time.  Useful when attempting to collect tickets over a non-interactive session, as captured tickets will be displayed upon exit, and a running process will not be left on systems.