### PR TITLE
Added option for user-defined creds in createnetonly command

### DIFF
--- a/Rubeus/Commands/Createnetonly.cs
+++ b/Rubeus/Commands/Createnetonly.cs
@@ -16,11 +16,25 @@ namespace Rubeus.Commands
             {
                 if (arguments.ContainsKey("/show"))
                 {
-                    Helpers.CreateProcessNetOnly(arguments["/program"], true);
+                    if (arguments.ContainsKey("/username"))
+                    {
+                        Helpers.CreateProcessNetOnly(arguments["/program"], true, arguments["/username"], arguments["/domain"], arguments["/password"]);
+                    }
+                    else
+                    {
+                        Helpers.CreateProcessNetOnly(arguments["/program"], true);
+                    }
                 }
                 else
                 {
-                    Helpers.CreateProcessNetOnly(arguments["/program"]);
+                    if (arguments.ContainsKey("/username"))
+                    {
+                        Helpers.CreateProcessNetOnly(arguments["/program"], true, arguments["/username"], arguments["/domain"], arguments["/password"]);
+                    }
+                    else
+                    {
+                        Helpers.CreateProcessNetOnly(arguments["/program"]);
+                    }
                 }
             }
 

--- a/Rubeus/Commands/Createnetonly.cs
+++ b/Rubeus/Commands/Createnetonly.cs
@@ -18,7 +18,7 @@ namespace Rubeus.Commands
             string domain = null;
             bool show = arguments.ContainsKey("/show");
 
-            if (arguments.ContainsKey("/program"))
+            if (arguments.ContainsKey("/program") && !String.IsNullOrWhiteSpace(arguments["/program"]))
             {
                 program = arguments["/program"];
             }
@@ -50,7 +50,7 @@ namespace Rubeus.Commands
 
             if (!String.IsNullOrWhiteSpace(username) && !String.IsNullOrWhiteSpace(password) && !String.IsNullOrWhiteSpace(domain))
             {
-                Console.WriteLine("\r\n[*] Using " + domain + "\\" + username + ":" + password + ".\r\n");
+                Console.WriteLine("\r\n[*] Using " + domain + "\\" + username + ":" + password + "\r\n");
                 Helpers.CreateProcessNetOnly(program, show, username, domain, password);
                 return;
             }

--- a/Rubeus/Commands/Createnetonly.cs
+++ b/Rubeus/Commands/Createnetonly.cs
@@ -12,36 +12,50 @@ namespace Rubeus.Commands
         {
             Console.WriteLine("\r\n[*] Action: Create Process (/netonly)\r\n");
 
+            string program = null;
+            string username = null;
+            string password = null;
+            string domain = null;
+            bool show = arguments.ContainsKey["/show"];
+
             if (arguments.ContainsKey("/program"))
             {
-                if (arguments.ContainsKey("/show"))
-                {
-                    if (arguments.ContainsKey("/username"))
-                    {
-                        Helpers.CreateProcessNetOnly(arguments["/program"], true, arguments["/username"], arguments["/domain"], arguments["/password"]);
-                    }
-                    else
-                    {
-                        Helpers.CreateProcessNetOnly(arguments["/program"], true);
-                    }
-                }
-                else
-                {
-                    if (arguments.ContainsKey("/username"))
-                    {
-                        Helpers.CreateProcessNetOnly(arguments["/program"], true, arguments["/username"], arguments["/domain"], arguments["/password"]);
-                    }
-                    else
-                    {
-                        Helpers.CreateProcessNetOnly(arguments["/program"]);
-                    }
-                }
+                program = arguments["/program"];
             }
-
             else
             {
                 Console.WriteLine("\r\n[X] A /program needs to be supplied!\r\n");
+                return;
             }
+
+            if (arguments.ContainsKey("/username"))
+            {
+                username = arguments["/username"];
+            }
+            if (arguments.ContainsKey("/password"))
+            {
+                password = arguments["/password"];
+            }
+            if (arguments.ContainsKey("/domain"))
+            {
+                domain = arguments["/domain"];
+            }
+
+            if (username == null && password == null && domain == null)
+            {
+                Console.WriteLine("\r\n[*] Using random username and password.\r\n");
+                Helpers.CreateProcessNetOnly(program, show, username, domain, password);
+                return;
+            }
+
+            if (!String.IsNullOrWhiteSpace(username) && !String.IsNullOrWhiteSpace(password) && !String.IsNullOrWhiteSpace(domain))
+            {
+                Console.WriteLine("\r\n[*] Using " + domain + "\\" + username + ":" + password + ".\r\n");
+                Helpers.CreateProcessNetOnly(program, show, username, domain, password);
+                return;
+            }
+
+            Console.WriteLine("\r\n[X] Explicit creds require /username, /password, and /domain to be supplied!\r\n");
         }
     }
 }

--- a/Rubeus/Commands/Createnetonly.cs
+++ b/Rubeus/Commands/Createnetonly.cs
@@ -16,7 +16,7 @@ namespace Rubeus.Commands
             string username = null;
             string password = null;
             string domain = null;
-            bool show = arguments.ContainsKey["/show"];
+            bool show = arguments.ContainsKey("/show");
 
             if (arguments.ContainsKey("/program"))
             {

--- a/Rubeus/Domain/Info.cs
+++ b/Rubeus/Domain/Info.cs
@@ -171,8 +171,8 @@ namespace Rubeus.Domain
 
  Miscellaneous:
 
-    Create a hidden program (unless /show is passed) with random /netonly credentials, displaying the PID and LUID:
-        Rubeus.exe createnetonly /program:""C:\Windows\System32\cmd.exe"" [/show]
+    Create a hidden program (unless /show is passed) with random (or user-defined) /netonly credentials, displaying the PID and LUID:
+        Rubeus.exe createnetonly /program:""C:\Windows\System32\cmd.exe"" [/show] [/username:USERNAME] [/domain:DOMAIN] [/password:PASSWORD]
 
     Reset a user's password from a supplied TGT (AoratoPw):
         Rubeus.exe changepw </ticket:BASE64 | /ticket:FILE.KIRBI> /new:PASSWORD [/dc:DOMAIN_CONTROLLER] [/targetuser:DOMAIN\USERNAME]

--- a/Rubeus/lib/Helpers.cs
+++ b/Rubeus/lib/Helpers.cs
@@ -223,7 +223,7 @@ namespace Rubeus
             return luid;
         }
 
-        public static LUID CreateProcessNetOnly(string commandLine, bool show = false)
+        public static LUID CreateProcessNetOnly(string commandLine, bool show = false, string username = null, string domain = null, string password = null)
         {
             // creates a hidden process with random /netonly credentials,
             //  displayng the process ID and LUID, and returning the LUID
@@ -242,8 +242,17 @@ namespace Rubeus
             Console.WriteLine("[*] Showing process : {0}", show);
             var luid = new LUID();
 
+
+            if (username == null) { username = Helpers.RandomString(8);}
+            if (domain == null) { domain = Helpers.RandomString(8); }
+            if (password == null) { password = Helpers.RandomString(8); }
+
+            Console.WriteLine("[*] Username        : {0}", username);
+            Console.WriteLine("[*] Domain          : {0}", domain);
+            Console.WriteLine("[*] Password        : {0}", password);
+
             // 0x00000002 == LOGON_NETCREDENTIALS_ONLY
-            if (!Interop.CreateProcessWithLogonW(Helpers.RandomString(8), Helpers.RandomString(8), Helpers.RandomString(8), 0x00000002, commandLine, String.Empty, 0, 0, null, ref si, out pi))
+            if (!Interop.CreateProcessWithLogonW(username, domain, password, 0x00000002, commandLine, String.Empty, 0, 0, null, ref si, out pi))
             {
                 var lastError = Interop.GetLastError();
                 Console.WriteLine("[X] CreateProcessWithLogonW error: {0}", lastError);


### PR DESCRIPTION
I've run into a few circumstances where Cobalt Strike's make_token seems to break subsequent fork-n-run commands.

Hacked this together so I'd have non-interactive runas /netonly with user-defined creds as a way to work around the above, seemed likely others would find it useful from time to time as well.

The if/else shenanigans I had to do in Createnetonly.cs kind of make my brain itch but I didn't want to change what was already there too much. LMK if there's a preferred approach.