### PR TITLE
Fix for various commands failing to get DC name on non domain machines

### DIFF
--- a/Rubeus/lib/Ask.cs
+++ b/Rubeus/lib/Ask.cs
@@ -200,7 +200,7 @@ namespace Rubeus {
                 Console.WriteLine("[*] Target LUID : {0}", (ulong)luid);
             }
 
-            string dcIP = Networking.GetDCIP(domainController, false);
+            string dcIP = Networking.GetDCIP(domainController, false, asReq.req_body.realm);
             if (String.IsNullOrEmpty(dcIP))
             {
                 throw new RubeusException("[X] Unable to get domain controller address");
@@ -278,7 +278,7 @@ namespace Rubeus {
 
         public static byte[] TGS(string userName, string domain, Ticket providedTicket, byte[] clientKey, Interop.KERB_ETYPE paEType, string service, Interop.KERB_ETYPE requestEType = Interop.KERB_ETYPE.subkey_keymaterial, string outfile = "", bool ptt = false, string domainController = "", bool display = true, bool enterprise = false, bool roast = false, bool opsec = false, KRB_CRED tgs = null, string targetDomain = "", string servicekey = "", string asrepkey = "", bool u2u = false, string targetUser = "", bool printargs = false)
         {
-            string dcIP = Networking.GetDCIP(domainController, display);
+            string dcIP = Networking.GetDCIP(domainController, display, domain);
             if (String.IsNullOrEmpty(dcIP)) { return null; }
 
             if (display)

--- a/Rubeus/lib/Renew.cs
+++ b/Rubeus/lib/Renew.cs
@@ -67,7 +67,7 @@ namespace Rubeus
 
         public static byte[] TGT(string userName, string domain, Ticket providedTicket, byte[] clientKey, Interop.KERB_ETYPE etype, string outfile, bool ptt, string domainController = "", bool display = true)
         {
-            string dcIP = Networking.GetDCIP(domainController, display);
+            string dcIP = Networking.GetDCIP(domainController, display, domain);
             if (String.IsNullOrEmpty(dcIP)) { return null; }
 
             if (display)


### PR DESCRIPTION
Fixes #111 

Tested `AskTgt` on domain and non domain machine and worked without any issues for me

Had a look at all the places that call this function and can't see anything that could cause unexpected side effects (seems like worst case scenario it just passes an empty string, which is the expected default value if no domain name was specified anyway). 