### PR TITLE
Code refactoring

### DIFF
--- a/Rubeus/Commands/Asreproast.cs
+++ b/Rubeus/Commands/Asreproast.cs
@@ -21,6 +21,7 @@ namespace Rubeus.Commands
             string ldapFilter = "";
             string outFile = "";
             bool ldaps = false;
+            System.Net.NetworkCredential cred = null;
 
             if (arguments.ContainsKey("/user"))
             {
@@ -90,14 +91,9 @@ namespace Rubeus.Commands
 
                 string password = arguments["/credpassword"];
 
-                System.Net.NetworkCredential cred = new System.Net.NetworkCredential(userName, password, domainName);
-
-                Roast.ASRepRoast(domain, user, ou, dc, format, cred, outFile, ldapFilter, ldaps);
+                cred = new System.Net.NetworkCredential(userName, password, domainName);
             }
-            else
-            {
-                Roast.ASRepRoast(domain, user, ou, dc, format, null, outFile, ldapFilter, ldaps);
-            }                
+            Roast.ASRepRoast(domain, user, ou, dc, format, cred, outFile, ldapFilter, ldaps);
         }
     }
 }

--- a/Rubeus/Commands/Kerberoast.cs
+++ b/Rubeus/Commands/Kerberoast.cs
@@ -35,6 +35,7 @@ namespace Rubeus.Commands
             bool enterprise = false;
             bool autoenterprise = false;
             bool ldaps = false;
+            System.Net.NetworkCredential cred = null;
 
             if (arguments.ContainsKey("/spn"))
             {
@@ -231,14 +232,10 @@ namespace Rubeus.Commands
 
                 string password = arguments["/credpassword"];
 
-                System.Net.NetworkCredential cred = new System.Net.NetworkCredential(userName, password, domainName);
+                cred = new System.Net.NetworkCredential(userName, password, domainName);
+            }
 
-                Roast.Kerberoast(spn, spns, user, OU, domain, dc, cred, outFile, simpleOutput, TGT, useTGTdeleg, supportedEType, pwdSetAfter, pwdSetBefore, ldapFilter, resultLimit, delay, jitter, listUsers, enterprise, autoenterprise, ldaps);
-            }
-            else
-            {
-                Roast.Kerberoast(spn, spns, user, OU, domain, dc, null, outFile, simpleOutput, TGT, useTGTdeleg, supportedEType, pwdSetAfter, pwdSetBefore, ldapFilter, resultLimit, delay, jitter, listUsers, enterprise, autoenterprise, ldaps);
-            }
+            Roast.Kerberoast(spn, spns, user, OU, domain, dc, cred, outFile, simpleOutput, TGT, useTGTdeleg, supportedEType, pwdSetAfter, pwdSetBefore, ldapFilter, resultLimit, delay, jitter, listUsers, enterprise, autoenterprise, ldaps);
         }
     }
 }

--- a/Rubeus/lib/Roast.cs
+++ b/Rubeus/lib/Roast.cs
@@ -529,6 +529,13 @@ namespace Rubeus
                                 // otherwise use the KerberosRequestorSecurityToken method
                                 bool result = GetTGSRepHash(servicePrincipalName, samAccountName, distinguishedName, cred, outFile, simpleOutput);
                                 Helpers.RandomDelayWithJitter(delay, jitter);
+                                if (!result && autoenterprise)
+                                {
+                                    Console.WriteLine("\r\n[-] Retrieving service ticket with SPN failed and '/autoenterprise' passed, retrying with the enterprise principal");
+                                    servicePrincipalName = String.Format("{0}@{1}", samAccountName, domain);
+                                    GetTGSRepHash(servicePrincipalName, samAccountName, distinguishedName, cred, outFile, simpleOutput);
+                                    Helpers.RandomDelayWithJitter(delay, jitter);
+                                }
                             }
                         }
                     }

--- a/Rubeus/lib/Roast.cs
+++ b/Rubeus/lib/Roast.cs
@@ -499,6 +499,7 @@ namespace Rubeus
                             }
                             if (TGT != null)
                             {
+                                Interop.KERB_ETYPE etype = Interop.KERB_ETYPE.subkey_keymaterial;
                                 // if a TGT .kirbi is supplied, use that for the request
                                 //      this could be a passed TGT or if TGT delegation is specified
 
@@ -510,28 +511,17 @@ namespace Rubeus
                                    )
                                 {
                                     // if we're roasting RC4, but AES is supported AND we have a TGT, specify RC4
-                                    bool result = GetTGSRepHash(TGT, servicePrincipalName, samAccountName, distinguishedName, outFile, simpleOutput, enterprise, dc, Interop.KERB_ETYPE.rc4_hmac);
-                                    Helpers.RandomDelayWithJitter(delay, jitter);
-                                    if (!result && autoenterprise)
-                                    {
-                                        Console.WriteLine("\r\n[-] Retrieving service ticket with SPN failed and '/autoenterprise' passed, retrying with the enterprise principal");
-                                        servicePrincipalName = String.Format("{0}@{1}", samAccountName, domain);
-                                        GetTGSRepHash(TGT, servicePrincipalName, samAccountName, distinguishedName, outFile, simpleOutput, true, dc, Interop.KERB_ETYPE.rc4_hmac);
-                                        Helpers.RandomDelayWithJitter(delay, jitter);
-                                    }
+                                    etype = Interop.KERB_ETYPE.rc4_hmac;
                                 }
-                                else
+                                
+                                bool result = GetTGSRepHash(TGT, servicePrincipalName, samAccountName, distinguishedName, outFile, simpleOutput, enterprise, dc, etype);
+                                Helpers.RandomDelayWithJitter(delay, jitter);
+                                if (!result && autoenterprise)
                                 {
-                                    // otherwise don't force RC4 - have all supported encryption types for opsec reasons
-                                    bool result = GetTGSRepHash(TGT, servicePrincipalName, samAccountName, distinguishedName, outFile, simpleOutput, enterprise, dc);
+                                    Console.WriteLine("\r\n[-] Retrieving service ticket with SPN failed and '/autoenterprise' passed, retrying with the enterprise principal");
+                                    servicePrincipalName = String.Format("{0}@{1}", samAccountName, domain);
+                                    GetTGSRepHash(TGT, servicePrincipalName, samAccountName, distinguishedName, outFile, simpleOutput, true, dc, etype);
                                     Helpers.RandomDelayWithJitter(delay, jitter);
-                                    if (!result && autoenterprise)
-                                    {
-                                        Console.WriteLine("\r\n[-] Retrieving service ticket with SPN failed and '/autoenterprise' passed, retrying with the enterprise principal");
-                                        servicePrincipalName = String.Format("{0}@{1}", samAccountName, domain);
-                                        GetTGSRepHash(TGT, servicePrincipalName, samAccountName, distinguishedName, outFile, simpleOutput, true, dc);
-                                        Helpers.RandomDelayWithJitter(delay, jitter);
-                                    }
                                 }
                             }
                             else
@@ -539,13 +529,6 @@ namespace Rubeus
                                 // otherwise use the KerberosRequestorSecurityToken method
                                 bool result = GetTGSRepHash(servicePrincipalName, samAccountName, distinguishedName, cred, outFile, simpleOutput);
                                 Helpers.RandomDelayWithJitter(delay, jitter);
-                                if (!result && autoenterprise)
-                                {
-                                    Console.WriteLine("\r\n[-] Retrieving service ticket with SPN failed and '/autoenterprise' passed, retrying with the enterprise principal");
-                                    servicePrincipalName = String.Format("{0}@{1}", samAccountName, domain);
-                                    GetTGSRepHash(servicePrincipalName, samAccountName, distinguishedName, cred, outFile, simpleOutput);
-                                    Helpers.RandomDelayWithJitter(delay, jitter);
-                                }
                             }
                         }
                     }


### PR DESCRIPTION
**EDIT: This first paragraph can be ignored now**
In the `Kerberoast` function we were calling `GetTGSRepHash` once and if it failed we checked to see if `/autoenterprise` was used - if it was then we tried again but with enterprise set to true. This makes sense for the version of `GetTGSRepHash` that accepts a TGT but the other version of it that uses `KerberosRequestorSecurityToken` doesn't let us use an enterprise principal, yet we were still calling the function again if it failed the first time. 

Also there are a lot of places in the code where the same function is called in multiple parts of an if/else branch but just with one argument hard coded to something different. I've cleaned up a few of these so they just use a variable and only call the function once. 

I understand if you're in no rush to test these changes and merge them (as they don't add new functionality or fix any real bugs) but I'm implementing them in my own fork for the GUI so figured I may as well offer them here just in case you want them