### PR TITLE
Allow exporting to full paths

### DIFF
--- a/Rubeus/lib/Helpers.cs
+++ b/Rubeus/lib/Helpers.cs
@@ -326,14 +326,23 @@ namespace Rubeus
             return result;
         }
 
-        // Great method from http://forcewake.me/today-i-learned-sanitize-file-name-in-csharp/
-        static public string MakeValidFileName(string name)
+        static public string MakeValidFileName(string filePath)
         {
+            // Can't use IO.Path.GetFileName and IO.Path.GetDirectoryName because they get confused by illegal file name characters (the whole reason we are here)
+            string fileName = filePath;
+            string directoryPath = string.Empty;
+            int lastSeparatorPosition = filePath.LastIndexOf(Path.DirectorySeparatorChar);
+            if ((lastSeparatorPosition > -1) && (filePath.Length > lastSeparatorPosition))
+            {
+                fileName = filePath.Substring(lastSeparatorPosition + 1);
+                directoryPath = filePath.Substring(0, lastSeparatorPosition + 1);
+            }
+
+            // Great method from http://forcewake.me/today-i-learned-sanitize-file-name-in-csharp/
             string invalidChars = new string(Path.GetInvalidFileNameChars());
             string escapedInvalidChars = Regex.Escape(invalidChars);
             string invalidRegex = string.Format(@"([{0}]*\.+$)|([{0}]+)", escapedInvalidChars);
-
-            return Regex.Replace(name, invalidRegex, "_");
+            return directoryPath + Regex.Replace(fileName, invalidRegex, "_");
         }
 
         #endregion


### PR DESCRIPTION
Fixes #76 and fixes #63 

Tested with `asktgt` and the following paths as the `/outfile` argument and all works as it should:

`C:\test\ticket.txt`
`\ticket.txt`
`C:\invalid/chars*.txt`  - file gets written to `C:\invalid_chars_.txt`
`invalid/chars*.txt`  - file gets written to `invalid_chars_.txt` in working directory

For the record I still think we should ditch the whole file name sanitization thing, especially as it is not used universally throughout the program (kerberoasting for example does not sanitize file names, so that already let you use full paths for `/outfile`). 

*New PR as I messed up the old one*