### PR TITLE
Implemented kerberoast results limit

### DIFF
--- a/Rubeus/lib/Roast.cs
+++ b/Rubeus/lib/Roast.cs
@@ -436,8 +436,15 @@ namespace Rubeus
                     // used to keep track of years that users had passwords last set in
                     SortedDictionary<int, int> userPWDsetYears = new SortedDictionary<int, int>();
 
+                    int resultCount = 0;
                     foreach (IDictionary<string, Object> user in users)
                     {
+                        resultCount++;
+                        if (resultLimit > 0 && resultCount > resultLimit)
+                        {
+                            Console.WriteLine("[*] More results were found but /resultlimit excludes them");
+                            break;
+                        }
                         string samAccountName = (string)user["samaccountname"];
                         string distinguishedName = (string)user["distinguishedname"];
                         string servicePrincipalName = ((string[])user["serviceprincipalname"])[0];


### PR DESCRIPTION
Fixes #120 

Not really sure why this wasn't already implemented as there was an argument for it in the kerberoast function and its mentioned a few times in the documentation, so I assume it must have worked at some point...

The way I've implemented it, if the user also uses `/stats` then this won't affect that. Not sure if you guys will think that's a good thing or a bad thing. I feel like its ok as you wouldn't really want to use stats to see how many users are vulnerable but then limit the number as well.  