### PR TITLE
fix to switch to FIPS compliant algorithms/classes

### DIFF
--- a/Rubeus/lib/KDCKeyAgreement.cs
+++ b/Rubeus/lib/KDCKeyAgreement.cs
@@ -21,7 +21,7 @@ namespace Rubeus {
             input[0] = count;
             data.CopyTo(input, 1);
 
-            using (SHA1Managed sha1 = new SHA1Managed()) { 
+            using (SHA1CryptoServiceProvider sha1 = new SHA1CryptoServiceProvider()) { 
                 return sha1.ComputeHash(input);
             }            
         }

--- a/Rubeus/lib/krb_structures/KrbPkAuthenticator.cs
+++ b/Rubeus/lib/krb_structures/KrbPkAuthenticator.cs
@@ -21,7 +21,7 @@ namespace Rubeus {
 
             byte[] paChecksum;
 
-            using (SHA1Managed sha1 = new SHA1Managed()) {
+            using (SHA1CryptoServiceProvider sha1 = new SHA1CryptoServiceProvider()) {
                 paChecksum = sha1.ComputeHash(RequestBody.Encode().Encode());
             }
         


### PR DESCRIPTION
*Managed (like SHA1Managed) are not FIPS compliant and will break on systems that enforce compliance.  The class I switched to has the same methods but is compliant and has been tested and works on systems enforcing FIPS compliance.