### PR TITLE
FIx Type 18 Hash Format

### DIFF
--- a/Rubeus/lib/Roast.cs
+++ b/Rubeus/lib/Roast.cs
@@ -899,7 +899,7 @@ namespace Rubeus
             {
                 int checksumStart = cipherText.Length - 24;
                 //Enclose SPN in *s rather than username, realm and SPN. This doesn't impact cracking, but might affect loading into hashcat.            
-                hash = String.Format("$krb5tgs${0}$*{1}${2}${3}*${4}${5}", encType, kerberoastUser, kerberoastDomain, sname, cipherText.Substring(checksumStart), cipherText.Substring(0, checksumStart));
+                hash = String.Format("$krb5tgs${0}${1}${2}$*{3}*${4}${5}", encType, kerberoastUser, kerberoastDomain, sname, cipherText.Substring(checksumStart), cipherText.Substring(0, checksumStart));
             }
             //if encType==23
             else


### PR DESCRIPTION
Simple fix for formatting of type 18 hashes. Fixes https://github.com/GhostPack/Rubeus/issues/35