### PR TITLE
Interactive mode support

### DIFF
--- a/Rubeus/Program.cs
+++ b/Rubeus/Program.cs
@@ -93,7 +93,7 @@ namespace Rubeus
             return output;
         }
 
-        public static void Main(string[] args)
+        public static void MainArgs(string[] args)
         {
             // try to parse the command line arguments, show usage on failure and then bail
             var parsed = ArgumentParser.Parse(args);
@@ -117,6 +117,28 @@ namespace Rubeus
             else
             {
                 MainExecute(commandName, parsed.Arguments);
+            }
+        }
+        
+        public static void Main(string[] args)
+        {
+            if (args.Length > 0 && args[0] != "")
+            {
+                MainArgs(args);
+            }
+            else
+            {
+                string command;
+                do
+                {
+                    Console.Write("Rubeus # ");
+                    command = Console.ReadLine();
+                    if (command != "" && command != "exit")
+                    {
+                        args = command.Split();
+                        MainArgs(args);
+                    }
+                } while (command != "exit");
             }
         }
     }


### PR DESCRIPTION
It allows to execute Rubeus in an interactive mode. It is useful to avoid the [command line process auditing](https://docs.microsoft.com/en-us/windows-server/identity/ad-ds/manage/component-updates/command-line-process-auditing) functionality.

It switches to interactive mode only when no command line arguments have been input as mimikatz does.

It is also useful if you want to use it with loaders which inject the process into memory such as PEzor. Although Donut already allows hardcoding arguments, it is not efficient generating a binary for each command.

This condition `(&& args[0] != "")` is just to make it work properly with PEzor. I don't know why but the loader adds an empty first argument. It has no impact on the normal behavior.