### PR TITLE
[PATCH] fix base64/fingerprint certFile confusion

### DIFF
--- a/Rubeus/lib/Ask.cs
+++ b/Rubeus/lib/Ask.cs
@@ -147,11 +147,6 @@ namespace Rubeus {
                     return null;
                 }
 
-                if (cert == null) {
-                    Console.WriteLine("[!] Failed to find certificate for {0}", certFile);
-                    return null;
-                }
-
                 KDCKeyAgreement agreement = new KDCKeyAgreement();
 
                 Console.WriteLine("[*] Using PKINIT with etype {0} and subject: {1} ", etype, cert.Subject);

--- a/Rubeus/lib/Ask.cs
+++ b/Rubeus/lib/Ask.cs
@@ -134,15 +134,17 @@ namespace Rubeus {
 
         public static byte[] TGT(string userName, string domain, string certFile, string certPass, Interop.KERB_ETYPE etype, string outfile, bool ptt, string domainController = "", LUID luid = new LUID(), bool describe = false, bool verifyCerts = false, string servicekey = "", bool getCredentials = false) {
             try {
-                X509Certificate2 cert;
+                X509Certificate2 cert = FindCertificate(certFile, certPass);
 
-                if (Helpers.IsBase64String(certFile))
+                // Check for Base64 encoded certificate second in case certFile was a hex-encoded fingerprint
+                if (cert == null && Helpers.IsBase64String(certFile))
                 {
                     cert = new X509Certificate2(Convert.FromBase64String(certFile), certPass);
                 }
-                else
-                {
-                    cert = FindCertificate(certFile, certPass);
+
+                if (cert == null) {
+                    Console.WriteLine("[!] Failed to find certificate for {0}", certFile);
+                    return null;
                 }
 
                 if (cert == null) {


### PR DESCRIPTION
`asktgt` can be given a fingerprint to use as `certFile`, but it doesn't work as it is interpreted as base64 encoded first. This patch fixes this bug.