### PR TITLE
fix for handling KERB_ERROR's

### DIFF
--- a/Rubeus/lib/krb_structures/KRB_ERROR.cs
+++ b/Rubeus/lib/krb_structures/KRB_ERROR.cs
@@ -71,11 +71,18 @@ namespace Rubeus
                         e_text = Encoding.ASCII.GetString(s.Sub[0].GetOctetString());
                         break;
                     case 12:
-                        e_data = new List<PA_DATA>();
-                        AsnElt tmpData = AsnElt.Decode(s.Sub[0].GetOctetString());
-                        foreach (AsnElt tmp in tmpData.Sub)
+                        try
                         {
-                            e_data.Add(new PA_DATA(tmp));
+                            e_data = new List<PA_DATA>();
+                            AsnElt tmpData = AsnElt.Decode(s.Sub[0].GetOctetString());
+                            foreach (AsnElt tmp in tmpData.Sub)
+                            {
+                                e_data.Add(new PA_DATA(tmp));
+                            }
+                        }
+                        catch (NullReferenceException ex)
+                        {
+                            e_data = null;
                         }
                         break;
                     default:
@@ -111,10 +118,6 @@ namespace Rubeus
         public string e_text { get; set; }
 
         public List<PA_DATA> e_data { get; set; }
-
-        // skipping these two for now
-        // e_data
-
 
         //public Ticket[] tickets { get; set; }
         public List<Ticket> tickets { get; set; }


### PR DESCRIPTION
My last PR included handling of `e_data` within `KERB_ERROR`'s for retrieval of the account salt from PA Data returned when a TGT was requested without preauth. This broke some errors (for instance `AP_ERR_MODIFIED`) where `e_data` isn't PA Data sections, as shown below:

```
[*] Action: Ask TGS

[*] Requesting default etypes (RC4_HMAC, AES[128/256]_CTS_HMAC_SHA1) for the service ticket
[*] Building TGS-REQ request for: 'ldap/idc1.internal.zeroday.lab'
[*] Using domain controller: idc1.internal.zeroday.lab (192.168.71.20)

[!] Unhandled Rubeus exception:

System.NullReferenceException: Object reference not set to an instance of an object.
   at Rubeus.PA_DATA..ctor(AsnElt body)
   at Rubeus.KRB_ERROR..ctor(AsnElt body)
   at Rubeus.Ask.TGS(String userName, String domain, Ticket providedTicket, Byte[] clientKey, KERB_ETYPE paEType, String service, KERB_ETYPE requestEType, String outfile, Boolean ptt, String domainController, Boolean display, Boolean enterprise, Boolean roast, Boolean opsec, KRB_CRED tgs, String targetDomain, String servicekey, String asrepkey, Boolean u2u, String targetUser, Boolean printargs, String proxyUrl)
   at Rubeus.Ask.TGS(KRB_CRED kirbi, String service, KERB_ETYPE requestEType, String outfile, Boolean ptt, String domainController, Boolean display, Boolean enterprise, Boolean roast, Boolean opsec, KRB_CRED tgs, String targetDomain, String servicekey, String asrepkey, Boolean u2u, String targetUser, Boolean printargs, String proxyUrl)
   at Rubeus.Commands.Asktgs.Execute(Dictionary`2 arguments)
   at Rubeus.Domain.CommandCollection.ExecuteCommand(String commandName, Dictionary`2 arguments)
   at Rubeus.Program.MainExecute(String commandName, Dictionary`2 parsedArgs)
```

Fixed by putting a try/catch around decoding the `e_data`  section and setting it to *null* if it fails:

```
[*] Action: Ask TGS

[*] Requesting default etypes (RC4_HMAC, AES[128/256]_CTS_HMAC_SHA1) for the service ticket
[*] Building TGS-REQ request for: 'ldap/idc1.internal.zeroday.lab'
[*] Using domain controller: idc1.internal.zeroday.lab (192.168.71.20)

[X] KRB-ERROR (41) : KRB_AP_ERR_MODIFIED
```