### PR TITLE
Added support for UTF8 usernames in TGTs

### DIFF
--- a/Rubeus/lib/krb_structures/PrincipalName.cs
+++ b/Rubeus/lib/krb_structures/PrincipalName.cs
@@ -61,7 +61,7 @@ namespace Rubeus
 
             for (int i = 0; i < numberOfNames; i++)
             {
-                name_string.Add(Encoding.ASCII.GetString(body.Sub[1].Sub[0].Sub[i].GetOctetString()));
+                name_string.Add(Encoding.UTF8.GetString(body.Sub[1].Sub[0].Sub[i].GetOctetString()));
             }
         }
 
@@ -80,7 +80,7 @@ namespace Rubeus
             for (int i = 0; i < name_string.Count; ++i)
             {
                 string name = name_string[i];
-                AsnElt nameStringElt = AsnElt.MakeString(AsnElt.IA5String, name);
+                AsnElt nameStringElt = AsnElt.MakeString(AsnElt.UTF8String, name);
                 nameStringElt = AsnElt.MakeImplicit(AsnElt.UNIVERSAL, AsnElt.GeneralString, nameStringElt);
                 strings[i] = nameStringElt;
             }


### PR DESCRIPTION
Fixes #114 

This also fixes the same problem with `asreproast` if the user with preauth disabled has unicode characters in their username

As ASCII and UTF8 are both the same width (1 byte) this shouldn't cause any problems but probably needs more testing than I've been able to do so far. I've tested with `asktgt` and `asreproast` using usernames that contain unicode characters (like é) and usernames that don't - both worked fine. 