### PR TITLE
Fix salt for user accounts (username is case-sensitive with sAMAccountName)

### DIFF
--- a/Rubeus/Commands/Asktgt.cs
+++ b/Rubeus/Commands/Asktgt.cs
@@ -76,7 +76,7 @@ namespace Rubeus.Commands
             {
                 password = arguments["/password"];
 
-                string salt = String.Format("{0}{1}", domain.ToUpper(), user.ToLower());
+                string salt = String.Format("{0}{1}", domain.ToUpper(), user);
 
                 // special case for computer account salts
                 if (user.EndsWith("$"))

--- a/Rubeus/lib/Bruteforcer.cs
+++ b/Rubeus/lib/Bruteforcer.cs
@@ -72,7 +72,7 @@ namespace Rubeus
         private void GetUsernamePasswordTGT(string username, string password)
         {
             Interop.KERB_ETYPE encType = Interop.KERB_ETYPE.aes256_cts_hmac_sha1;
-            string salt = String.Format("{0}{1}", domain.ToUpper(), username.ToLower());
+            string salt = String.Format("{0}{1}", domain.ToUpper(), username);
 
             // special case for computer account salts
             if (username.EndsWith("$"))

--- a/Rubeus/lib/Crypto.cs
+++ b/Rubeus/lib/Crypto.cs
@@ -14,7 +14,7 @@ namespace Rubeus
 
             Console.WriteLine("[*] Input password             : {0}", password);
 
-            string salt = String.Format("{0}{1}", domainName.ToUpper(), userName.ToLower());
+            string salt = String.Format("{0}{1}", domainName.ToUpper(), userName);
 
             // special case for computer account salts
             if (userName.EndsWith("$"))


### PR DESCRIPTION
Hi !

Currently, the salt generated by Rubeus for key derivation is incorrect for user accounts: the username is supposed to be case-sensitive (compared with `sAMAccountName`), but Rubeus converts it to lower case.
As such, when requesting a TGT:
- with an AES `enctype`,
- using a password,
- for a user account
- whose `sAMAccountName` is not all lower case,

the request will fail with `KRB-ERROR (24) : KDC_ERR_PREAUTH_FAILED`.

Dirk-jan Mollema explains this in [this article](https://dirkjanm.io/krbrelayx-unconstrained-delegation-abuse-toolkit/):
"""
To calculate the Kerberos keys from plaintext passwords, we also need to specify the salt. If you’re familiar with Kerberos, you’ll know that there are different encryption algorithms used. The weakest cipher supported by modern AD installs uses RC4, with a key based on the NTLM hash of the user (not including any salt). The AES-128 and AES-256 ciphers that Windows will pick by default however do include a salt, which we will need to include in the key calculation. The salt to calculate these keys [is as follows](https://github.com/Kevin-Robertson/Powermad/blob/master/Powermad.ps1#L4374):

    For user accounts, it is the uppercase Kerberos realm name + case sensitive username
    For computer accounts, it is the uppercase realm name + the word host + full lowercase hostname

The Kerberos realm name is the fully qualified domain name (FQDN) of the domain (so not the NETBIOS name!), the full hostname is also the FQDN of the host, not just the machine name, and does not include an $. The username used as salt for user accounts is the case-sensitive SAMAccountName (so if the user is called `awEsOmEusER1` then `awesomeuser1` will not generate the correct key).
"""

This PR aims to fix that, by just removing the call to `ToLower()` on the username when computing salts. The user will however have to correctly capitalize the username when invoking Rubeus.

Cheers !