### PR TITLE
added support for KDC proxies to asktgt, asktgs and s4u

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.2]
+
+### Added
+
+* Support for making requests through a KDC proxy using the `/proxyurl:` argument for `asktgt`, `asktgs` and `s4u` (@0xe7)
+
+### Changed
+
+* `KDC_ERR_SVC_UNAVAILABLE` KERBEROS_ERROR, added `KDC_ERR_MUST_USE_USER2USER` and `KDC_ERR_PATH_NOT_ACCEPTED` (@0xe7)
 
 ## [2.0.0] - 2021-08-04
 

--- a/README.md
+++ b/README.md
@@ -79,31 +79,31 @@ Rubeus is licensed under the BSD 3-Clause license.
       | |  \ \| |_| | |_) ) ____| |_| |___ |
       |_|   |_|____/|____/|_____)____/(___/
 
-      v2.0.1
+      v2.0.2
 
 
      Ticket requests and renewals:
 
         Retrieve a TGT based on a user password/hash, optionally saving to a file or applying to the current logon session or a specific LUID:
-            Rubeus.exe asktgt /user:USER </password:PASSWORD [/enctype:DES|RC4|AES128|AES256] | /des:HASH | /rc4:HASH | /aes128:HASH | /aes256:HASH> [/domain:DOMAIN] [/dc:DOMAIN_CONTROLLER] [/outfile:FILENAME] [/ptt] [/luid] [/nowrap] [/opsec] [/nopac]
+            Rubeus.exe asktgt /user:USER </password:PASSWORD [/enctype:DES|RC4|AES128|AES256] | /des:HASH | /rc4:HASH | /aes128:HASH | /aes256:HASH> [/domain:DOMAIN] [/dc:DOMAIN_CONTROLLER] [/outfile:FILENAME] [/ptt] [/luid] [/nowrap] [/opsec] [/nopac] [/proxyurl:https://KDC_PROXY/kdcproxy]
 
         Retrieve a TGT based on a user password/hash, optionally saving to a file or applying to the current logon session or a specific LUID:
-            Rubeus.exe asktgt /user:USER </password:PASSWORD [/enctype:DES|RC4|AES128|AES256] | /des:HASH | /rc4:HASH | /aes128:HASH | /aes256:HASH> [/domain:DOMAIN] [/dc:DOMAIN_CONTROLLER] [/outfile:FILENAME] [/ptt] [/luid] [/nowrap] [/opsec] [/nopac]
+            Rubeus.exe asktgt /user:USER </password:PASSWORD [/enctype:DES|RC4|AES128|AES256] | /des:HASH | /rc4:HASH | /aes128:HASH | /aes256:HASH> [/domain:DOMAIN] [/dc:DOMAIN_CONTROLLER] [/outfile:FILENAME] [/ptt] [/luid] [/nowrap] [/opsec] [/nopac] [/proxyurl:https://KDC_PROXY/kdcproxy]
     
         Retrieve a TGT based on a user password/hash, start a /netonly process, and to apply the ticket to the new process/logon session:
-            Rubeus.exe asktgt /user:USER </password:PASSWORD [/enctype:DES|RC4|AES128|AES256] | /des:HASH | /rc4:HASH | /aes128:HASH | /aes256:HASH> /createnetonly:C:\Windows\System32\cmd.exe [/show] [/domain:DOMAIN] [/dc:DOMAIN_CONTROLLER] [/nowrap] [/opsec] [/nopac]
+            Rubeus.exe asktgt /user:USER </password:PASSWORD [/enctype:DES|RC4|AES128|AES256] | /des:HASH | /rc4:HASH | /aes128:HASH | /aes256:HASH> /createnetonly:C:\Windows\System32\cmd.exe [/show] [/domain:DOMAIN] [/dc:DOMAIN_CONTROLLER] [/nowrap] [/opsec] [/nopac] [/proxyurl:https://KDC_PROXY/kdcproxy]
 
         Retrieve a TGT using a PCKS12 certificate, start a /netonly process, and to apply the ticket to the new process/logon session:
-            Rubeus.exe asktgt /user:USER /certificate:C:\temp\leaked.pfx </password:STOREPASSWORD> /createnetonly:C:\Windows\System32\cmd.exe [/getcredentials] [/servicekey:KRBTGTKEY] [/show] [/domain:DOMAIN] [/dc:DOMAIN_CONTROLLER] [/nowrap]
+            Rubeus.exe asktgt /user:USER /certificate:C:\temp\leaked.pfx </password:STOREPASSWORD> /createnetonly:C:\Windows\System32\cmd.exe [/getcredentials] [/servicekey:KRBTGTKEY] [/show] [/domain:DOMAIN] [/dc:DOMAIN_CONTROLLER] [/nowrap] [/proxyurl:https://KDC_PROXY/kdcproxy]
 
         Retrieve a TGT using a certificate from the users keystore (Smartcard) specifying certificate thumbprint or subject, start a /netonly process, and to apply the ticket to the new process/logon session:
             Rubeus.exe asktgt /user:USER /certificate:f063e6f4798af085946be6cd9d82ba3999c7ebac /createnetonly:C:\Windows\System32\cmd.exe [/show] [/domain:DOMAIN] [/dc:DOMAIN_CONTROLLER] [/nowrap]
 
         Retrieve a TGT suitable for changing an account with an expired password using the changepw command
-            Rubeus.exe asktgt /user:USER </password:PASSWORD /changepw [/enctype:DES|RC4|AES128|AES256] | /des:HASH | /rc4:HASH | /aes128:HASH | /aes256:HASH> [/domain:DOMAIN] [/dc:DOMAIN_CONTROLLER] [/outfile:FILENAME] [/ptt] [/luid] [/nowrap] [/opsec]
+            Rubeus.exe asktgt /user:USER </password:PASSWORD /changepw [/enctype:DES|RC4|AES128|AES256] | /des:HASH | /rc4:HASH | /aes128:HASH | /aes256:HASH> [/domain:DOMAIN] [/dc:DOMAIN_CONTROLLER] [/outfile:FILENAME] [/ptt] [/luid] [/nowrap] [/opsec] [/proxyurl:https://KDC_PROXY/kdcproxy]
 
        Retrieve a service ticket for one or more SPNs, optionally saving or applying the ticket:
-            Rubeus.exe asktgs </ticket:BASE64 | /ticket:FILE.KIRBI> </service:SPN1,SPN2,...> [/enctype:DES|RC4|AES128|AES256] [/dc:DOMAIN_CONTROLLER] [/outfile:FILENAME] [/ptt] [/nowrap] [/enterprise] [/opsec] </tgs:BASE64 | /tgs:FILE.KIRBI> [/targetdomain] [/u2u] [/targetuser] [/servicekey:PASSWORDHASH] [/asrepkey:ASREPKEY]
+            Rubeus.exe asktgs </ticket:BASE64 | /ticket:FILE.KIRBI> </service:SPN1,SPN2,...> [/enctype:DES|RC4|AES128|AES256] [/dc:DOMAIN_CONTROLLER] [/outfile:FILENAME] [/ptt] [/nowrap] [/enterprise] [/opsec] </tgs:BASE64 | /tgs:FILE.KIRBI> [/targetdomain] [/u2u] [/targetuser] [/servicekey:PASSWORDHASH] [/asrepkey:ASREPKEY] [/proxyurl:https://KDC_PROXY/kdcproxy]
 
         Renew a TGT, optionally applying the ticket, saving it, or auto-renewing the ticket up to its renew-till limit:
             Rubeus.exe renew </ticket:BASE64 | /ticket:FILE.KIRBI> [/dc:DOMAIN_CONTROLLER] [/outfile:FILENAME] [/ptt] [/autorenew] [/nowrap]
@@ -115,8 +115,8 @@ Rubeus is licensed under the BSD 3-Clause license.
      Constrained delegation abuse:
 
         Perform S4U constrained delegation abuse:
-            Rubeus.exe s4u </ticket:BASE64 | /ticket:FILE.KIRBI> </impersonateuser:USER | /tgs:BASE64 | /tgs:FILE.KIRBI> /msdsspn:SERVICE/SERVER [/altservice:SERVICE] [/dc:DOMAIN_CONTROLLER] [/outfile:FILENAME] [/ptt] [/nowrap] [/opsec] [/self]
-            Rubeus.exe s4u /user:USER </rc4:HASH | /aes256:HASH> [/domain:DOMAIN] </impersonateuser:USER | /tgs:BASE64 | /tgs:FILE.KIRBI> /msdsspn:SERVICE/SERVER [/altservice:SERVICE] [/dc:DOMAIN_CONTROLLER] [/outfile:FILENAME] [/ptt] [/nowrap] [/opsec] [/self] [/bronzebit] [/nopac]
+            Rubeus.exe s4u </ticket:BASE64 | /ticket:FILE.KIRBI> </impersonateuser:USER | /tgs:BASE64 | /tgs:FILE.KIRBI> /msdsspn:SERVICE/SERVER [/altservice:SERVICE] [/dc:DOMAIN_CONTROLLER] [/outfile:FILENAME] [/ptt] [/nowrap] [/opsec] [/self] [/proxyurl:https://KDC_PROXY/kdcproxy]
+            Rubeus.exe s4u /user:USER </rc4:HASH | /aes256:HASH> [/domain:DOMAIN] </impersonateuser:USER | /tgs:BASE64 | /tgs:FILE.KIRBI> /msdsspn:SERVICE/SERVER [/altservice:SERVICE] [/dc:DOMAIN_CONTROLLER] [/outfile:FILENAME] [/ptt] [/nowrap] [/opsec] [/self] [/bronzebit] [/nopac] [/proxyurl:https://KDC_PROXY/kdcproxy]
 
         Perform S4U constrained delegation abuse across domains:
             Rubeus.exe s4u /user:USER </rc4:HASH | /aes256:HASH> [/domain:DOMAIN] </impersonateuser:USER | /tgs:BASE64 | /tgs:FILE.KIRBI> /msdsspn:SERVICE/SERVER /targetdomain:DOMAIN.LOCAL /targetdc:DC.DOMAIN.LOCAL [/altservice:SERVICE] [/dc:DOMAIN_CONTROLLER] [/nowrap] [/self] [/nopac]
@@ -351,6 +351,8 @@ PKINIT authentication is supported with the `/certificate:X` argument. When the 
 
 Requesting a TGT without a PAC can be done using the `/nopac` switch.
 
+Using a KDC proxy ([MS-KKDCP](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-kkdcp/5bcebb8d-b747-4ee5-9453-428aec1c5c38)) to make the request is possible using the `/proxyurl:URL` argument. The full URL for the KDC proxy is required, eg. https://kdcproxy.exmaple.com/kdcproxy
+
 Requesting a ticket via RC4 hash for **dfm.a@testlab.local**, applying it to the current logon session:
 
     C:\Rubeus>Rubeus.exe asktgt /user:dfm.a /rc4:2b576acbe6bcfda7294d6bd18041b8fe /ptt
@@ -517,6 +519,7 @@ The `/u2u` flag was implemented to request User-to-User tickets. Together with t
 
 The `/printargs` flag will print the arguments required to forge a ticket with the same PAC values if the PAC is readable. This could be done by supplying the `/servicekey:X` argument or performing a `/u2u` request with a known session key.
 
+Using a KDC proxy ([MS-KKDCP](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-kkdcp/5bcebb8d-b747-4ee5-9453-428aec1c5c38)) to make the request is possible using the `/proxyurl:URL` argument. The full URL for the KDC proxy is required, eg. https://kdcproxy.exmaple.com/kdcproxy
 
 Requesting a TGT for dfm.a and then using that ticket to request a service ticket for the "LDAP/primary.testlab.local" and "cifs/primary.testlab.local" SPNs:
 
@@ -1012,6 +1015,8 @@ A **TL;DR** explanation is that an account with constrained delegation enabled i
 This "control" can be the hash of the account (`/rc4` or `/aes256`), or an existing TGT (`/ticket:X`) for the account with a **msds-allowedtodelegateto** value set. If a `/user` and rc4/aes256 hash is supplied, the **s4u** module performs an [asktgt](#asktgt) action first, using the returned ticket for the steps following. If a TGT `/ticket:X` is supplied, that TGT is used instead.
 
 If an account hash is supplied, the `/nopac` switch can be used to request the initial TGT without a PAC.
+
+Using a KDC proxy ([MS-KKDCP](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-kkdcp/5bcebb8d-b747-4ee5-9453-428aec1c5c38)) to make the requests is possible using the `/proxyurl:URL` argument. The full URL for the KDC proxy is required, eg. https://kdcproxy.exmaple.com/kdcproxy. When used for the `s4u` command, *all* requests will be sent through the proxy.
 
 A `/impersonateuser:X` parameter **MUST** be supplied to the **s4u** module. If nothing else is supplied, just the S4U2self process is executed, returning a forwardable ticket:
 

--- a/Rubeus/Commands/Asktgs.cs
+++ b/Rubeus/Commands/Asktgs.cs
@@ -28,6 +28,8 @@ namespace Rubeus.Commands
             string targetUser = "";
             bool printargs = false;
 
+            string proxyUrl = null;
+
             if (arguments.ContainsKey("/outfile"))
             {
                 outfile = arguments["/outfile"];
@@ -142,9 +144,16 @@ namespace Rubeus.Commands
                 targetDomain = arguments["/targetdomain"];
             }
 
+            // for adding a PA-for-User PA data section
             if (arguments.ContainsKey("/targetuser"))
             {
                 targetUser = arguments["/targetuser"];
+            }
+
+            // for using a KDC proxy
+            if (arguments.ContainsKey("/proxyurl"))
+            {
+                proxyUrl = arguments["/proxyurl"];
             }
 
             if (arguments.ContainsKey("/ticket"))
@@ -155,14 +164,14 @@ namespace Rubeus.Commands
                 {
                     byte[] kirbiBytes = Convert.FromBase64String(kirbi64);
                     KRB_CRED kirbi = new KRB_CRED(kirbiBytes);
-                    Ask.TGS(kirbi, service, requestEnctype, outfile, ptt, dc, true, enterprise, false, opsec, tgs, targetDomain, servicekey, asrepkey, u2u, targetUser, printargs);
+                    Ask.TGS(kirbi, service, requestEnctype, outfile, ptt, dc, true, enterprise, false, opsec, tgs, targetDomain, servicekey, asrepkey, u2u, targetUser, printargs, proxyUrl);
                     return;
                 }
                 else if (File.Exists(kirbi64))
                 {
                     byte[] kirbiBytes = File.ReadAllBytes(kirbi64);
                     KRB_CRED kirbi = new KRB_CRED(kirbiBytes);
-                    Ask.TGS(kirbi, service, requestEnctype, outfile, ptt, dc, true, enterprise, false, opsec, tgs, targetDomain, servicekey, asrepkey, u2u, targetUser, printargs);
+                    Ask.TGS(kirbi, service, requestEnctype, outfile, ptt, dc, true, enterprise, false, opsec, tgs, targetDomain, servicekey, asrepkey, u2u, targetUser, printargs, proxyUrl);
                     return;
                 }
                 else

--- a/Rubeus/Commands/Asktgt.cs
+++ b/Rubeus/Commands/Asktgt.cs
@@ -32,6 +32,8 @@ namespace Rubeus.Commands
             LUID luid = new LUID();
             Interop.KERB_ETYPE encType = Interop.KERB_ETYPE.subkey_keymaterial;
 
+            string proxyUrl = null;
+
             if (arguments.ContainsKey("/user"))
             {
                 string[] parts = arguments["/user"].Split('\\');
@@ -158,6 +160,12 @@ namespace Rubeus.Commands
                 pac = false;
             }
 
+
+            if (arguments.ContainsKey("/proxyurl"))
+            {
+                proxyUrl = arguments["/proxyurl"];
+            }
+
             if (arguments.ContainsKey("/luid"))
             {
                 try
@@ -220,9 +228,9 @@ namespace Rubeus.Commands
                     return;
                 }
                 if (String.IsNullOrEmpty(certificate))
-                    Ask.TGT(user, domain, hash, encType, outfile, ptt, dc, luid, true, opsec, servicekey, changepw, pac);
+                    Ask.TGT(user, domain, hash, encType, outfile, ptt, dc, luid, true, opsec, servicekey, changepw, pac, proxyUrl);
                 else
-                    Ask.TGT(user, domain, certificate, password, encType, outfile, ptt, dc, luid, true, verifyCerts, servicekey, getCredentials);
+                    Ask.TGT(user, domain, certificate, password, encType, outfile, ptt, dc, luid, true, verifyCerts, servicekey, getCredentials, proxyUrl);
 
                 return;
             }

--- a/Rubeus/Commands/S4u.cs
+++ b/Rubeus/Commands/S4u.cs
@@ -30,6 +30,7 @@ namespace Rubeus.Commands
             bool pac = true;
             Interop.KERB_ETYPE encType = Interop.KERB_ETYPE.subkey_keymaterial; // throwaway placeholder, changed to something valid
             KRB_CRED tgs = null;
+            string proxyUrl = null;
 
             if (arguments.ContainsKey("/user"))
             {
@@ -120,6 +121,10 @@ namespace Rubeus.Commands
             {
                 pac = false;
             }
+            if (arguments.ContainsKey("/proxyurl"))
+            {
+                proxyUrl = arguments["/proxyurl"];
+            }
 
             if (arguments.ContainsKey("/tgs"))
             {
@@ -194,7 +199,7 @@ namespace Rubeus.Commands
                     return;
                 }
 
-                S4U.Execute(user, domain, hash, encType, targetUser, targetSPN, outfile, ptt, dc, altSname, tgs, targetDC, targetDomain, self, opsec, bronzebit, pac);
+                S4U.Execute(user, domain, hash, encType, targetUser, targetSPN, outfile, ptt, dc, altSname, tgs, targetDC, targetDomain, self, opsec, bronzebit, pac, proxyUrl);
                 return;
             }
             else

--- a/Rubeus/Domain/Info.cs
+++ b/Rubeus/Domain/Info.cs
@@ -12,7 +12,7 @@ namespace Rubeus.Domain
             Console.WriteLine("  |  __  /| | | |  _ \\| ___ | | | |/___)");
             Console.WriteLine("  | |  \\ \\| |_| | |_) ) ____| |_| |___ |");
             Console.WriteLine("  |_|   |_|____/|____/|_____)____/(___/\r\n");
-            Console.WriteLine("  v2.0.1 \r\n");
+            Console.WriteLine("  v2.0.2 \r\n");
         }
 
         public static void ShowUsage()
@@ -21,19 +21,19 @@ namespace Rubeus.Domain
  Ticket requests and renewals:
 
     Retrieve a TGT based on a user password/hash, optionally saving to a file or applying to the current logon session or a specific LUID:
-        Rubeus.exe asktgt /user:USER </password:PASSWORD [/enctype:DES|RC4|AES128|AES256] | /des:HASH | /rc4:HASH | /aes128:HASH | /aes256:HASH> [/domain:DOMAIN] [/dc:DOMAIN_CONTROLLER] [/outfile:FILENAME] [/ptt] [/luid] [/nowrap] [/opsec] [/nopac] [/oldsam]
+        Rubeus.exe asktgt /user:USER </password:PASSWORD [/enctype:DES|RC4|AES128|AES256] | /des:HASH | /rc4:HASH | /aes128:HASH | /aes256:HASH> [/domain:DOMAIN] [/dc:DOMAIN_CONTROLLER] [/outfile:FILENAME] [/ptt] [/luid] [/nowrap] [/opsec] [/nopac] [/oldsam] [/proxyurl:https://KDC_PROXY/kdcproxy]
 
     Retrieve a TGT based on a user password/hash, start a /netonly process, and to apply the ticket to the new process/logon session:
-        Rubeus.exe asktgt /user:USER </password:PASSWORD [/enctype:DES|RC4|AES128|AES256] | /des:HASH | /rc4:HASH | /aes128:HASH | /aes256:HASH> /createnetonly:C:\Windows\System32\cmd.exe [/show] [/domain:DOMAIN] [/dc:DOMAIN_CONTROLLER] [/nowrap] [/opsec] [/nopac] [/oldsam]
+        Rubeus.exe asktgt /user:USER </password:PASSWORD [/enctype:DES|RC4|AES128|AES256] | /des:HASH | /rc4:HASH | /aes128:HASH | /aes256:HASH> /createnetonly:C:\Windows\System32\cmd.exe [/show] [/domain:DOMAIN] [/dc:DOMAIN_CONTROLLER] [/nowrap] [/opsec] [/nopac] [/oldsam] [/proxyurl:https://KDC_PROXY/kdcproxy]
 
     Retrieve a TGT using a PCKS12 certificate, start a /netonly process, and to apply the ticket to the new process/logon session:
-        Rubeus.exe asktgt /user:USER /certificate:C:\temp\leaked.pfx </password:STOREPASSWORD> /createnetonly:C:\Windows\System32\cmd.exe [/getcredentials] [/servicekey:KRBTGTKEY] [/show] [/domain:DOMAIN] [/dc:DOMAIN_CONTROLLER] [/nowrap] [/nopac]
+        Rubeus.exe asktgt /user:USER /certificate:C:\temp\leaked.pfx </password:STOREPASSWORD> /createnetonly:C:\Windows\System32\cmd.exe [/getcredentials] [/servicekey:KRBTGTKEY] [/show] [/domain:DOMAIN] [/dc:DOMAIN_CONTROLLER] [/nowrap] [/nopac] [/proxyurl:https://KDC_PROXY/kdcproxy]
 
     Retrieve a TGT using a certificate from the users keystore (Smartcard) specifying certificate thumbprint or subject, start a /netonly process, and to apply the ticket to the new process/logon session:
         Rubeus.exe asktgt /user:USER /certificate:f063e6f4798af085946be6cd9d82ba3999c7ebac /createnetonly:C:\Windows\System32\cmd.exe [/show] [/domain:DOMAIN] [/dc:DOMAIN_CONTROLLER] [/nowrap]
 
     Retrieve a service ticket for one or more SPNs, optionally saving or applying the ticket:
-        Rubeus.exe asktgs </ticket:BASE64 | /ticket:FILE.KIRBI> </service:SPN1,SPN2,...> [/enctype:DES|RC4|AES128|AES256] [/dc:DOMAIN_CONTROLLER] [/outfile:FILENAME] [/ptt] [/nowrap] [/enterprise] [/opsec] </tgs:BASE64 | /tgs:FILE.KIRBI> [/targetdomain] [/u2u] [/targetuser] [/servicekey:PASSWORDHASH] [/asrepkey:ASREPKEY]
+        Rubeus.exe asktgs </ticket:BASE64 | /ticket:FILE.KIRBI> </service:SPN1,SPN2,...> [/enctype:DES|RC4|AES128|AES256] [/dc:DOMAIN_CONTROLLER] [/outfile:FILENAME] [/ptt] [/nowrap] [/enterprise] [/opsec] </tgs:BASE64 | /tgs:FILE.KIRBI> [/targetdomain] [/u2u] [/targetuser] [/servicekey:PASSWORDHASH] [/asrepkey:ASREPKEY] [/proxyurl:https://KDC_PROXY/kdcproxy]
 
     Renew a TGT, optionally applying the ticket, saving it, or auto-renewing the ticket up to its renew-till limit:
         Rubeus.exe renew </ticket:BASE64 | /ticket:FILE.KIRBI> [/dc:DOMAIN_CONTROLLER] [/outfile:FILENAME] [/ptt] [/autorenew] [/nowrap]
@@ -45,8 +45,8 @@ namespace Rubeus.Domain
  Constrained delegation abuse:
 
     Perform S4U constrained delegation abuse:
-        Rubeus.exe s4u </ticket:BASE64 | /ticket:FILE.KIRBI> </impersonateuser:USER | /tgs:BASE64 | /tgs:FILE.KIRBI> /msdsspn:SERVICE/SERVER [/altservice:SERVICE] [/dc:DOMAIN_CONTROLLER] [/outfile:FILENAME] [/ptt] [/nowrap] [/opsec] [/self]
-        Rubeus.exe s4u /user:USER </rc4:HASH | /aes256:HASH> [/domain:DOMAIN] </impersonateuser:USER | /tgs:BASE64 | /tgs:FILE.KIRBI> /msdsspn:SERVICE/SERVER [/altservice:SERVICE] [/dc:DOMAIN_CONTROLLER] [/outfile:FILENAME] [/ptt] [/nowrap] [/opsec] [/self] [/bronzebit] [/nopac]
+        Rubeus.exe s4u </ticket:BASE64 | /ticket:FILE.KIRBI> </impersonateuser:USER | /tgs:BASE64 | /tgs:FILE.KIRBI> /msdsspn:SERVICE/SERVER [/altservice:SERVICE] [/dc:DOMAIN_CONTROLLER] [/outfile:FILENAME] [/ptt] [/nowrap] [/opsec] [/self] [/proxyurl:https://KDC_PROXY/kdcproxy]
+        Rubeus.exe s4u /user:USER </rc4:HASH | /aes256:HASH> [/domain:DOMAIN] </impersonateuser:USER | /tgs:BASE64 | /tgs:FILE.KIRBI> /msdsspn:SERVICE/SERVER [/altservice:SERVICE] [/dc:DOMAIN_CONTROLLER] [/outfile:FILENAME] [/ptt] [/nowrap] [/opsec] [/self] [/bronzebit] [/nopac] [/proxyurl:https://KDC_PROXY/kdcproxy]
 
     Perform S4U constrained delegation abuse across domains:
         Rubeus.exe s4u /user:USER </rc4:HASH | /aes256:HASH> [/domain:DOMAIN] </impersonateuser:USER | /tgs:BASE64 | /tgs:FILE.KIRBI> /msdsspn:SERVICE/SERVER /targetdomain:DOMAIN.LOCAL /targetdc:DC.DOMAIN.LOCAL [/altservice:SERVICE] [/dc:DOMAIN_CONTROLLER] [/nowrap] [/self] [/nopac]

--- a/Rubeus/Rubeus.csproj
+++ b/Rubeus/Rubeus.csproj
@@ -137,6 +137,7 @@
     <Compile Include="lib\krb_structures\EncryptionKey.cs" />
     <Compile Include="lib\krb_structures\EncTicketPart.cs" />
     <Compile Include="lib\krb_structures\HostAddress.cs" />
+    <Compile Include="lib\krb_structures\KDC_PROXY_MESSAGE.cs" />
     <Compile Include="lib\krb_structures\KDC_REQ_BODY.cs" />
     <Compile Include="lib\krb_structures\ADRestrictionEntry.cs" />
     <Compile Include="lib\krb_structures\KERB_PA_PAC_REQUEST.cs" />

--- a/Rubeus/Rubeus.csproj
+++ b/Rubeus/Rubeus.csproj
@@ -136,6 +136,7 @@
     <Compile Include="lib\krb_structures\EncryptedData.cs" />
     <Compile Include="lib\krb_structures\EncryptionKey.cs" />
     <Compile Include="lib\krb_structures\EncTicketPart.cs" />
+    <Compile Include="lib\krb_structures\ETYPE_INFO2_ENTRY.cs" />
     <Compile Include="lib\krb_structures\HostAddress.cs" />
     <Compile Include="lib\krb_structures\KDC_PROXY_MESSAGE.cs" />
     <Compile Include="lib\krb_structures\KDC_REQ_BODY.cs" />

--- a/Rubeus/lib/Ask.cs
+++ b/Rubeus/lib/Ask.cs
@@ -336,7 +336,6 @@ namespace Rubeus {
                 dcIP = Networking.GetDCIP(domainController, display, domain);
                 if (String.IsNullOrEmpty(dcIP)) { return null; }
 
-                Console.WriteLine("[*] Using domain controller: {0}:88", dcIP);
                 response = Networking.SendBytes(dcIP, 88, tgsBytes);
             }
             else

--- a/Rubeus/lib/Interop.cs
+++ b/Rubeus/lib/Interop.cs
@@ -295,7 +295,9 @@ namespace Rubeus
             KDC_ERR_PREAUTH_FAILED = 0x18, //Pre-authentication information was invalid
             KDC_ERR_PREAUTH_REQUIRED = 0x19, // Additional preauthentication required
             KDC_ERR_SERVER_NOMATCH = 0x1A, //KDC does not know about the requested server
-            KDC_ERR_SVC_UNAVAILABLE = 0x1B, // KDC is unavailable
+            KDC_ERR_MUST_USE_USER2USER = 0x1B,
+            KDC_ERR_PATH_NOT_ACCEPTED = 0x1C,
+            KDC_ERR_SVC_UNAVAILABLE = 0x1D, // KDC is unavailable (modified as stated here: https://github.com/dotnet/Kerberos.NET/blob/develop/Kerberos.NET/Entities/Krb/KerberosErrorCode.cs)
             KRB_AP_ERR_BAD_INTEGRITY = 0x1F, // Integrity check on decrypted field failed
             KRB_AP_ERR_TKT_EXPIRED = 0x20, // The ticket has expired
             KRB_AP_ERR_TKT_NYV = 0x21, //The ticket is not yet valid

--- a/Rubeus/lib/Networking.cs
+++ b/Rubeus/lib/Networking.cs
@@ -5,10 +5,10 @@ using System.DirectoryServices.Protocols;
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using System.Collections.Generic;
-using System.Threading;
 using SearchScope = System.DirectoryServices.Protocols.SearchScope;
 using System.IO;
-using System.Linq;
+using System.Net;
+using Asn1;
 
 namespace Rubeus
 {
@@ -556,6 +556,61 @@ namespace Rubeus
                 }
             }
             return returnResult;
+        }
+
+        public static byte[] MakeProxyRequest(string proxyUrl, KDC_PROXY_MESSAGE message)
+        {
+            byte[] responseBytes = null;
+
+            byte[] messageBytes = message.Encode().Encode();
+            BinaryWriter bw = new BinaryWriter(new MemoryStream());
+            bw.Write(messageBytes);
+            byte[] data = ((MemoryStream)bw.BaseStream).ToArray();
+
+            // because we don't care if the server certificate can't be verified
+            ServicePointManager.ServerCertificateValidationCallback = new System.Net.Security.RemoteCertificateValidationCallback(AcceptAllCertifications);
+
+            try
+            {
+                HttpWebRequest request = (HttpWebRequest)WebRequest.Create(proxyUrl);
+                request.Method = "POST";
+                request.ContentLength = data.Length;
+                request.ContentType = "application/kerberos";
+                request.UserAgent = "Rubeus/1.0";
+
+                BinaryWriter socketWriter = new BinaryWriter(request.GetRequestStream());
+                socketWriter.Write(data);
+
+                var response = (HttpWebResponse)request.GetResponse();
+
+                BinaryReader socketReader = new BinaryReader(response.GetResponseStream());
+                responseBytes = socketReader.ReadBytes((int)response.ContentLength);
+
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine("\r\n[!] Unhandled Rubeus exception:\r\n");
+                Console.WriteLine(e);
+            }
+
+            KDC_PROXY_MESSAGE responseMessage = new KDC_PROXY_MESSAGE(AsnElt.Decode(responseBytes));
+
+            BinaryReader br = new BinaryReader(new MemoryStream(responseMessage.kerb_message));
+            int recordMark = IPAddress.NetworkToHostOrder(br.ReadInt32());
+            int recordSize = recordMark & 0x7fffffff;
+
+            if ((recordMark & 0x80000000) > 0)
+            {
+                Console.WriteLine("[X] Unexpected reserved bit set on response record mark from KDC Proxy: {0}, aborting", proxyUrl);
+                return null;
+            }
+
+            return br.ReadBytes(recordSize);
+        }
+
+        public static bool AcceptAllCertifications(object sender, System.Security.Cryptography.X509Certificates.X509Certificate certification, System.Security.Cryptography.X509Certificates.X509Chain chain, System.Net.Security.SslPolicyErrors sslPolicyErrors)
+        {
+            return true;
         }
     }
 }

--- a/Rubeus/lib/krb_structures/ETYPE_INFO2_ENTRY.cs
+++ b/Rubeus/lib/krb_structures/ETYPE_INFO2_ENTRY.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Asn1;
+
+namespace Rubeus
+{
+    public class ETYPE_INFO2_ENTRY
+    {
+        /*
+        ETYPE-INFO2-ENTRY::= SEQUENCE {
+        etype [0] Int32 -- EncryptionType --,
+        salt [1] KerberosString OPTIONAL,
+        s2kparams [2] INTEGER OPTIONAL
+        }
+        */
+
+        public ETYPE_INFO2_ENTRY(AsnElt body)
+        {
+            foreach (AsnElt s in body.Sub[0].Sub)
+            {
+                switch (s.TagValue)
+                {
+                    case 0:
+                        etype = Convert.ToInt32(s.Sub[0].GetInteger());
+                        break;
+                    case 1:
+                        salt = Encoding.ASCII.GetString(s.Sub[0].GetOctetString());
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public Int32 etype { get; set; }
+
+        public string salt { get; set; }
+
+        // skip sk2params for now
+    }
+}

--- a/Rubeus/lib/krb_structures/KDC_PROXY_MESSAGE.cs
+++ b/Rubeus/lib/krb_structures/KDC_PROXY_MESSAGE.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Text;
+using Asn1;
+
+namespace Rubeus
+{
+    public class KDC_PROXY_MESSAGE
+    {
+        /*
+        KDC-PROXY-MESSAGE::= SEQUENCE {
+        kerb-message [0] OCTET STRING,
+        target-domain [1] KerberosString OPTIONAL,
+        dclocator-hint [2] INTEGER OPTIONAL
+        }
+        */
+
+        public KDC_PROXY_MESSAGE()
+        {
+            kerb_message = null;
+            target_domain = null;
+            dclocator_hint = null;
+        }
+
+        public KDC_PROXY_MESSAGE(byte[] message)
+        {
+            BinaryWriter bw = new BinaryWriter(new MemoryStream());
+            bw.Write(IPAddress.HostToNetworkOrder(message.Length));
+            bw.Write(message);
+            kerb_message = ((MemoryStream)bw.BaseStream).ToArray();
+            target_domain = null;
+            dclocator_hint = null;
+        }
+
+        public KDC_PROXY_MESSAGE(AsnElt body)
+        {
+            foreach (AsnElt s in body.Sub)
+            {
+                switch (s.TagValue)
+                {
+                    case 0:
+                        kerb_message = s.Sub[0].GetOctetString();
+                        break;
+                    case 1:
+                        target_domain = Encoding.ASCII.GetString(s.Sub[0].GetOctetString());
+                        break;
+                    case 2:
+                        dclocator_hint = Convert.ToUInt32(s.Sub[0].GetInteger());
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public AsnElt Encode()
+        {
+            List<AsnElt> allNodes = new List<AsnElt>();
+
+            // kerb-message [0] OCTET STRING
+            AsnElt messageAsn = AsnElt.MakeBlob(kerb_message);
+            AsnElt messageSeq = AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] { messageAsn });
+            messageSeq = AsnElt.MakeImplicit(AsnElt.CONTEXT, 0, messageSeq);
+            allNodes.Add(messageSeq);
+
+            // target-domain [1] KerberosString OPTIONAL,
+            if (target_domain != null)
+            {
+                AsnElt domainAsn = AsnElt.MakeString(AsnElt.IA5String, target_domain);
+                domainAsn = AsnElt.MakeImplicit(AsnElt.UNIVERSAL, AsnElt.GeneralString, domainAsn);
+                AsnElt domainSeq = AsnElt.Make(AsnElt.SEQUENCE, new[] { domainAsn });
+                domainSeq = AsnElt.MakeImplicit(AsnElt.CONTEXT, 1, domainSeq);
+                allNodes.Add(domainSeq);
+            }
+
+            // dclocator-hint [2] INTEGER OPTIONAL
+            if (dclocator_hint != null)
+            {
+                AsnElt dchintAsn = AsnElt.MakeInteger((uint)dclocator_hint);
+                AsnElt dchintSeq = AsnElt.Make(AsnElt.SEQUENCE, new[] { dchintAsn });
+                dchintSeq = AsnElt.MakeImplicit(AsnElt.CONTEXT, 2, dchintSeq);
+                allNodes.Add(dchintSeq);
+            }
+
+            AsnElt seq = AsnElt.Make(AsnElt.SEQUENCE, allNodes.ToArray());
+
+            return seq;
+        }
+
+        public byte[] kerb_message { get; set; }
+
+        public string target_domain { get; set; }
+
+        public uint? dclocator_hint { get; set; }
+    }
+}
+

--- a/Rubeus/lib/krb_structures/KRB_ERROR.cs
+++ b/Rubeus/lib/krb_structures/KRB_ERROR.cs
@@ -67,6 +67,17 @@ namespace Rubeus
                     case 10:
                         sname = new PrincipalName(s.Sub[0]);
                         break;
+                    case 11:
+                        e_text = Encoding.ASCII.GetString(s.Sub[0].GetOctetString());
+                        break;
+                    case 12:
+                        e_data = new List<PA_DATA>();
+                        AsnElt tmpData = AsnElt.Decode(s.Sub[0].GetOctetString());
+                        foreach (AsnElt tmp in tmpData.Sub)
+                        {
+                            e_data.Add(new PA_DATA(tmp));
+                        }
+                        break;
                     default:
                         break;
                 }
@@ -97,8 +108,11 @@ namespace Rubeus
 
         public PrincipalName sname { get; set; }
 
+        public string e_text { get; set; }
+
+        public List<PA_DATA> e_data { get; set; }
+
         // skipping these two for now
-        // e_text
         // e_data
 
 

--- a/Rubeus/lib/krb_structures/PA_DATA.cs
+++ b/Rubeus/lib/krb_structures/PA_DATA.cs
@@ -138,6 +138,9 @@ namespace Rubeus {
                     break;
                 case Interop.PADATA_TYPE.PA_S4U_X509_USER:
                     break;
+                case Interop.PADATA_TYPE.ETYPE_INFO2:
+                    value = new ETYPE_INFO2_ENTRY(AsnElt.Decode(body.Sub[1].Sub[0].CopyValue()));
+                    break;
             }
         }
 


### PR DESCRIPTION
As requested by MichaelGrafnetter in issue #100. `asktgt`, `asktgs` and `s4u` can now be used through a KDC proxy using the `/proxyurl:URL` argument. If the `/proxyurl` argument isn't passed, Rubeus should behave as before. An example of using it to request a service ticket:

```
C:\Rubeus>.\Rubeus.exe asktgs /service:ldap/idc1.internal.zeroday.lab /nowrap /proxyurl:https://192.168.71.40/kdcproxy /ticket:doIFtDCCBbCg...mFsLnplcm9kYXkubGFi

   ______        _
  (_____ \      | |
   _____) )_   _| |__  _____ _   _  ___
  |  __  /| | | |  _ \| ___ | | | |/___)
  | |  \ \| |_| | |_) ) ____| |_| |___ |
  |_|   |_|____/|____/|_____)____/(___/

  v2.0.2

[*] Action: Ask TGS

[*] Requesting default etypes (RC4_HMAC, AES[128/256]_CTS_HMAC_SHA1) for the service ticket
[*] Building TGS-REQ request for: 'ldap/idc1.internal.zeroday.lab'
[*] Sending request via KDC proxy: https://192.168.71.40/kdcproxy
[+] TGS request successful!
[*] base64(ticket.kirbi):

      doIF/DCCBfigAwIBBaE...nplcm9kYXkubGFi

  ServiceName              :  ldap/idc1.internal.zeroday.lab
  ServiceRealm             :  INTERNAL.ZERODAY.LAB
  UserName                 :  internal.user
  UserRealm                :  INTERNAL.ZERODAY.LAB
  StartTime                :  27/01/2022 23:32:21
  EndTime                  :  28/01/2022 09:32:21
  RenewTill                :  04/02/2022 23:21:42
  Flags                    :  name_canonicalize, ok_as_delegate, pre_authent, renewable, forwardable
  KeyType                  :  aes256_cts_hmac_sha1
  Base64(key)              :  Y9MGx/TY77PBNMxo+z+3etq1fRSl2JPa4L1PlUlPhnU=
```