### PR TITLE
Correct Attributes parameter of ResourceGroups

### DIFF
--- a/Rubeus/lib/ForgeTicket.cs
+++ b/Rubeus/lib/ForgeTicket.cs
@@ -404,7 +404,7 @@ namespace Rubeus
                                 {
                                     string groupSid = (string)o["objectsid"];
                                     int groupId = Int32.Parse(groupSid.Substring(groupSid.LastIndexOf('-') + 1));
-                                    Array.Copy(new Ndr._GROUP_MEMBERSHIP[] { new Ndr._GROUP_MEMBERSHIP(groupId, 7) }, 0, kvi.GroupIds, c, 1);
+                                    Array.Copy(new Ndr._GROUP_MEMBERSHIP[] { new Ndr._GROUP_MEMBERSHIP(groupId, Interop.GROUP_ATTRIBUTES_DEFAULT) }, 0, kvi.GroupIds, c, 1);
                                     c += 1;
                                 }
                             }
@@ -540,7 +540,7 @@ namespace Rubeus
                 c = 0;
                 foreach (int gid in allGroups)
                 {
-                    Array.Copy(new Ndr._GROUP_MEMBERSHIP[] { new Ndr._GROUP_MEMBERSHIP(gid, 7) }, 0, kvi.GroupIds, c, 1);
+                    Array.Copy(new Ndr._GROUP_MEMBERSHIP[] { new Ndr._GROUP_MEMBERSHIP(gid, Interop.GROUP_ATTRIBUTES_DEFAULT) }, 0, kvi.GroupIds, c, 1);
                     c += 1;
                 }
             }
@@ -552,7 +552,7 @@ namespace Rubeus
                 c = 0;
                 foreach (string s in sids.Split(','))
                 {
-                    Array.Copy(new Ndr._KERB_SID_AND_ATTRIBUTES[] { new Ndr._KERB_SID_AND_ATTRIBUTES(new Ndr._RPC_SID(new SecurityIdentifier(s)), 7) }, 0, kvi.ExtraSids, c, 1);
+                    Array.Copy(new Ndr._KERB_SID_AND_ATTRIBUTES[] { new Ndr._KERB_SID_AND_ATTRIBUTES(new Ndr._RPC_SID(new SecurityIdentifier(s)), Interop.GROUP_ATTRIBUTES_DEFAULT) }, 0, kvi.ExtraSids, c, 1);
                     c += 1;
                 }
             }
@@ -564,9 +564,10 @@ namespace Rubeus
                     kvi.ResourceGroupCount = resourceGroups.Count;
                     kvi.ResourceGroupIds = new Ndr._GROUP_MEMBERSHIP[resourceGroups.Count];
                     c = 0;
+
                     foreach (int rgroup in resourceGroups)
                     {
-                        Array.Copy(new Ndr._GROUP_MEMBERSHIP[] { new Ndr._GROUP_MEMBERSHIP(rgroup, 7) }, 0, kvi.ResourceGroupIds, c, 1);
+                        Array.Copy(new Ndr._GROUP_MEMBERSHIP[] { new Ndr._GROUP_MEMBERSHIP(rgroup, Interop.R_GROUP_ATTRIBUTES_DEFAULT) }, 0, kvi.ResourceGroupIds, c, 1);
                         c += 1;
                     }
                 }

--- a/Rubeus/lib/Interop.cs
+++ b/Rubeus/lib/Interop.cs
@@ -26,6 +26,21 @@ namespace Rubeus
         public const int KRB_KEY_USAGE_KRB_NON_KERB_CKSUM_SALT = 17;
         public const int KRB_KEY_USAGE_PA_S4U_X509_USER = 26;
 
+        // 7 - https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-pac/311aab27-ebdf-47f7-b939-13dc99b15341
+        public const int GROUP_ATTRIBUTES_DEFAULT = (int)(
+            KERB_SID_AND_ATTRIBUTES_Attributes.SE_GROUP_ENABLED |
+            KERB_SID_AND_ATTRIBUTES_Attributes.SE_GROUP_ENABLED_BY_DEFAULT |
+            KERB_SID_AND_ATTRIBUTES_Attributes.SE_GROUP_MANDATORY
+        );
+
+        // 536870919 - https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-pac/311aab27-ebdf-47f7-b939-13dc99b15341
+        public const int R_GROUP_ATTRIBUTES_DEFAULT = (int)(
+            KERB_SID_AND_ATTRIBUTES_Attributes.SE_GROUP_ENABLED |
+            KERB_SID_AND_ATTRIBUTES_Attributes.SE_GROUP_ENABLED_BY_DEFAULT |
+            KERB_SID_AND_ATTRIBUTES_Attributes.SE_GROUP_MANDATORY |
+            KERB_SID_AND_ATTRIBUTES_Attributes.SE_GROUP_RESOURCE
+        );
+
         // Enums
 
         [Flags]
@@ -145,6 +160,17 @@ namespace Rubeus
             KRB5_KPASSWD_ACCESSDENIED = 5,
             KRB5_KPASSWD_BAD_VERSION = 6,
             KRB5_KPASSWD_INITIAL_FLAG_NEEDED = 7
+        }
+
+        // from https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-pac/311aab27-ebdf-47f7-b939-13dc99b15341
+        [Flags]
+        public enum KERB_SID_AND_ATTRIBUTES_Attributes
+        {
+            SE_GROUP_MANDATORY = 1,          // Group is mandatory for the user and cannot be disabled.
+            SE_GROUP_ENABLED_BY_DEFAULT = 2, // Group is marked as enabled by default.
+            SE_GROUP_ENABLED = 4,            // Group is enabled for use.
+            SE_GROUP_OWNER = 8,              // Group can be assigned as an owner of a resource.
+            SE_GROUP_RESOURCE = 536870912,   // Group is a domain-local or resource group.
         }
 
         public enum KERB_CHECKSUM_ALGORITHM


### PR DESCRIPTION
The Attributes parameter of KERB_SID_AND_ATTRIBUTES was missing the E bit flag: "This setting means that the group is a domain-local or resource group."