### PR TITLE
General code cleanup

### DIFF
--- a/Rubeus/Asn1/AsnElt.cs
+++ b/Rubeus/Asn1/AsnElt.cs
@@ -299,7 +299,7 @@ public class AsnElt {
 		case PRIVATE:
 			return "PRIVATE:" + tv;
 		default:
-			return String.Format("INVALID:{0}/{1}", tc, tv);
+			return $"INVALID:{tc}/{tv}";
 		}
 
 		switch (tv) {
@@ -749,9 +749,7 @@ public class AsnElt {
 	{
 		int vlen = ValueLength;
 		if (off < 0 || len < 0 || len > (vlen - off)) {
-			throw new AsnException(String.Format(
-				"invalid value window {0}:{1}"
-				+ " (value length = {2})", off, len, vlen));
+			throw new AsnException($"invalid value window {off}:{len}" + $" (value length = {vlen})");
 		}
 		EncodeValue(off, off + len, dst, dstOff);
 	}
@@ -808,8 +806,7 @@ public class AsnElt {
 		}
 		int vlen = ValueLength;
 		if (vlen != 1) {
-			throw new AsnException(String.Format(
-				"invalid BOOLEAN (length = {0})", vlen));
+			throw new AsnException($"invalid BOOLEAN (length = {vlen})");
 		}
 		return ValueByte(0) != 0;
 	}
@@ -976,8 +973,7 @@ public class AsnElt {
 		}
 		int fb = ValueByte(0);
 		if (fb > 7 || (vlen == 1 && fb != 0)) {
-			throw new AsnException(String.Format(
-				"invalid BIT STRING (start = 0x{0:X2})", fb));
+			throw new AsnException($"invalid BIT STRING (start = 0x{fb:X2})");
 		}
 		byte[] r = new byte[vlen - 1];
 		CopyValueChunk(1, vlen - 1, r, 0);
@@ -998,8 +994,7 @@ public class AsnElt {
 				"invalid NULL (constructed)");
 		}
 		if (ValueLength != 0) {
-			throw new AsnException(String.Format(
-				"invalid NULL (length = {0})", ValueLength));
+			throw new AsnException($"invalid NULL (length = {ValueLength})");
 		}
 	}
 
@@ -1635,7 +1630,7 @@ public class AsnElt {
 	static AsnException BadTime(int type, string s, Exception e)
 	{
 		string tt = (type == UTCTime) ? "UTCTime" : "GeneralizedTime";
-		string msg = String.Format("invalid {0} string: '{1}'", tt, s);
+		string msg = $"invalid {tt} string: '{s}'";
 		if (e == null) {
 			return new AsnException(msg);
 		} else {
@@ -2044,9 +2039,7 @@ public class AsnElt {
 				continue;
 			}
 			if (c < '0' || c > '9') {
-				throw new AsnException(String.Format(
-					"invalid character U+{0:X4} in OID",
-					c));
+				throw new AsnException($"invalid character U+{c:X4} in OID");
 			}
 			if (x < 0) {
 				x = 0;
@@ -2220,9 +2213,7 @@ public class AsnElt {
 		case UTCTime:
 			int year = dt.Year;
 			if (year < 1950 || year >= 2050) {
-				throw new AsnException(String.Format(
-					"cannot encode year {0} as UTCTime",
-					year));
+				throw new AsnException($"cannot encode year {year} as UTCTime");
 			}
 			year = year % 100;
 			str = String.Format(

--- a/Rubeus/Asn1/AsnElt.cs
+++ b/Rubeus/Asn1/AsnElt.cs
@@ -930,7 +930,7 @@ public class AsnElt {
 		if (Constructed) {
 			int orig = off;
 			foreach (AsnElt ae in Sub) {
-				ae.CheckTag(AsnElt.OCTET_STRING);
+				ae.CheckTag(OCTET_STRING);
 				off += ae.GetOctetString(dst, off);
 			}
 			return off - orig;
@@ -2010,12 +2010,12 @@ public class AsnElt {
 		return a;
 	}
 
-	public static AsnElt NULL_V = AsnElt.MakePrimitive(
+	public static AsnElt NULL_V = MakePrimitive(
 		NULL, new byte[0]);
 
-	public static AsnElt BOOL_TRUE = AsnElt.MakePrimitive(
+	public static AsnElt BOOL_TRUE = MakePrimitive(
 		BOOLEAN, new byte[] { 0xFF });
-	public static AsnElt BOOL_FALSE = AsnElt.MakePrimitive(
+	public static AsnElt BOOL_FALSE = MakePrimitive(
 		BOOLEAN, new byte[] { 0x00 });
 
 	/*

--- a/Rubeus/Asn1/AsnIO.cs
+++ b/Rubeus/Asn1/AsnIO.cs
@@ -1,7 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Text;
 
 namespace Asn1 {
 

--- a/Rubeus/Asn1/AsnIO.cs
+++ b/Rubeus/Asn1/AsnIO.cs
@@ -115,8 +115,8 @@ public static class AsnIO {
 		 * then we remove both, keeping only the characters that
 		 * occur in between.
 		 */
-		int p = str.IndexOf("-----BEGIN ");
-		int q = str.IndexOf("-----END ");
+		int p = str.IndexOf("-----BEGIN ", StringComparison.Ordinal);
+		int q = str.IndexOf("-----END ", StringComparison.Ordinal);
 		if (p >= 0 && q >= 0) {
 			p += 11;
 			int r = str.IndexOf((char)10, p) + 1;

--- a/Rubeus/Asn1/AsnOID.cs
+++ b/Rubeus/Asn1/AsnOID.cs
@@ -281,7 +281,7 @@ public class AsnOID {
 		if (oid.StartsWith(".") || oid.EndsWith(".")) {
 			return false;
 		}
-		if (oid.IndexOf("..") >= 0) {
+		if (oid.IndexOf("..", StringComparison.Ordinal) >= 0) {
 			return false;
 		}
 		if (oid.IndexOf('.') < 0) {

--- a/Rubeus/Commands/Asktgs.cs
+++ b/Rubeus/Commands/Asktgs.cs
@@ -178,12 +178,10 @@ namespace Rubeus.Commands
                 {
                     Console.WriteLine("\r\n[X] /ticket:X must either be a .kirbi file or a base64 encoded .kirbi\r\n");
                 }
-                return;
             }
             else
             {
                 Console.WriteLine("\r\n[X] A /ticket:X needs to be supplied!\r\n");
-                return;
             }
         }
     }

--- a/Rubeus/Commands/Asktgt.cs
+++ b/Rubeus/Commands/Asktgt.cs
@@ -217,7 +217,6 @@ namespace Rubeus.Commands
             if (!((encType == Interop.KERB_ETYPE.des_cbc_md5) || (encType == Interop.KERB_ETYPE.rc4_hmac) || (encType == Interop.KERB_ETYPE.aes128_cts_hmac_sha1) || (encType == Interop.KERB_ETYPE.aes256_cts_hmac_sha1)))
             {
                 Console.WriteLine("\r\n[X] Only /des, /rc4, /aes128, and /aes256 are supported at this time.\r\n");
-                return;
             }
             else
             {
@@ -230,8 +229,6 @@ namespace Rubeus.Commands
                     Ask.TGT(user, domain, hash, encType, outfile, ptt, dc, luid, true, opsec, servicekey, changepw, pac, proxyUrl);
                 else
                     Ask.TGT(user, domain, certificate, password, encType, outfile, ptt, dc, luid, true, verifyCerts, servicekey, getCredentials, proxyUrl);
-
-                return;
             }
         }
     }

--- a/Rubeus/Commands/Asktgt.cs
+++ b/Rubeus/Commands/Asktgt.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using Rubeus.lib.Interop;
 
 

--- a/Rubeus/Commands/Asktgt.cs
+++ b/Rubeus/Commands/Asktgt.cs
@@ -78,18 +78,18 @@ namespace Rubeus.Commands
             {
                 password = arguments["/password"];
 
-                string salt = String.Format("{0}{1}", domain.ToUpper(), user);
+                string salt = $"{domain.ToUpper()}{user}";
 
                 // special case for computer account salts
                 if (user.EndsWith("$"))
                 {
-                    salt = String.Format("{0}host{1}.{2}", domain.ToUpper(), user.TrimEnd('$').ToLower(), domain.ToLower());
+                    salt = $"{domain.ToUpper()}host{user.TrimEnd('$').ToLower()}.{domain.ToLower()}";
                 }
 
                 // special case for samaccountname spoofing to support Kerberos AES Encryption
                 if (arguments.ContainsKey("/oldsam"))
                 {
-                    salt = String.Format("{0}host{1}.{2}", domain.ToUpper(), arguments["/oldsam"].TrimEnd('$').ToLower(), domain.ToLower());
+                    salt = $"{domain.ToUpper()}host{arguments["/oldsam"].TrimEnd('$').ToLower()}.{domain.ToLower()}";
 
                 }
 

--- a/Rubeus/Commands/Brute.cs
+++ b/Rubeus/Commands/Brute.cs
@@ -40,22 +40,22 @@ namespace Rubeus.Commands
             Console.WriteLine("\r\n[*] Action: Perform Kerberos Brute Force\r\n");
             try
             {
-                this.ParseArguments(arguments);
-                this.ObtainUsers();
+                ParseArguments(arguments);
+                ObtainUsers();
 
                 IBruteforcerReporter consoleReporter = new BruteforceConsoleReporter(
-                    this.outfile, this.verbose, this.saveTickets);
+                    outfile, verbose, saveTickets);
 
-                Bruteforcer bruter = new Bruteforcer(this.domain, this.dc, consoleReporter);
-                bool success = bruter.Attack(this.usernames, this.passwords);
+                Bruteforcer bruter = new Bruteforcer(domain, dc, consoleReporter);
+                bool success = bruter.Attack(usernames, passwords);
                 if (success)
                 {
-                    if (!String.IsNullOrEmpty(this.outfile))
+                    if (!String.IsNullOrEmpty(outfile))
                     {
-                        Console.WriteLine("\r\n[+] Done: Credentials should be saved in \"{0}\"\r\n", this.outfile);
+                        Console.WriteLine("\r\n[+] Done: Credentials should be saved in \"{0}\"\r\n", outfile);
                     }else
                     {
-                        Console.WriteLine("\r\n[+] Done\r\n", this.outfile);
+                        Console.WriteLine("\r\n[+] Done\r\n", outfile);
                     }
                 } else
                 {
@@ -74,26 +74,26 @@ namespace Rubeus.Commands
 
         private void ParseArguments(Dictionary<string, string> arguments)
         {
-            this.ParseDomain(arguments);
-            this.ParseOU(arguments);
-            this.ParseDC(arguments);
-            this.ParseCreds(arguments);
-            this.ParsePasswords(arguments);
-            this.ParseUsers(arguments);
-            this.ParseOutfile(arguments);
-            this.ParseVerbose(arguments);
-            this.ParseSaveTickets(arguments);
+            ParseDomain(arguments);
+            ParseOU(arguments);
+            ParseDC(arguments);
+            ParseCreds(arguments);
+            ParsePasswords(arguments);
+            ParseUsers(arguments);
+            ParseOutfile(arguments);
+            ParseVerbose(arguments);
+            ParseSaveTickets(arguments);
         }
 
         private void ParseDomain(Dictionary<string, string> arguments)
         {
             if (arguments.ContainsKey("/domain"))
             {
-                this.domain = arguments["/domain"];
+                domain = arguments["/domain"];
             }
             else
             {
-                this.domain = System.Net.NetworkInformation.IPGlobalProperties.GetIPGlobalProperties().DomainName;
+                domain = System.Net.NetworkInformation.IPGlobalProperties.GetIPGlobalProperties().DomainName;
             }
         }
 
@@ -101,7 +101,7 @@ namespace Rubeus.Commands
         {
             if (arguments.ContainsKey("/ou"))
             {
-                this.ou = arguments["/ou"];
+                ou = arguments["/ou"];
             }
         }
 
@@ -109,10 +109,10 @@ namespace Rubeus.Commands
         {
             if (arguments.ContainsKey("/dc"))
             {
-                this.dc = arguments["/dc"];
+                dc = arguments["/dc"];
             }else
             {
-                this.dc = this.domain;
+                dc = domain;
             }
         }
 
@@ -126,15 +126,15 @@ namespace Rubeus.Commands
                 }
 
                 string[] parts = arguments["/creduser"].Split('\\');
-                this.credDomain = parts[0];
-                this.credUser = parts[1];
+                credDomain = parts[0];
+                credUser = parts[1];
 
                 if (!arguments.ContainsKey("/credpassword"))
                 {
                     throw new BruteArgumentException("[X] /credpassword is required when specifying /creduser");
                 }
 
-                this.credPassword = arguments["/credpassword"];
+                credPassword = arguments["/credpassword"];
             }
 
         }
@@ -145,7 +145,7 @@ namespace Rubeus.Commands
             {
                 try
                 {
-                    this.passwords = File.ReadAllLines(arguments["/passwords"]);
+                    passwords = File.ReadAllLines(arguments["/passwords"]);
                 }catch(FileNotFoundException)
                 {
                     throw new BruteArgumentException("[X] Unable to open passwords file \"" + arguments["/passwords"] + "\": Not found file");
@@ -153,7 +153,7 @@ namespace Rubeus.Commands
             }
             else if (arguments.ContainsKey("/password"))
             {
-                this.passwords = new string[] { arguments["/password"] };
+                passwords = new string[] { arguments["/password"] };
             }
             else
             {
@@ -167,7 +167,7 @@ namespace Rubeus.Commands
             if (arguments.ContainsKey("/users"))
             {
                 try {
-                    this.usernames = File.ReadAllLines(arguments["/users"]);
+                    usernames = File.ReadAllLines(arguments["/users"]);
                 }catch (FileNotFoundException)
                 {
                     throw new BruteArgumentException("[X] Unable to open users file \"" + arguments["/users"] + "\": Not found file");
@@ -175,7 +175,7 @@ namespace Rubeus.Commands
             }
             else if (arguments.ContainsKey("/user"))
             {
-                this.usernames = new string[] { arguments["/user"] };
+                usernames = new string[] { arguments["/user"] };
             }
         }
 
@@ -183,7 +183,7 @@ namespace Rubeus.Commands
         {
             if (arguments.ContainsKey("/outfile"))
             {
-                this.outfile = arguments["/outfile"];
+                outfile = arguments["/outfile"];
             }
         }
 
@@ -191,7 +191,7 @@ namespace Rubeus.Commands
         {
             if (arguments.ContainsKey("/verbose"))
             {
-                this.verbose = 2;
+                verbose = 2;
             }
         }
 
@@ -199,21 +199,21 @@ namespace Rubeus.Commands
         {
             if (arguments.ContainsKey("/noticket"))
             {
-                this.saveTickets = false;
+                saveTickets = false;
             }
         }
 
         private void ObtainUsers()
         {
-            if(this.usernames == null)
+            if(usernames == null)
             {
-                this.usernames = this.DomainUsernames();
+                usernames = DomainUsernames();
             }
             else
             {
-                if(this.verbose == 0)
+                if(verbose == 0)
                 {
-                    this.verbose = 1;
+                    verbose = 1;
                 }
             }
         }
@@ -221,21 +221,21 @@ namespace Rubeus.Commands
         private string[] DomainUsernames()
         {
 
-            string domainController = this.DomainController();
-            string bindPath = this.BindPath(domainController);
+            string domainController = DomainController();
+            string bindPath = BindPath(domainController);
             DirectoryEntry directoryObject = new DirectoryEntry(bindPath);
 
-            if (!String.IsNullOrEmpty(this.credUser))
+            if (!String.IsNullOrEmpty(credUser))
             {
-                string userDomain = $"{this.credDomain}\\{this.credUser}";
+                string userDomain = $"{credDomain}\\{credUser}";
 
-                if (!this.AreCredentialsValid())
+                if (!AreCredentialsValid())
                 {
                     throw new BruteArgumentException("[X] Credentials supplied for '" + userDomain + "' are invalid!");
                 }
                 
                 directoryObject.Username = userDomain;
-                directoryObject.Password = this.credPassword;
+                directoryObject.Password = credPassword;
 
                 Console.WriteLine("[*] Using alternate creds  : {0}\r\n", userDomain);
             }
@@ -281,7 +281,7 @@ namespace Rubeus.Commands
             string domainController = null;
 
 
-            if (String.IsNullOrEmpty(this.dc))
+            if (String.IsNullOrEmpty(dc))
             {
                 domainController = Networking.GetDCName();
 
@@ -292,7 +292,7 @@ namespace Rubeus.Commands
             }
             else
             {
-                domainController = this.dc;
+                domainController = dc;
             }
 
             return domainController;
@@ -302,14 +302,14 @@ namespace Rubeus.Commands
         {
             string bindPath = $"LDAP://{domainController}";
 
-            if (!String.IsNullOrEmpty(this.ou))
+            if (!String.IsNullOrEmpty(ou))
             {
-                string ouPath = this.ou.Replace("ldap", "LDAP").Replace("LDAP://", "");
+                string ouPath = ou.Replace("ldap", "LDAP").Replace("LDAP://", "");
                 bindPath = $"{bindPath}/{ouPath}";
             }
-            else if (!String.IsNullOrEmpty(this.domain))
+            else if (!String.IsNullOrEmpty(domain))
             {
-                string domainPath = this.domain.Replace(".", ",DC=");
+                string domainPath = domain.Replace(".", ",DC=");
                 bindPath = $"{bindPath}/DC={domainPath}";
             }
 
@@ -318,9 +318,9 @@ namespace Rubeus.Commands
 
         private bool AreCredentialsValid()
         {
-            using (PrincipalContext pc = new PrincipalContext(ContextType.Domain, this.credDomain))
+            using (PrincipalContext pc = new PrincipalContext(ContextType.Domain, credDomain))
             {
-                return pc.ValidateCredentials(this.credUser, this.credPassword);
+                return pc.ValidateCredentials(credUser, credPassword);
             }
         }
 
@@ -344,11 +344,11 @@ namespace Rubeus.Commands
 
         public void ReportValidPassword(string domain, string username, string password, byte[] ticket, Interop.KERBEROS_ERROR err = Interop.KERBEROS_ERROR.KDC_ERR_NONE)
         {
-            this.WriteUserPasswordToFile(username, password);
+            WriteUserPasswordToFile(username, password);
             if (ticket != null)
             {
                 Console.WriteLine("[+] STUPENDOUS => {0}:{1}", username, password);
-                this.HandleTicket(username, ticket);
+                HandleTicket(username, ticket);
             }
             else
             {
@@ -366,7 +366,7 @@ namespace Rubeus.Commands
 
         public void ReportInvalidUser(string domain, string username)
         {
-            if (this.verbose > 1)
+            if (verbose > 1)
             {
                 Console.WriteLine("[-] Invalid user => {0}", username);
             }
@@ -386,7 +386,7 @@ namespace Rubeus.Commands
 
         private void WriteUserPasswordToFile(string username, string password)
         {
-            if (String.IsNullOrEmpty(this.passwordsOutfile))
+            if (String.IsNullOrEmpty(passwordsOutfile))
             {
                 return;
             }
@@ -394,20 +394,20 @@ namespace Rubeus.Commands
             string line = $"{username}:{password}{Environment.NewLine}";
             try
             {
-                File.AppendAllText(this.passwordsOutfile, line);
+                File.AppendAllText(passwordsOutfile, line);
             }catch(UnauthorizedAccessException)
             {
-                if (!this.reportedBadOutputFile)
+                if (!reportedBadOutputFile)
                 {
-                    Console.WriteLine("[X] Unable to write credentials in \"{0}\": Access denied", this.passwordsOutfile);
-                    this.reportedBadOutputFile = true;
+                    Console.WriteLine("[X] Unable to write credentials in \"{0}\": Access denied", passwordsOutfile);
+                    reportedBadOutputFile = true;
                 }
             }
         }
 
         private void HandleTicket(string username, byte[] ticket)
         {
-            if(this.saveTicket)
+            if(saveTicket)
             {
                 string ticketFilename = username + ".kirbi";
                 File.WriteAllBytes(ticketFilename, ticket);
@@ -415,7 +415,7 @@ namespace Rubeus.Commands
             }
             else
             {
-                this.PrintTicketBase64(username, ticket);
+                PrintTicketBase64(username, ticket);
             }
         }
 
@@ -426,7 +426,7 @@ namespace Rubeus.Commands
             Console.WriteLine("[*] base64({0}.kirbi):\r\n", ticketname);
 
             // display in columns of 80 chararacters
-            if (Rubeus.Program.wrapTickets)
+            if (Program.wrapTickets)
             {
                 foreach (string line in Helpers.Split(ticketB64, 80))
                 {

--- a/Rubeus/Commands/Brute.cs
+++ b/Rubeus/Commands/Brute.cs
@@ -1,13 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.IO;
 using System.DirectoryServices;
 using System.DirectoryServices.AccountManagement;
 using System.Collections;
 using System.Text.RegularExpressions;
-using Microsoft.Win32;
 
 
 namespace Rubeus.Commands

--- a/Rubeus/Commands/Brute.cs
+++ b/Rubeus/Commands/Brute.cs
@@ -438,7 +438,7 @@ namespace Rubeus.Commands
                 Console.WriteLine("      {0}", ticketB64);
             }
 
-            Console.WriteLine("\r\n", ticketname);
+            Console.WriteLine("\r\n");
         }
 
     }

--- a/Rubeus/Commands/Brute.cs
+++ b/Rubeus/Commands/Brute.cs
@@ -227,7 +227,7 @@ namespace Rubeus.Commands
 
             if (!String.IsNullOrEmpty(this.credUser))
             {
-                string userDomain = String.Format("{0}\\{1}", this.credDomain, this.credUser);
+                string userDomain = $"{this.credDomain}\\{this.credUser}";
 
                 if (!this.AreCredentialsValid())
                 {
@@ -300,17 +300,17 @@ namespace Rubeus.Commands
 
         private string BindPath(string domainController)
         {
-            string bindPath = String.Format("LDAP://{0}", domainController);
+            string bindPath = $"LDAP://{domainController}";
 
             if (!String.IsNullOrEmpty(this.ou))
             {
                 string ouPath = this.ou.Replace("ldap", "LDAP").Replace("LDAP://", "");
-                bindPath = String.Format("{0}/{1}", bindPath, ouPath);
+                bindPath = $"{bindPath}/{ouPath}";
             }
             else if (!String.IsNullOrEmpty(this.domain))
             {
                 string domainPath = this.domain.Replace(".", ",DC=");
-                bindPath = String.Format("{0}/DC={1}", bindPath, domainPath);
+                bindPath = $"{bindPath}/DC={domainPath}";
             }
 
             return bindPath;
@@ -391,7 +391,7 @@ namespace Rubeus.Commands
                 return;
             }
 
-            string line = String.Format("{0}:{1}{2}", username, password, Environment.NewLine);
+            string line = $"{username}:{password}{Environment.NewLine}";
             try
             {
                 File.AppendAllText(this.passwordsOutfile, line);

--- a/Rubeus/Commands/Changepw.cs
+++ b/Rubeus/Commands/Changepw.cs
@@ -56,12 +56,10 @@ namespace Rubeus.Commands
                 {
                     Console.WriteLine("\r\n[X]/ticket:X must either be a .kirbi file or a base64 encoded .kirbi\r\n");
                 }
-                return;
             }
             else
             {
                 Console.WriteLine("\r\n[X] A /ticket:X needs to be supplied!\r\n");
-                return;
             }
         }
     }

--- a/Rubeus/Commands/Describe.cs
+++ b/Rubeus/Commands/Describe.cs
@@ -64,12 +64,10 @@ namespace Rubeus.Commands
                 {
                     Console.WriteLine("\r\n[X] /ticket:X must either be a .kirbi file or a base64 encoded .kirbi\r\n");
                 }
-                return;
             }
             else
             {
                 Console.WriteLine("\r\n[X] A /ticket:X needs to be supplied!\r\n");
-                return;
             }
         }
     }

--- a/Rubeus/Commands/Golden.cs
+++ b/Rubeus/Commands/Golden.cs
@@ -387,7 +387,7 @@ namespace Rubeus.Commands
             {
                 ForgeTickets.ForgeTicket(
                     user,
-                    String.Format("krbtgt/{0}", domain),
+                    $"krbtgt/{domain}",
                     Helpers.StringToByteArray(hash),
                     encType,
                     null,

--- a/Rubeus/Commands/Golden.cs
+++ b/Rubeus/Commands/Golden.cs
@@ -161,7 +161,7 @@ namespace Rubeus.Commands
                 foreach (string u in arguments["/uac"].Split(','))
                 {
                     Interop.PacUserAccountControl result;
-                    bool status = Interop.PacUserAccountControl.TryParse(u, out result);
+                    bool status = Enum.TryParse(u, out result);
 
                     if (status)
                     {
@@ -276,7 +276,7 @@ namespace Rubeus.Commands
                 foreach (string flag in arguments["/flags"].Split(','))
                 {
                     Interop.TicketFlags result;
-                    bool status = Interop.TicketFlags.TryParse(flag, out result);
+                    bool status = Enum.TryParse(flag, out result);
 
                     if (status)
                     {

--- a/Rubeus/Commands/Golden.cs
+++ b/Rubeus/Commands/Golden.cs
@@ -381,7 +381,6 @@ namespace Rubeus.Commands
             if (!((encType == Interop.KERB_ETYPE.des_cbc_md5) || (encType == Interop.KERB_ETYPE.rc4_hmac) || (encType == Interop.KERB_ETYPE.aes128_cts_hmac_sha1) || (encType == Interop.KERB_ETYPE.aes256_cts_hmac_sha1)))
             {
                 Console.WriteLine("\r\n[X] Only /des, /rc4, /aes128, and /aes256 are supported at this time.\r\n");
-                return;
             }
             else
             {
@@ -430,7 +429,6 @@ namespace Rubeus.Commands
                     ptt,
                     printcmd
                     );
-                return;
             }
         }
     }

--- a/Rubeus/Commands/Ptt.cs
+++ b/Rubeus/Commands/Ptt.cs
@@ -47,12 +47,10 @@ namespace Rubeus.Commands
                 {
                     Console.WriteLine("\r\n[X]/ticket:X must either be a .kirbi file or a base64 encoded .kirbi\r\n");
                 }
-                return;
             }
             else
             {
                 Console.WriteLine("\r\n[X] A /ticket:X needs to be supplied!\r\n");
-                return;
             }
         }
     }

--- a/Rubeus/Commands/RenewCommand.cs
+++ b/Rubeus/Commands/RenewCommand.cs
@@ -64,13 +64,10 @@ namespace Rubeus.Commands
                         byte[] blah = Renew.TGT(kirbi, outfile, ptt, dc);
                     }
                 }
-
-                return;
             }
             else
             {
                 Console.WriteLine("\r\n[X] A /ticket:X needs to be supplied!\r\n");
-                return;
             }
         }
     }

--- a/Rubeus/Commands/S4u.cs
+++ b/Rubeus/Commands/S4u.cs
@@ -185,7 +185,6 @@ namespace Rubeus.Commands
                 {
                     Console.WriteLine("\r\n[X] /ticket:X must either be a .kirbi file or a base64 encoded .kirbi\r\n");
                 }
-                return;
             }
             else if (arguments.ContainsKey("/user"))
             {
@@ -200,13 +199,11 @@ namespace Rubeus.Commands
                 }
 
                 S4U.Execute(user, domain, hash, encType, targetUser, targetSPN, outfile, ptt, dc, altSname, tgs, targetDC, targetDomain, self, opsec, bronzebit, pac, proxyUrl);
-                return;
             }
             else
             {
                 Console.WriteLine("\r\n[X] A /ticket:X needs to be supplied for S4U!\r\n");
                 Console.WriteLine("[X] Alternatively, supply a /user and </rc4:X | /aes256:X> hash to first retrieve a TGT.\r\n");
-                return;
             }
         }
     }

--- a/Rubeus/Commands/Silver.cs
+++ b/Rubeus/Commands/Silver.cs
@@ -168,7 +168,7 @@ namespace Rubeus.Commands
                 foreach (string u in arguments["/uac"].Split(','))
                 {
                     Interop.PacUserAccountControl result;
-                    bool status = Interop.PacUserAccountControl.TryParse(u, out result);
+                    bool status = Enum.TryParse(u, out result);
 
                     if (status)
                     {
@@ -324,7 +324,7 @@ namespace Rubeus.Commands
                 foreach (string flag in arguments["/flags"].Split(','))
                 {
                     Interop.TicketFlags result;
-                    bool status = Interop.TicketFlags.TryParse(flag, out result);
+                    bool status = Enum.TryParse(flag, out result);
 
                     if (status)
                     {

--- a/Rubeus/Commands/Silver.cs
+++ b/Rubeus/Commands/Silver.cs
@@ -454,7 +454,6 @@ namespace Rubeus.Commands
             if (!((encType == Interop.KERB_ETYPE.des_cbc_md5) || (encType == Interop.KERB_ETYPE.rc4_hmac) || (encType == Interop.KERB_ETYPE.aes128_cts_hmac_sha1) || (encType == Interop.KERB_ETYPE.aes256_cts_hmac_sha1)))
             {
                 Console.WriteLine("\r\n[X] Only /des, /rc4, /aes128, and /aes256 are supported at this time.\r\n");
-                return;
             }
             else
             {
@@ -508,7 +507,6 @@ namespace Rubeus.Commands
                     s4uTransitedServices,
                     includeAuthData
                     );
-                return;
             }
         }
     }

--- a/Rubeus/Commands/Tgssub.cs
+++ b/Rubeus/Commands/Tgssub.cs
@@ -66,12 +66,10 @@ namespace Rubeus.Commands
                 {
                     Console.WriteLine("\r\n[X]/ticket:X must either be a .kirbi file or a base64 encoded .kirbi\r\n");
                 }
-                return;
             }
             else
             {
                 Console.WriteLine("\r\n[X] A /ticket:X needs to be supplied!\r\n");
-                return;
             }
         }
     }

--- a/Rubeus/Properties/AssemblyInfo.cs
+++ b/Rubeus/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/Rubeus/Rubeus.csproj
+++ b/Rubeus/Rubeus.csproj
@@ -1,239 +1,239 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-  <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{658C8B7F-3664-4A95-9572-A3E5871DFC06}</ProjectGuid>
-    <OutputType>Exe</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Rubeus</RootNamespace>
-    <AssemblyName>Rubeus</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <TargetFrameworkProfile />
-    <PublishUrl>publish\</PublishUrl>
-    <Install>true</Install>
-    <InstallFrom>Disk</InstallFrom>
-    <UpdateEnabled>false</UpdateEnabled>
-    <UpdateMode>Foreground</UpdateMode>
-    <UpdateInterval>7</UpdateInterval>
-    <UpdateIntervalUnits>Days</UpdateIntervalUnits>
-    <UpdatePeriodically>false</UpdatePeriodically>
-    <UpdateRequired>false</UpdateRequired>
-    <MapFileExtensions>true</MapFileExtensions>
-    <ApplicationRevision>0</ApplicationRevision>
-    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
-    <IsWebBootstrapper>false</IsWebBootstrapper>
-    <UseApplicationTrust>false</UseApplicationTrust>
-    <BootstrapperEnabled>true</BootstrapperEnabled>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugType>none</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
-    <DebugSymbols>false</DebugSymbols>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-  </PropertyGroup>
-  <PropertyGroup>
-    <StartupObject />
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.DirectoryServices" />
-    <Reference Include="System.DirectoryServices.AccountManagement" />
-    <Reference Include="System.DirectoryServices.Protocols" />
-    <Reference Include="System.IdentityModel" />
-    <Reference Include="System.Security" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Asn1\AsnElt.cs" />
-    <Compile Include="Asn1\AsnException.cs" />
-    <Compile Include="Asn1\AsnIO.cs" />
-    <Compile Include="Asn1\AsnOID.cs" />
-    <Compile Include="Asn1\Asn1Extensions.cs" />
-    <Compile Include="Commands\Asktgs.cs" />
-    <Compile Include="Commands\Asktgt.cs" />
-    <Compile Include="Commands\Asreproast.cs" />
-    <Compile Include="Commands\Brute.cs" />
-    <Compile Include="Commands\Changepw.cs" />
-    <Compile Include="Commands\Createnetonly.cs" />
-    <Compile Include="Commands\Currentluid.cs" />
-    <Compile Include="Commands\Describe.cs" />
-    <Compile Include="Commands\Dump.cs" />
-    <Compile Include="Commands\HarvestCommand.cs" />
-    <Compile Include="Commands\Hash.cs" />
-    <Compile Include="Commands\ICommand.cs" />
-    <Compile Include="Commands\Kerberoast.cs" />
-    <Compile Include="Commands\Klist.cs" />
-    <Compile Include="Commands\Monitor.cs" />
-    <Compile Include="Commands\Ptt.cs" />
-    <Compile Include="Commands\Purge.cs" />
-    <Compile Include="Commands\RenewCommand.cs" />
-    <Compile Include="Commands\S4u.cs" />
-    <Compile Include="Commands\Golden.cs" />
-    <Compile Include="Commands\Silver.cs" />
-    <Compile Include="Commands\Tgssub.cs" />
-    <Compile Include="Commands\Tgtdeleg.cs" />
-    <Compile Include="Commands\Triage.cs" />
-    <Compile Include="Domain\ArgumentParser.cs" />
-    <Compile Include="Domain\ArgumentParserResult.cs" />
-    <Compile Include="Domain\CommandCollection.cs" />
-    <Compile Include="Domain\Info.cs" />
-    <Compile Include="lib\Ask.cs" />
-    <Compile Include="lib\Bruteforcer.cs" />
-    <Compile Include="lib\ConsoleTable.cs" />
-    <Compile Include="lib\Crypto.cs" />
-    <Compile Include="lib\crypto\dh\DiffieHellmanKey.cs" />
-    <Compile Include="lib\crypto\dh\IExchangeKey.cs" />
-    <Compile Include="lib\crypto\dh\IKeyAgreement.cs" />
-    <Compile Include="lib\crypto\dh\KeyAgreementAlgorithm.cs" />
-    <Compile Include="lib\crypto\dh\ManagedDiffieHellman.cs" />
-    <Compile Include="lib\crypto\dh\ManagedDiffieHellmanOakley14.cs" />
-    <Compile Include="lib\crypto\dh\ManagedDiffieHellmanOakley2.cs" />
-    <Compile Include="lib\crypto\dh\Oakley.cs" />
-    <Compile Include="lib\crypto\SafeNativeMethods.cs" />
-    <Compile Include="lib\Harvest.cs" />
-    <Compile Include="lib\Helpers.cs" />
-    <Compile Include="lib\Interop.cs" />
-    <Compile Include="lib\Interop\Luid.cs" />
-    <Compile Include="lib\Interop\NtException.cs" />
-    <Compile Include="lib\KDCKeyAgreement.cs" />
-    <Compile Include="lib\krb_structures\ADIfRelevant.cs" />
-    <Compile Include="lib\krb_structures\ADKerbLocal.cs" />
-    <Compile Include="lib\krb_structures\ADWin2KPac.cs" />
-    <Compile Include="lib\krb_structures\AP_REQ.cs" />
-    <Compile Include="lib\krb_structures\AS_REP.cs" />
-    <Compile Include="lib\krb_structures\AS_REQ.cs" />
-    <Compile Include="lib\krb_structures\Authenticator.cs" />
-    <Compile Include="lib\krb_structures\AuthorizationData.cs" />
-    <Compile Include="lib\krb_structures\Checksum.cs" />
-    <Compile Include="lib\krb_structures\EncKDCRepPart.cs" />
-    <Compile Include="lib\krb_structures\EncKrbCredPart.cs" />
-    <Compile Include="lib\krb_structures\EncKrbPrivPart.cs" />
-    <Compile Include="lib\krb_structures\EncryptedData.cs" />
-    <Compile Include="lib\krb_structures\EncryptionKey.cs" />
-    <Compile Include="lib\krb_structures\EncTicketPart.cs" />
-    <Compile Include="lib\krb_structures\ETYPE_INFO2_ENTRY.cs" />
-    <Compile Include="lib\krb_structures\HostAddress.cs" />
-    <Compile Include="lib\krb_structures\KDC_PROXY_MESSAGE.cs" />
-    <Compile Include="lib\krb_structures\KDC_REQ_BODY.cs" />
-    <Compile Include="lib\krb_structures\ADRestrictionEntry.cs" />
-    <Compile Include="lib\krb_structures\KERB_PA_PAC_REQUEST.cs" />
-    <Compile Include="lib\krb_structures\KrbAlgorithmIdentifier.cs" />
-    <Compile Include="lib\krb_structures\KrbAuthPack.cs" />
-    <Compile Include="lib\krb_structures\KrbCredInfo.cs" />
-    <Compile Include="lib\krb_structures\KrbDHRepInfo.cs" />
-    <Compile Include="lib\krb_structures\KrbKDCDHKeyInfo.cs" />
-    <Compile Include="lib\krb_structures\KrbPkAuthenticator.cs" />
-    <Compile Include="lib\krb_structures\KrbSubjectPublicKeyInfo.cs" />
-    <Compile Include="lib\krb_structures\KRB_CRED.cs" />
-    <Compile Include="lib\krb_structures\KRB_ERROR.cs" />
-    <Compile Include="lib\krb_structures\KRB_PRIV.cs" />
-    <Compile Include="lib\krb_structures\LastReq.cs" />
-    <Compile Include="lib\krb_structures\pac\Attributes.cs" />
-    <Compile Include="lib\krb_structures\pac\Requestor.cs" />
-    <Compile Include="lib\krb_structures\pac\S4UDelegationInfo.cs" />
-    <Compile Include="lib\krb_structures\pac\PacCredentialInfo.cs" />
-    <Compile Include="lib\krb_structures\pac\PACTYPE.cs" />
-    <Compile Include="lib\krb_structures\pac\ClientName.cs" />
-    <Compile Include="lib\krb_structures\pac\LogonInfo.cs" />
-    <Compile Include="lib\krb_structures\pac\Ndr\Kerberos_PAC.cs" />
-    <Compile Include="lib\krb_structures\pac\PacInfoBuffer.cs" />
-    <Compile Include="lib\krb_structures\pac\SignatureData.cs" />
-    <Compile Include="lib\krb_structures\pac\UpnDns.cs" />
-    <Compile Include="lib\krb_structures\PA_DATA.cs" />
-    <Compile Include="lib\krb_structures\PA_ENC_TS_ENC.cs" />
-    <Compile Include="lib\krb_structures\PA_FOR_USER.cs" />
-    <Compile Include="lib\krb_structures\PA_PAC_OPTIONS.cs" />
-    <Compile Include="lib\krb_structures\PA_S4U_X509_USER.cs" />
-    <Compile Include="lib\krb_structures\PA_PK_AS_REP.cs" />
-    <Compile Include="lib\krb_structures\PA_PK_AS_REQ.cs" />
-    <Compile Include="lib\krb_structures\PrincipalName.cs" />
-    <Compile Include="lib\krb_structures\S4UUserID.cs" />
-    <Compile Include="lib\krb_structures\TGS_REP.cs" />
-    <Compile Include="lib\krb_structures\TGS_REQ.cs" />
-    <Compile Include="lib\krb_structures\Ticket.cs" />
-    <Compile Include="lib\krb_structures\TransitedEncoding.cs" />
-    <Compile Include="lib\LSA.cs" />
-    <Compile Include="lib\math\BigInteger.cs" />
-    <Compile Include="lib\math\ConfidenceFactor.cs" />
-    <Compile Include="lib\math\NextPrimeFinder.cs" />
-    <Compile Include="lib\math\PrimalityTest.cs" />
-    <Compile Include="lib\math\PrimeGeneratorBase.cs" />
-    <Compile Include="lib\math\SequentialSearchPrimeGeneratorBase.cs" />
-    <Compile Include="lib\ndr\Ndr\Marshal\INdrConformantStructure.cs" />
-    <Compile Include="lib\ndr\Ndr\Marshal\INdrNonEncapsulatedUnion.cs" />
-    <Compile Include="lib\ndr\Ndr\Marshal\INdrStructure.cs" />
-    <Compile Include="lib\ndr\Ndr\Marshal\NdrContextHandle.cs" />
-    <Compile Include="lib\ndr\Ndr\Marshal\NdrDataRepresentation.cs" />
-    <Compile Include="lib\ndr\Ndr\Marshal\NdrDeferralStack.cs" />
-    <Compile Include="lib\ndr\Ndr\Marshal\NdrEmbeddedPointer.cs" />
-    <Compile Include="lib\ndr\Ndr\Marshal\NdrEmpty.cs" />
-    <Compile Include="lib\ndr\Ndr\Marshal\NdrEnum16.cs" />
-    <Compile Include="lib\ndr\Ndr\Marshal\NdrInt3264.cs" />
-    <Compile Include="lib\ndr\Ndr\Marshal\NdrInterfacePointer.cs" />
-    <Compile Include="lib\ndr\Ndr\Marshal\NdrMarshalBuffer.cs" />
-    <Compile Include="lib\ndr\Ndr\Marshal\NdrPickledType.cs" />
-    <Compile Include="lib\ndr\Ndr\Marshal\NdrPipe.cs" />
-    <Compile Include="lib\ndr\Ndr\Marshal\NdrUnmarshalBuffer.cs" />
-    <Compile Include="lib\ndr\Ndr\Marshal\NdrUnsupported.cs" />
-    <Compile Include="lib\ndr\Ndr\NdrNativeUtils.cs" />
-    <Compile Include="lib\ndr\Ndr\NdrParser.cs" />
-    <Compile Include="lib\ndr\Utilities\Memory\CrossBitnessTypeAttribute.cs" />
-    <Compile Include="lib\ndr\Utilities\Memory\IMemoryReader.cs" />
-    <Compile Include="lib\ndr\Utilities\Memory\SafeBufferWrapper.cs" />
-    <Compile Include="lib\ndr\Utilities\Text\BinaryEncoding.cs" />
-    <Compile Include="lib\ndr\Utilities\Text\HexDumpBuilder.cs" />
-    <Compile Include="lib\ndr\Win32\Rpc\RpcUtils.cs" />
-    <Compile Include="lib\Networking.cs" />
-    <Compile Include="lib\Renew.cs" />
-    <Compile Include="lib\Reset.cs" />
-    <Compile Include="lib\Roast.cs" />
-    <Compile Include="lib\S4U.cs" />
-    <Compile Include="lib\ForgeTicket.cs" />
-    <Compile Include="Program.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework 3.5 SP1</ProductName>
-      <Install>true</Install>
-    </BootstrapperPackage>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="app.config" />
-  </ItemGroup>
-  <ItemGroup />
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+    <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+    <PropertyGroup>
+        <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+        <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+        <ProjectGuid>{658C8B7F-3664-4A95-9572-A3E5871DFC06}</ProjectGuid>
+        <OutputType>Exe</OutputType>
+        <AppDesignerFolder>Properties</AppDesignerFolder>
+        <RootNamespace>Rubeus</RootNamespace>
+        <AssemblyName>Rubeus</AssemblyName>
+        <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+        <FileAlignment>512</FileAlignment>
+        <TargetFrameworkProfile />
+        <PublishUrl>publish\</PublishUrl>
+        <Install>true</Install>
+        <InstallFrom>Disk</InstallFrom>
+        <UpdateEnabled>false</UpdateEnabled>
+        <UpdateMode>Foreground</UpdateMode>
+        <UpdateInterval>7</UpdateInterval>
+        <UpdateIntervalUnits>Days</UpdateIntervalUnits>
+        <UpdatePeriodically>false</UpdatePeriodically>
+        <UpdateRequired>false</UpdateRequired>
+        <MapFileExtensions>true</MapFileExtensions>
+        <ApplicationRevision>0</ApplicationRevision>
+        <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
+        <IsWebBootstrapper>false</IsWebBootstrapper>
+        <UseApplicationTrust>false</UseApplicationTrust>
+        <BootstrapperEnabled>true</BootstrapperEnabled>
+    </PropertyGroup>
+    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+        <PlatformTarget>AnyCPU</PlatformTarget>
+        <DebugSymbols>true</DebugSymbols>
+        <DebugType>full</DebugType>
+        <Optimize>false</Optimize>
+        <OutputPath>bin\Debug\</OutputPath>
+        <DefineConstants>DEBUG;TRACE</DefineConstants>
+        <ErrorReport>prompt</ErrorReport>
+        <WarningLevel>4</WarningLevel>
+        <Prefer32Bit>false</Prefer32Bit>
+        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    </PropertyGroup>
+    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+        <PlatformTarget>AnyCPU</PlatformTarget>
+        <DebugType>none</DebugType>
+        <Optimize>true</Optimize>
+        <OutputPath>bin\Release\</OutputPath>
+        <DefineConstants>TRACE</DefineConstants>
+        <ErrorReport>prompt</ErrorReport>
+        <WarningLevel>4</WarningLevel>
+        <Prefer32Bit>false</Prefer32Bit>
+        <DebugSymbols>false</DebugSymbols>
+        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    </PropertyGroup>
+    <PropertyGroup>
+        <StartupObject />
+    </PropertyGroup>
+    <ItemGroup>
+        <Reference Include="System" />
+        <Reference Include="System.Core" />
+        <Reference Include="System.DirectoryServices" />
+        <Reference Include="System.DirectoryServices.AccountManagement" />
+        <Reference Include="System.DirectoryServices.Protocols" />
+        <Reference Include="System.IdentityModel" />
+        <Reference Include="System.Security" />
+        <Reference Include="System.Xml.Linq" />
+        <Reference Include="System.Data.DataSetExtensions" />
+        <Reference Include="System.Data" />
+        <Reference Include="System.Xml" />
+    </ItemGroup>
+    <ItemGroup>
+        <Compile Include="Asn1\AsnElt.cs" />
+        <Compile Include="Asn1\AsnException.cs" />
+        <Compile Include="Asn1\AsnIO.cs" />
+        <Compile Include="Asn1\AsnOID.cs" />
+        <Compile Include="Asn1\Asn1Extensions.cs" />
+        <Compile Include="Commands\Asktgs.cs" />
+        <Compile Include="Commands\Asktgt.cs" />
+        <Compile Include="Commands\Asreproast.cs" />
+        <Compile Include="Commands\Brute.cs" />
+        <Compile Include="Commands\Changepw.cs" />
+        <Compile Include="Commands\Createnetonly.cs" />
+        <Compile Include="Commands\Currentluid.cs" />
+        <Compile Include="Commands\Describe.cs" />
+        <Compile Include="Commands\Dump.cs" />
+        <Compile Include="Commands\HarvestCommand.cs" />
+        <Compile Include="Commands\Hash.cs" />
+        <Compile Include="Commands\ICommand.cs" />
+        <Compile Include="Commands\Kerberoast.cs" />
+        <Compile Include="Commands\Klist.cs" />
+        <Compile Include="Commands\Monitor.cs" />
+        <Compile Include="Commands\Ptt.cs" />
+        <Compile Include="Commands\Purge.cs" />
+        <Compile Include="Commands\RenewCommand.cs" />
+        <Compile Include="Commands\S4u.cs" />
+        <Compile Include="Commands\Golden.cs" />
+        <Compile Include="Commands\Silver.cs" />
+        <Compile Include="Commands\Tgssub.cs" />
+        <Compile Include="Commands\Tgtdeleg.cs" />
+        <Compile Include="Commands\Triage.cs" />
+        <Compile Include="Domain\ArgumentParser.cs" />
+        <Compile Include="Domain\ArgumentParserResult.cs" />
+        <Compile Include="Domain\CommandCollection.cs" />
+        <Compile Include="Domain\Info.cs" />
+        <Compile Include="lib\Ask.cs" />
+        <Compile Include="lib\Bruteforcer.cs" />
+        <Compile Include="lib\ConsoleTable.cs" />
+        <Compile Include="lib\Crypto.cs" />
+        <Compile Include="lib\crypto\dh\DiffieHellmanKey.cs" />
+        <Compile Include="lib\crypto\dh\IExchangeKey.cs" />
+        <Compile Include="lib\crypto\dh\IKeyAgreement.cs" />
+        <Compile Include="lib\crypto\dh\KeyAgreementAlgorithm.cs" />
+        <Compile Include="lib\crypto\dh\ManagedDiffieHellman.cs" />
+        <Compile Include="lib\crypto\dh\ManagedDiffieHellmanOakley14.cs" />
+        <Compile Include="lib\crypto\dh\ManagedDiffieHellmanOakley2.cs" />
+        <Compile Include="lib\crypto\dh\Oakley.cs" />
+        <Compile Include="lib\crypto\SafeNativeMethods.cs" />
+        <Compile Include="lib\Harvest.cs" />
+        <Compile Include="lib\Helpers.cs" />
+        <Compile Include="lib\Interop.cs" />
+        <Compile Include="lib\Interop\Luid.cs" />
+        <Compile Include="lib\Interop\NtException.cs" />
+        <Compile Include="lib\KDCKeyAgreement.cs" />
+        <Compile Include="lib\krb_structures\ADIfRelevant.cs" />
+        <Compile Include="lib\krb_structures\ADKerbLocal.cs" />
+        <Compile Include="lib\krb_structures\ADWin2KPac.cs" />
+        <Compile Include="lib\krb_structures\AP_REQ.cs" />
+        <Compile Include="lib\krb_structures\AS_REP.cs" />
+        <Compile Include="lib\krb_structures\AS_REQ.cs" />
+        <Compile Include="lib\krb_structures\Authenticator.cs" />
+        <Compile Include="lib\krb_structures\AuthorizationData.cs" />
+        <Compile Include="lib\krb_structures\Checksum.cs" />
+        <Compile Include="lib\krb_structures\EncKDCRepPart.cs" />
+        <Compile Include="lib\krb_structures\EncKrbCredPart.cs" />
+        <Compile Include="lib\krb_structures\EncKrbPrivPart.cs" />
+        <Compile Include="lib\krb_structures\EncryptedData.cs" />
+        <Compile Include="lib\krb_structures\EncryptionKey.cs" />
+        <Compile Include="lib\krb_structures\EncTicketPart.cs" />
+        <Compile Include="lib\krb_structures\ETYPE_INFO2_ENTRY.cs" />
+        <Compile Include="lib\krb_structures\HostAddress.cs" />
+        <Compile Include="lib\krb_structures\KDC_PROXY_MESSAGE.cs" />
+        <Compile Include="lib\krb_structures\KDC_REQ_BODY.cs" />
+        <Compile Include="lib\krb_structures\ADRestrictionEntry.cs" />
+        <Compile Include="lib\krb_structures\KERB_PA_PAC_REQUEST.cs" />
+        <Compile Include="lib\krb_structures\KrbAlgorithmIdentifier.cs" />
+        <Compile Include="lib\krb_structures\KrbAuthPack.cs" />
+        <Compile Include="lib\krb_structures\KrbCredInfo.cs" />
+        <Compile Include="lib\krb_structures\KrbDHRepInfo.cs" />
+        <Compile Include="lib\krb_structures\KrbKDCDHKeyInfo.cs" />
+        <Compile Include="lib\krb_structures\KrbPkAuthenticator.cs" />
+        <Compile Include="lib\krb_structures\KrbSubjectPublicKeyInfo.cs" />
+        <Compile Include="lib\krb_structures\KRB_CRED.cs" />
+        <Compile Include="lib\krb_structures\KRB_ERROR.cs" />
+        <Compile Include="lib\krb_structures\KRB_PRIV.cs" />
+        <Compile Include="lib\krb_structures\LastReq.cs" />
+        <Compile Include="lib\krb_structures\pac\Attributes.cs" />
+        <Compile Include="lib\krb_structures\pac\Requestor.cs" />
+        <Compile Include="lib\krb_structures\pac\S4UDelegationInfo.cs" />
+        <Compile Include="lib\krb_structures\pac\PacCredentialInfo.cs" />
+        <Compile Include="lib\krb_structures\pac\PACTYPE.cs" />
+        <Compile Include="lib\krb_structures\pac\ClientName.cs" />
+        <Compile Include="lib\krb_structures\pac\LogonInfo.cs" />
+        <Compile Include="lib\krb_structures\pac\Ndr\Kerberos_PAC.cs" />
+        <Compile Include="lib\krb_structures\pac\PacInfoBuffer.cs" />
+        <Compile Include="lib\krb_structures\pac\SignatureData.cs" />
+        <Compile Include="lib\krb_structures\pac\UpnDns.cs" />
+        <Compile Include="lib\krb_structures\PA_DATA.cs" />
+        <Compile Include="lib\krb_structures\PA_ENC_TS_ENC.cs" />
+        <Compile Include="lib\krb_structures\PA_FOR_USER.cs" />
+        <Compile Include="lib\krb_structures\PA_PAC_OPTIONS.cs" />
+        <Compile Include="lib\krb_structures\PA_S4U_X509_USER.cs" />
+        <Compile Include="lib\krb_structures\PA_PK_AS_REP.cs" />
+        <Compile Include="lib\krb_structures\PA_PK_AS_REQ.cs" />
+        <Compile Include="lib\krb_structures\PrincipalName.cs" />
+        <Compile Include="lib\krb_structures\S4UUserID.cs" />
+        <Compile Include="lib\krb_structures\TGS_REP.cs" />
+        <Compile Include="lib\krb_structures\TGS_REQ.cs" />
+        <Compile Include="lib\krb_structures\Ticket.cs" />
+        <Compile Include="lib\krb_structures\TransitedEncoding.cs" />
+        <Compile Include="lib\LSA.cs" />
+        <Compile Include="lib\math\BigInteger.cs" />
+        <Compile Include="lib\math\ConfidenceFactor.cs" />
+        <Compile Include="lib\math\NextPrimeFinder.cs" />
+        <Compile Include="lib\math\PrimalityTest.cs" />
+        <Compile Include="lib\math\PrimeGeneratorBase.cs" />
+        <Compile Include="lib\math\SequentialSearchPrimeGeneratorBase.cs" />
+        <Compile Include="lib\ndr\Ndr\Marshal\INdrConformantStructure.cs" />
+        <Compile Include="lib\ndr\Ndr\Marshal\INdrNonEncapsulatedUnion.cs" />
+        <Compile Include="lib\ndr\Ndr\Marshal\INdrStructure.cs" />
+        <Compile Include="lib\ndr\Ndr\Marshal\NdrContextHandle.cs" />
+        <Compile Include="lib\ndr\Ndr\Marshal\NdrDataRepresentation.cs" />
+        <Compile Include="lib\ndr\Ndr\Marshal\NdrDeferralStack.cs" />
+        <Compile Include="lib\ndr\Ndr\Marshal\NdrEmbeddedPointer.cs" />
+        <Compile Include="lib\ndr\Ndr\Marshal\NdrEmpty.cs" />
+        <Compile Include="lib\ndr\Ndr\Marshal\NdrEnum16.cs" />
+        <Compile Include="lib\ndr\Ndr\Marshal\NdrInt3264.cs" />
+        <Compile Include="lib\ndr\Ndr\Marshal\NdrInterfacePointer.cs" />
+        <Compile Include="lib\ndr\Ndr\Marshal\NdrMarshalBuffer.cs" />
+        <Compile Include="lib\ndr\Ndr\Marshal\NdrPickledType.cs" />
+        <Compile Include="lib\ndr\Ndr\Marshal\NdrPipe.cs" />
+        <Compile Include="lib\ndr\Ndr\Marshal\NdrUnmarshalBuffer.cs" />
+        <Compile Include="lib\ndr\Ndr\Marshal\NdrUnsupported.cs" />
+        <Compile Include="lib\ndr\Ndr\NdrNativeUtils.cs" />
+        <Compile Include="lib\ndr\Ndr\NdrParser.cs" />
+        <Compile Include="lib\ndr\Utilities\Memory\CrossBitnessTypeAttribute.cs" />
+        <Compile Include="lib\ndr\Utilities\Memory\IMemoryReader.cs" />
+        <Compile Include="lib\ndr\Utilities\Memory\SafeBufferWrapper.cs" />
+        <Compile Include="lib\ndr\Utilities\Text\BinaryEncoding.cs" />
+        <Compile Include="lib\ndr\Utilities\Text\HexDumpBuilder.cs" />
+        <Compile Include="lib\ndr\Win32\Rpc\RpcUtils.cs" />
+        <Compile Include="lib\Networking.cs" />
+        <Compile Include="lib\Renew.cs" />
+        <Compile Include="lib\Reset.cs" />
+        <Compile Include="lib\Roast.cs" />
+        <Compile Include="lib\S4U.cs" />
+        <Compile Include="lib\ForgeTicket.cs" />
+        <Compile Include="Program.cs" />
+        <Compile Include="Properties\AssemblyInfo.cs" />
+    </ItemGroup>
+    <ItemGroup>
+        <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
+            <Visible>False</Visible>
+            <ProductName>.NET Framework 3.5 SP1</ProductName>
+            <Install>true</Install>
+        </BootstrapperPackage>
+    </ItemGroup>
+    <ItemGroup>
+        <None Include="app.config" />
+    </ItemGroup>
+    <ItemGroup />
+    <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+    <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+         Other similar extension points exist, see Microsoft.Common.targets.
+    <Target Name="BeforeBuild">
+    </Target>
+    <Target Name="AfterBuild">
+    </Target>
+    -->
 </Project>

--- a/Rubeus/lib/Ask.cs
+++ b/Rubeus/lib/Ask.cs
@@ -479,7 +479,7 @@ namespace Rubeus {
                 {
                     Console.WriteLine("[*] base64(ticket.kirbi):\r\n", kirbiString);
 
-                    if (Rubeus.Program.wrapTickets)
+                    if (Program.wrapTickets)
                     {
                         // display the .kirbi base64, columns of 80 chararacters
                         foreach (string line in Helpers.Split(kirbiString, 80))
@@ -728,7 +728,7 @@ namespace Rubeus {
 
                 Console.WriteLine("[*] base64(ticket.kirbi):\r\n", kirbiString);
 
-                if (Rubeus.Program.wrapTickets)
+                if (Program.wrapTickets)
                 {
                     // display the .kirbi base64, columns of 80 chararacters
                     foreach (string line in Helpers.Split(kirbiString, 80))

--- a/Rubeus/lib/Ask.cs
+++ b/Rubeus/lib/Ask.cs
@@ -403,7 +403,7 @@ namespace Rubeus {
                 if (opsec && (!roast) && ((encRepPart.flags & Interop.TicketFlags.ok_as_delegate) != 0))
                 {
                     Console.WriteLine("[*] '/opsec' passed and service ticket has the 'ok-as-delegate' flag set, requesting a delegated TGT.");
-                    byte[] tgtBytes = TGS_REQ.NewTGSReq(userName, domain, string.Format("krbtgt/{0}", domain), providedTicket, clientKey, paEType, requestEType, false, "", enterprise, roast, opsec, true);
+                    byte[] tgtBytes = TGS_REQ.NewTGSReq(userName, domain, $"krbtgt/{domain}", providedTicket, clientKey, paEType, requestEType, false, "", enterprise, roast, opsec, true);
 
                     if (String.IsNullOrEmpty(proxyUrl))
                     {
@@ -526,26 +526,26 @@ namespace Rubeus {
                     {
                         if (pacInfoBuffer is LogonInfo li)
                         {
-                            outArgs = String.Format("/user:{0} /id:{1} /pgid:{2} /logoncount:{3} /badpwdcount:{4} /sid:{5} /netbios:{6}", li.KerbValidationInfo.EffectiveName, li.KerbValidationInfo.UserId, li.KerbValidationInfo.PrimaryGroupId, li.KerbValidationInfo.LogonCount, li.KerbValidationInfo.BadPasswordCount, li.KerbValidationInfo.LogonDomainId.GetValue(), li.KerbValidationInfo.LogonDomainName);
+                            outArgs = $"/user:{li.KerbValidationInfo.EffectiveName} /id:{li.KerbValidationInfo.UserId} /pgid:{li.KerbValidationInfo.PrimaryGroupId} /logoncount:{li.KerbValidationInfo.LogonCount} /badpwdcount:{li.KerbValidationInfo.BadPasswordCount} /sid:{li.KerbValidationInfo.LogonDomainId.GetValue()} /netbios:{li.KerbValidationInfo.LogonDomainName}";
                             if (!String.IsNullOrEmpty(li.KerbValidationInfo.FullName.ToString()))
-                                outArgs = String.Format("{0} /displayname:\"{1}\"", outArgs, li.KerbValidationInfo.FullName);
+                                outArgs = $"{outArgs} /displayname:\"{li.KerbValidationInfo.FullName}\"";
                             if (!String.IsNullOrEmpty(li.KerbValidationInfo.LogonScript.ToString()))
-                                outArgs = String.Format("{0} /scriptpath:\"{1}\"", outArgs, li.KerbValidationInfo.LogonScript);
+                                outArgs = $"{outArgs} /scriptpath:\"{li.KerbValidationInfo.LogonScript}\"";
                             if (!String.IsNullOrEmpty(li.KerbValidationInfo.ProfilePath.ToString()))
-                                outArgs = String.Format("{0} /profilepath:\"{1}\"", outArgs, li.KerbValidationInfo.ProfilePath);
+                                outArgs = $"{outArgs} /profilepath:\"{li.KerbValidationInfo.ProfilePath}\"";
                             if (!String.IsNullOrEmpty(li.KerbValidationInfo.HomeDirectory.ToString()))
-                                outArgs = String.Format("{0} /homedir:\"{1}\"", outArgs, li.KerbValidationInfo.HomeDirectory);
+                                outArgs = $"{outArgs} /homedir:\"{li.KerbValidationInfo.HomeDirectory}\"";
                             if (!String.IsNullOrEmpty(li.KerbValidationInfo.HomeDirectoryDrive.ToString()))
-                                outArgs = String.Format("{0} /homedrive:\"{1}\"", outArgs, li.KerbValidationInfo.HomeDirectoryDrive);
+                                outArgs = $"{outArgs} /homedrive:\"{li.KerbValidationInfo.HomeDirectoryDrive}\"";
                             if (li.KerbValidationInfo.GroupCount > 0)
-                                outArgs = String.Format("{0} /groups:{1}", outArgs, li.KerbValidationInfo.GroupIds?.GetValue().Select(g => g.RelativeId.ToString()).Aggregate((cur, next) => cur + "," + next));
+                                outArgs = $"{outArgs} /groups:{li.KerbValidationInfo.GroupIds?.GetValue().Select(g => g.RelativeId.ToString()).Aggregate((cur, next) => cur + "," + next)}";
                             if (li.KerbValidationInfo.SidCount > 0)
-                                outArgs = String.Format("{0} /sids:{1}", outArgs, li.KerbValidationInfo.ExtraSids.GetValue().Select(s => s.Sid.ToString()).Aggregate((cur, next) => cur + "," + next));
+                                outArgs = $"{outArgs} /sids:{li.KerbValidationInfo.ExtraSids.GetValue().Select(s => s.Sid.ToString()).Aggregate((cur, next) => cur + "," + next)}";
                             if (li.KerbValidationInfo.ResourceGroupCount > 0)
-                                outArgs = String.Format("{0} /resourcegroupsid:{1} /resourcegroups:{2}", outArgs, li.KerbValidationInfo.ResourceGroupDomainSid.GetValue().ToString(), li.KerbValidationInfo.ResourceGroupIds.GetValue().Select(g => g.RelativeId.ToString()).Aggregate((cur, next) => cur + "," + next));
+                                outArgs = $"{outArgs} /resourcegroupsid:{li.KerbValidationInfo.ResourceGroupDomainSid.GetValue().ToString()} /resourcegroups:{li.KerbValidationInfo.ResourceGroupIds.GetValue().Select(g => g.RelativeId.ToString()).Aggregate((cur, next) => cur + "," + next)}";
                             try
                             {
-                                outArgs = String.Format("{0} /logofftime:\"{1}\"", outArgs, DateTime.FromFileTimeUtc((long)li.KerbValidationInfo.LogoffTime.LowDateTime | ((long)li.KerbValidationInfo.LogoffTime.HighDateTime << 32)).ToLocalTime());
+                                outArgs = $"{outArgs} /logofftime:\"{DateTime.FromFileTimeUtc((long)li.KerbValidationInfo.LogoffTime.LowDateTime | ((long)li.KerbValidationInfo.LogoffTime.HighDateTime << 32)).ToLocalTime()}\"";
                             }
                             catch { }
                             DateTime? passLastSet = null;
@@ -556,7 +556,7 @@ namespace Rubeus {
                             catch { }
                             if (passLastSet != null)
                             {
-                                outArgs = String.Format("{0} /pwdlastset:\"{1}\"", outArgs, ((DateTime)passLastSet).ToLocalTime());
+                                outArgs = $"{outArgs} /pwdlastset:\"{((DateTime)passLastSet).ToLocalTime()}\"";
                                 DateTime? passCanSet = null;
                                 try
                                 {
@@ -564,7 +564,7 @@ namespace Rubeus {
                                 }
                                 catch { }
                                 if (passCanSet != null)
-                                    outArgs = String.Format("{0} /minpassage:{1}d", outArgs, (((DateTime)passCanSet) - ((DateTime)passLastSet)).Days);
+                                    outArgs = $"{outArgs} /minpassage:{(((DateTime)passCanSet) - ((DateTime)passLastSet)).Days}d";
                                 DateTime? passMustSet = null;
                                 try
                                 {
@@ -572,12 +572,12 @@ namespace Rubeus {
                                 }
                                 catch { }
                                 if (passMustSet != null)
-                                    outArgs = String.Format("{0} /maxpassage:{1}d", outArgs, (((DateTime)passMustSet) - ((DateTime)passLastSet)).Days);
+                                    outArgs = $"{outArgs} /maxpassage:{(((DateTime)passMustSet) - ((DateTime)passLastSet)).Days}d";
                             }
                             if (!String.IsNullOrEmpty(li.KerbValidationInfo.LogonServer.ToString()))
-                                outArgs = String.Format("{0} /dc:{1}.{2}", outArgs, li.KerbValidationInfo.LogonServer.ToString(), cred.tickets[0].realm);
+                                outArgs = $"{outArgs} /dc:{li.KerbValidationInfo.LogonServer.ToString()}.{cred.tickets[0].realm}";
                             if ((Interop.PacUserAccountControl)li.KerbValidationInfo.UserAccountControl != Interop.PacUserAccountControl.NORMAL_ACCOUNT)
-                                outArgs = String.Format("{0} /uac:{1}", outArgs, String.Format("{0}", (Interop.PacUserAccountControl)li.KerbValidationInfo.UserAccountControl).Replace(" ", ""));
+                                outArgs = $"{outArgs} /uac:{$"{(Interop.PacUserAccountControl)li.KerbValidationInfo.UserAccountControl}".Replace(" ", "")}";
                         }
                     }
 
@@ -812,11 +812,11 @@ namespace Rubeus {
                                         int flags = BitConverter.ToInt32((byte[])(Array)credData.Credentials, 4);
                                         if (flags == 3)
                                         {
-                                            hash = String.Format("{0}:{1}", Helpers.ByteArrayToString(((byte[])(Array)credData.Credentials).Skip(8).Take(16).ToArray()), Helpers.ByteArrayToString(((byte[])(Array)credData.Credentials).Skip(24).Take(16).ToArray()));
+                                            hash = $"{Helpers.ByteArrayToString(((byte[])(Array)credData.Credentials).Skip(8).Take(16).ToArray())}:{Helpers.ByteArrayToString(((byte[])(Array)credData.Credentials).Skip(24).Take(16).ToArray())}";
                                         }
                                         else
                                         {
-                                            hash = String.Format("{0}", Helpers.ByteArrayToString(((byte[])(Array)credData.Credentials).Skip(24).Take(16).ToArray()));
+                                            hash = $"{Helpers.ByteArrayToString(((byte[])(Array)credData.Credentials).Skip(24).Take(16).ToArray())}";
                                         }
                                     }
                                     else

--- a/Rubeus/lib/Bruteforcer.cs
+++ b/Rubeus/lib/Bruteforcer.cs
@@ -27,11 +27,11 @@ namespace Rubeus
         public Bruteforcer(string domain, string domainController, IBruteforcerReporter reporter)
         {
             this.domain = domain;
-            this.dc = domainController;
+            dc = domainController;
             this.reporter = reporter;
-            this.invalidUsers = new Dictionary<string, bool>();
-            this.validUsers = new Dictionary<string, bool>();
-            this.validCredentials = new Dictionary<string, string>();
+            invalidUsers = new Dictionary<string, bool>();
+            validUsers = new Dictionary<string, bool>();
+            validCredentials = new Dictionary<string, string>();
         }
 
         public bool Attack(string[] usernames, string[] passwords)
@@ -41,7 +41,7 @@ namespace Rubeus
             {
                 foreach (string username in usernames)
                 {
-                    if(this.TestUsernamePassword(username, password))
+                    if(TestUsernamePassword(username, password))
                     {
                         success = true;
                     }
@@ -57,13 +57,13 @@ namespace Rubeus
             {
                 if (!invalidUsers.ContainsKey(username) && !validCredentials.ContainsKey(username))
                 {
-                    this.GetUsernamePasswordTGT(username, password);
+                    GetUsernamePasswordTGT(username, password);
                     return true;
                 }
             }
             catch (KerberosErrorException ex)
             {
-                return this.HandleKerberosError(ex, username, password);
+                return HandleKerberosError(ex, username, password);
             }
 
             return false;
@@ -84,9 +84,9 @@ namespace Rubeus
 
             AS_REQ unpwAsReq = AS_REQ.NewASReq(username, domain, hash, encType);
 
-            byte[] TGT = Ask.InnerTGT(unpwAsReq, encType, null, false, this.dc);
+            byte[] TGT = Ask.InnerTGT(unpwAsReq, encType, null, false, dc);
 
-            this.ReportValidPassword(username, password, TGT);
+            ReportValidPassword(username, password, TGT);
         }
 
         private bool HandleKerberosError(KerberosErrorException ex, string username, string password)
@@ -99,23 +99,23 @@ namespace Rubeus
             switch ((Interop.KERBEROS_ERROR)krbError.error_code)
             {
                 case Interop.KERBEROS_ERROR.KDC_ERR_PREAUTH_FAILED:
-                    this.ReportValidUser(username);
+                    ReportValidUser(username);
                     break;
                 case Interop.KERBEROS_ERROR.KDC_ERR_C_PRINCIPAL_UNKNOWN:
-                    this.ReportInvalidUser(username);
+                    ReportInvalidUser(username);
                     break;
                 case Interop.KERBEROS_ERROR.KDC_ERR_CLIENT_REVOKED:
-                    this.ReportBlockedUser(username);
+                    ReportBlockedUser(username);
                     break;
                 case Interop.KERBEROS_ERROR.KDC_ERR_ETYPE_NOTSUPP:
-                    this.ReportInvalidEncryptionType(username, krbError);
+                    ReportInvalidEncryptionType(username, krbError);
                     break;
                 case Interop.KERBEROS_ERROR.KDC_ERR_KEY_EXPIRED:
-                    this.ReportValidPassword(username, password, null, (Interop.KERBEROS_ERROR)krbError.error_code);
+                    ReportValidPassword(username, password, null, (Interop.KERBEROS_ERROR)krbError.error_code);
                     ret = true;
                     break;
                 default:
-                    this.ReportKrbError(username, krbError);
+                    ReportKrbError(username, krbError);
                     throw ex;
             }
             return ret;
@@ -129,7 +129,7 @@ namespace Rubeus
             {
                 validUsers.Add(username, true);
             }
-            this.reporter.ReportValidPassword(this.domain, username, password, ticket, err);
+            reporter.ReportValidPassword(domain, username, password, ticket, err);
         }
 
         private void ReportValidUser(string username)
@@ -137,7 +137,7 @@ namespace Rubeus
             if (!validUsers.ContainsKey(username))
             {
                 validUsers.Add(username, true);
-                this.reporter.ReportValidUser(this.domain, username);
+                reporter.ReportValidUser(domain, username);
             }
         }
 
@@ -146,7 +146,7 @@ namespace Rubeus
             if (!invalidUsers.ContainsKey(username))
             {
                 invalidUsers.Add(username, true);
-                this.reporter.ReportInvalidUser(this.domain, username);
+                reporter.ReportInvalidUser(domain, username);
             }
         }
 
@@ -155,7 +155,7 @@ namespace Rubeus
             if (!invalidUsers.ContainsKey(username))
             {
                 invalidUsers.Add(username, true);
-                this.reporter.ReportBlockedUser(this.domain, username);
+                reporter.ReportBlockedUser(domain, username);
             }
         }
 
@@ -164,13 +164,13 @@ namespace Rubeus
             if (!invalidUsers.ContainsKey(username))
             {
                 invalidUsers.Add(username, true);
-                this.ReportKrbError(username, krbError);
+                ReportKrbError(username, krbError);
             }
         }
 
         private void ReportKrbError(string username, KRB_ERROR krbError)
         {
-            this.reporter.ReportKrbError(this.domain, username, krbError);
+            reporter.ReportKrbError(domain, username, krbError);
         }
 
     }

--- a/Rubeus/lib/Bruteforcer.cs
+++ b/Rubeus/lib/Bruteforcer.cs
@@ -72,12 +72,12 @@ namespace Rubeus
         private void GetUsernamePasswordTGT(string username, string password)
         {
             Interop.KERB_ETYPE encType = Interop.KERB_ETYPE.aes256_cts_hmac_sha1;
-            string salt = String.Format("{0}{1}", domain.ToUpper(), username);
+            string salt = $"{domain.ToUpper()}{username}";
 
             // special case for computer account salts
             if (username.EndsWith("$"))
             {
-                salt = String.Format("{0}host{1}.{2}", domain.ToUpper(), username.TrimEnd('$').ToLower(), domain.ToLower());
+                salt = $"{domain.ToUpper()}host{username.TrimEnd('$').ToLower()}.{domain.ToLower()}";
             }
 
             string hash = Crypto.KerberosPasswordHash(encType, password, salt);

--- a/Rubeus/lib/ConsoleTable.cs
+++ b/Rubeus/lib/ConsoleTable.cs
@@ -78,7 +78,7 @@ namespace ConsoleTables
             var results = Rows.Select(row => string.Format(format, row)).ToList();
 
             // create the divider
-            var divider = String.Format(" {0} ", new String('-', longestLine - 1));
+            var divider = $" {new String('-', longestLine - 1)} ";
 
             builder.AppendLine(divider);
             builder.AppendLine(columnHeaders);

--- a/Rubeus/lib/ConsoleTable.cs
+++ b/Rubeus/lib/ConsoleTable.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using System.Text;
-using System.Text.RegularExpressions;
 
 // Copyright (c) 2013 Khalid Abuhakmeh, The MIT License (MIT)
 // Source: https://github.com/khalidabuhakmeh/ConsoleTables

--- a/Rubeus/lib/Crypto.cs
+++ b/Rubeus/lib/Crypto.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Linq;
-using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.ComponentModel;
 

--- a/Rubeus/lib/Crypto.cs
+++ b/Rubeus/lib/Crypto.cs
@@ -13,12 +13,12 @@ namespace Rubeus
 
             Console.WriteLine("[*] Input password             : {0}", password);
 
-            string salt = String.Format("{0}{1}", domainName.ToUpper(), userName);
+            string salt = $"{domainName.ToUpper()}{userName}";
 
             // special case for computer account salts
             if (userName.EndsWith("$"))
             {
-                salt = String.Format("{0}host{1}.{2}", domainName.ToUpper(), userName.TrimEnd('$').ToLower(), domainName.ToLower());
+                salt = $"{domainName.ToUpper()}host{userName.TrimEnd('$').ToLower()}.{domainName.ToLower()}";
             }
 
             if (!String.IsNullOrEmpty(userName) && !String.IsNullOrEmpty(domainName))
@@ -43,7 +43,7 @@ namespace Rubeus
                 string aes256Hash = KerberosPasswordHash(Interop.KERB_ETYPE.aes256_cts_hmac_sha1, password, salt);
                 Console.WriteLine("[*]       aes256_cts_hmac_sha1 : {0}", aes256Hash);
 
-                string desHash = KerberosPasswordHash(Interop.KERB_ETYPE.des_cbc_md5, String.Format("{0}{1}", password, salt), salt);
+                string desHash = KerberosPasswordHash(Interop.KERB_ETYPE.des_cbc_md5, $"{password}{salt}", salt);
                 Console.WriteLine("[*]       des_cbc_md5          : {0}", desHash);
             }
 

--- a/Rubeus/lib/Crypto.cs
+++ b/Rubeus/lib/Crypto.cs
@@ -61,12 +61,12 @@ namespace Rubeus
             // locate the crypto system for the hash type we want
             int status = Interop.CDLocateCSystem(etype, out pCSystemPtr);
 
-            pCSystem = (Interop.KERB_ECRYPT)System.Runtime.InteropServices.Marshal.PtrToStructure(pCSystemPtr, typeof(Interop.KERB_ECRYPT));
+            pCSystem = (Interop.KERB_ECRYPT)Marshal.PtrToStructure(pCSystemPtr, typeof(Interop.KERB_ECRYPT));
             if (status != 0)
-                throw new System.ComponentModel.Win32Exception(status, "Error on CDLocateCSystem");
+                throw new Win32Exception(status, "Error on CDLocateCSystem");
 
             // get the delegate for the password hash function
-            Interop.KERB_ECRYPT_HashPassword pCSystemHashPassword = (Interop.KERB_ECRYPT_HashPassword)System.Runtime.InteropServices.Marshal.GetDelegateForFunctionPointer(pCSystem.HashPassword, typeof(Interop.KERB_ECRYPT_HashPassword));
+            Interop.KERB_ECRYPT_HashPassword pCSystemHashPassword = (Interop.KERB_ECRYPT_HashPassword)Marshal.GetDelegateForFunctionPointer(pCSystem.HashPassword, typeof(Interop.KERB_ECRYPT_HashPassword));
             Interop.UNICODE_STRING passwordUnicode = new Interop.UNICODE_STRING(password);
             Interop.UNICODE_STRING saltUnicode = new Interop.UNICODE_STRING(salt);
 
@@ -77,7 +77,7 @@ namespace Rubeus
             if (status != 0)
                 throw new Win32Exception(status);
 
-            return System.BitConverter.ToString(output).Replace("-", "");
+            return BitConverter.ToString(output).Replace("-", "");
         }
 
         // Adapted from Vincent LE TOUX' "MakeMeEnterpriseAdmin"

--- a/Rubeus/lib/ForgeTicket.cs
+++ b/Rubeus/lib/ForgeTicket.cs
@@ -1,10 +1,8 @@
 ﻿using System;
-using System.Text;
 using System.Security.Principal;
 using System.Collections.Generic;
 using System.Linq;
 using System.Globalization;
-using System.DirectoryServices;
 using System.Text.RegularExpressions;
 using Rubeus.lib.Interop;
 using Rubeus.Kerberos.PAC;

--- a/Rubeus/lib/Harvest.cs
+++ b/Rubeus/lib/Harvest.cs
@@ -25,8 +25,8 @@ namespace Rubeus
             this.renewTickets = renewTickets;
             this.targetUser = targetUser;
             this.registryBasePath = registryBasePath;
-            this.lastDisplay = DateTime.Now;
-            this.collectionStart = DateTime.Now;
+            lastDisplay = DateTime.Now;
+            collectionStart = DateTime.Now;
             this.nowrap = nowrap;
             this.runFor = runFor;
         }
@@ -43,7 +43,7 @@ namespace Rubeus
             while (true)
             {
                 // extract out the TGTs (service = krbtgt_ w/ full data, silent enumeration
-                List<LSA.SESSION_CRED> sessionCreds = LSA.EnumerateTickets(true, new LUID(), "krbtgt", this.targetUser, null, true, true);
+                List<LSA.SESSION_CRED> sessionCreds = LSA.EnumerateTickets(true, new LUID(), "krbtgt", targetUser, null, true, true);
                 List<KRB_CRED> currentTickets = new List<KRB_CRED>();
                 foreach(var sessionCred in sessionCreds)
                 {
@@ -58,9 +58,9 @@ namespace Rubeus
                     AddTicketsToTicketCache(currentTickets, false);
 
                     // check if we're at a new display interval
-                    if(lastDisplay.AddSeconds(this.displayIntervalSeconds) < DateTime.Now.AddSeconds(1))
+                    if(lastDisplay.AddSeconds(displayIntervalSeconds) < DateTime.Now.AddSeconds(1))
                     {
-                        this.lastDisplay = DateTime.Now;
+                        lastDisplay = DateTime.Now;
                         // refresh/renew everything in the cache and display the working set
                         RefreshTicketCache(true);
                         Console.WriteLine("[*] Sleeping until {0} ({1} seconds) for next display\r\n", DateTime.Now.AddSeconds(displayIntervalSeconds), displayIntervalSeconds);
@@ -85,18 +85,18 @@ namespace Rubeus
                 if (runFor > 0)
                 {
                     // compares execution start time + time entered to run the harvest for against current time to determine if we should exit
-                    if (collectionStart.AddSeconds(this.runFor) < DateTime.Now)
+                    if (collectionStart.AddSeconds(runFor) < DateTime.Now)
                     {
                         Console.WriteLine("[*] Completed running for {0} seconds, exiting\r\n", runFor);
-                        System.Environment.Exit(0);
+                        Environment.Exit(0);
                     }
                 }
 
                 // If a runFor time is set and the monitoring interval is longer than the time remaining on the run, 
                 // the sleep interval will be adjusted down to however much time left in the run there is. 
-                if (runFor > 0 && collectionStart.AddSeconds(this.runFor) < DateTime.Now.AddSeconds(monitorIntervalSeconds))
+                if (runFor > 0 && collectionStart.AddSeconds(runFor) < DateTime.Now.AddSeconds(monitorIntervalSeconds))
                 {
-                    TimeSpan t = collectionStart.AddSeconds(this.runFor + 1) - DateTime.Now;
+                    TimeSpan t = collectionStart.AddSeconds(runFor + 1) - DateTime.Now;
                     Thread.Sleep((int)t.TotalSeconds * 1000);
                 }
                 // else we'll do a normal monitor interval sleep
@@ -150,7 +150,7 @@ namespace Rubeus
                 if (displayNewTickets)
                 {
                     Console.WriteLine($"\r\n[*] {DateTime.Now.ToUniversalTime()} UTC - Found new TGT:\r\n");
-                    LSA.DisplayTicket(ticket, 2, true, true, false, this.nowrap);
+                    LSA.DisplayTicket(ticket, 2, true, true, false, nowrap);
                 }
             }
 
@@ -201,7 +201,7 @@ namespace Rubeus
                     }
 
                     if (display)
-                        LSA.DisplayTicket(harvesterTicketCache[i], 2, true, true, false, this.nowrap);
+                        LSA.DisplayTicket(harvesterTicketCache[i], 2, true, true, false, nowrap);
                 }
 
             }

--- a/Rubeus/lib/Helpers.cs
+++ b/Rubeus/lib/Helpers.cs
@@ -418,7 +418,7 @@ namespace Rubeus
                 {
                     if (File.Exists(filePath))
                     {
-                        throw new Exception(String.Format("{0} already exists! Data not written to file.\r\n", filePath));
+                        throw new Exception($"{filePath} already exists! Data not written to file.\r\n");
                     }
                 }
                 File.WriteAllBytes(filePath, data);

--- a/Rubeus/lib/Helpers.cs
+++ b/Rubeus/lib/Helpers.cs
@@ -59,7 +59,7 @@ namespace Rubeus
             if ((hex.Length % 16) != 0)
             {
                 Console.WriteLine("\r\n[X] Hash must be 16, 32 or 64 characters in length\r\n");
-                System.Environment.Exit(1);
+                Environment.Exit(1);
             }
 
             // yes I know this inefficient
@@ -243,9 +243,9 @@ namespace Rubeus
             var luid = new LUID();
 
 
-            if (username == null) { username = Helpers.RandomString(8);}
-            if (domain == null) { domain = Helpers.RandomString(8); }
-            if (password == null) { password = Helpers.RandomString(8); }
+            if (username == null) { username = RandomString(8);}
+            if (domain == null) { domain = RandomString(8); }
+            if (password == null) { password = RandomString(8); }
 
             Console.WriteLine("[*] Username        : {0}", username);
             Console.WriteLine("[*] Domain          : {0}", domain);

--- a/Rubeus/lib/Interop.cs
+++ b/Rubeus/lib/Interop.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using Asn1;
-using System.Text;
-using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using Rubeus.lib.Interop;
 

--- a/Rubeus/lib/Interop/Luid.cs
+++ b/Rubeus/lib/Interop/Luid.cs
@@ -58,7 +58,7 @@ namespace Rubeus.lib.Interop
         public override string ToString()
         {
             UInt64 Value = ((UInt64)this.HighPart << 32) + this.LowPart;
-            return String.Format("0x{0:x}", (ulong)Value);
+            return $"0x{(ulong)Value:x}";
         }
 
         public static bool operator ==(LUID x, LUID y)

--- a/Rubeus/lib/Interop/Luid.cs
+++ b/Rubeus/lib/Interop/Luid.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.InteropServices;
-using System.Text;
 
 namespace Rubeus.lib.Interop
 {

--- a/Rubeus/lib/Interop/Luid.cs
+++ b/Rubeus/lib/Interop/Luid.cs
@@ -39,14 +39,14 @@ namespace Rubeus.lib.Interop
             }
             else
             {
-                System.ArgumentException argEx = new System.ArgumentException("Passed LUID string value is not in a hex or decimal form", value);
+                ArgumentException argEx = new ArgumentException("Passed LUID string value is not in a hex or decimal form", value);
                 throw argEx;
             }
         }
 
         public override int GetHashCode()
         {
-            UInt64 Value = ((UInt64)this.HighPart << 32) + this.LowPart;
+            UInt64 Value = ((UInt64)HighPart << 32) + LowPart;
             return Value.GetHashCode();
         }
 
@@ -57,7 +57,7 @@ namespace Rubeus.lib.Interop
 
         public override string ToString()
         {
-            UInt64 Value = ((UInt64)this.HighPart << 32) + this.LowPart;
+            UInt64 Value = ((UInt64)HighPart << 32) + LowPart;
             return $"0x{(ulong)Value:x}";
         }
 

--- a/Rubeus/lib/Interop/NtException.cs
+++ b/Rubeus/lib/Interop/NtException.cs
@@ -1,9 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
 using System.Runtime.InteropServices;
-using System.Text;
 
 namespace Rubeus.lib.Interop
 {

--- a/Rubeus/lib/LSA.cs
+++ b/Rubeus/lib/LSA.cs
@@ -190,7 +190,7 @@ namespace Rubeus
                 // parse the returned pointer into our initial KERB_RETRIEVE_TKT_RESPONSE structure
                 response =
                     (Interop.KERB_RETRIEVE_TKT_RESPONSE)Marshal.PtrToStructure(
-                        (System.IntPtr)responsePointer,
+                        (IntPtr)responsePointer,
                         typeof(Interop.KERB_RETRIEVE_TKT_RESPONSE));
 
                 var encodedTicketSize = response.Ticket.EncodedTicketSize;
@@ -361,7 +361,7 @@ namespace Rubeus
                     {
                         // parse the returned pointer into our initial KERB_QUERY_TKT_CACHE_RESPONSE structure
                         ticketCacheResponse = (Interop.KERB_QUERY_TKT_CACHE_RESPONSE)Marshal.PtrToStructure(
-                            (System.IntPtr)ticketsPointer, typeof(Interop.KERB_QUERY_TKT_CACHE_RESPONSE));
+                            (IntPtr)ticketsPointer, typeof(Interop.KERB_QUERY_TKT_CACHE_RESPONSE));
                         var count2 = ticketCacheResponse.CountOfTickets;
 
                         if (count2 != 0)
@@ -549,7 +549,7 @@ namespace Rubeus
                 Console.WriteLine("{0}Flags                 :  {1}", indent, cred.enc_part.ticket_info[0].flags);
                 Console.WriteLine("{0}Base64EncodedTicket   :\r\n", indent);
 
-                if (Rubeus.Program.wrapTickets)
+                if (Program.wrapTickets)
                 {
                     foreach (var line in Helpers.Split(base64ticket, 100))
                     {
@@ -585,7 +585,7 @@ namespace Rubeus
                 {
                     // if we're displaying the base64 encoding of the ticket
                     Console.WriteLine("{0}Base64EncodedTicket   :\r\n", indent);
-                    if (Rubeus.Program.wrapTickets)
+                    if (Program.wrapTickets)
                     {
                         foreach (var line in Helpers.Split(base64ticket, 100))
                         {
@@ -1261,7 +1261,7 @@ namespace Rubeus
             if ((retCode == 0) && ((uint)winError == 0) && (returnBufferLength != 0))
             {
                 // parse the returned pointer into our initial KERB_RETRIEVE_TKT_RESPONSE structure
-                response = (Interop.KERB_RETRIEVE_TKT_RESPONSE)Marshal.PtrToStructure((System.IntPtr)responsePointer, typeof(Interop.KERB_RETRIEVE_TKT_RESPONSE));
+                response = (Interop.KERB_RETRIEVE_TKT_RESPONSE)Marshal.PtrToStructure((IntPtr)responsePointer, typeof(Interop.KERB_RETRIEVE_TKT_RESPONSE));
 
                 // extract the session key
                 var sessionKeyType = (Interop.KERB_ETYPE)response.Ticket.SessionKey.KeyType;
@@ -1474,7 +1474,7 @@ namespace Rubeus
                                                             {
                                                                 Console.WriteLine("[*] base64(ticket.kirbi):\r\n", kirbiString);
 
-                                                                if (Rubeus.Program.wrapTickets)
+                                                                if (Program.wrapTickets)
                                                                 {
                                                                     // display the .kirbi base64, columns of 80 chararacters
                                                                     foreach (var line in Helpers.Split(kirbiString, 80))
@@ -1562,7 +1562,7 @@ namespace Rubeus
 
             var kirbiBytes = kirbi.Encode().Encode();
 
-            LSA.DisplayTicket(kirbi, 2, false, true);
+            DisplayTicket(kirbi, 2, false, true);
 
             // TODO: check this code!
 
@@ -1581,7 +1581,7 @@ namespace Rubeus
             if (ptt || ((ulong)luid != 0))
             {
                 // pass-the-ticket -> import into LSASS
-                LSA.ImportTicket(kirbiBytes, luid);
+                ImportTicket(kirbiBytes, luid);
             }
         }
 

--- a/Rubeus/lib/LSA.cs
+++ b/Rubeus/lib/LSA.cs
@@ -10,7 +10,6 @@ using Microsoft.Win32;
 using ConsoleTables;
 using System.Security.Principal;
 using Rubeus.lib.Interop;
-using System.IO;
 using Rubeus.Kerberos;
 using Rubeus.Kerberos.PAC;
 using System.Linq;

--- a/Rubeus/lib/LSA.cs
+++ b/Rubeus/lib/LSA.cs
@@ -393,11 +393,11 @@ namespace Rubeus
 
                                 bool includeTicket = true;
 
-                                if ( !String.IsNullOrEmpty(targetService) && !Regex.IsMatch(ticket.ServerName, String.Format(@"^{0}/.*", Regex.Escape(targetService)), RegexOptions.IgnoreCase))
+                                if ( !String.IsNullOrEmpty(targetService) && !Regex.IsMatch(ticket.ServerName, $@"^{Regex.Escape(targetService)}/.*", RegexOptions.IgnoreCase))
                                 {
                                     includeTicket = false;
                                 }
-                                if (!String.IsNullOrEmpty(targetServer) && !Regex.IsMatch(ticket.ServerName, String.Format(@".*/{0}", Regex.Escape(targetServer)), RegexOptions.IgnoreCase))
+                                if (!String.IsNullOrEmpty(targetServer) && !Regex.IsMatch(ticket.ServerName, $@".*/{Regex.Escape(targetServer)}", RegexOptions.IgnoreCase))
                                 {
                                     includeTicket = false;
                                 }
@@ -491,7 +491,7 @@ namespace Rubeus
 
                     if (displayFormat == TicketDisplayFormat.Triage)
                     {
-                        table.AddRow(sessionCred.LogonSession.LogonID.ToString(), String.Format("{0} @ {1}", ticket.ClientName, ticket.ClientRealm), ticket.ServerName, ticket.EndTime.ToString());
+                        table.AddRow(sessionCred.LogonSession.LogonID.ToString(), $"{ticket.ClientName} @ {ticket.ClientRealm}", ticket.ServerName, ticket.EndTime.ToString());
                     }
                     else if (displayFormat == TicketDisplayFormat.Klist)
                     {
@@ -531,7 +531,7 @@ namespace Rubeus
 
             var userName = string.Join("@", cred.enc_part.ticket_info[0].pname.name_string.ToArray());
             var sname = string.Join("/", cred.enc_part.ticket_info[0].sname.name_string.ToArray());
-            var keyType = String.Format("{0}", (Interop.KERB_ETYPE)cred.enc_part.ticket_info[0].key.keytype);
+            var keyType = $"{(Interop.KERB_ETYPE)cred.enc_part.ticket_info[0].key.keytype}";
             var b64Key = Convert.ToBase64String(cred.enc_part.ticket_info[0].key.keyvalue);
             var eType = (Interop.KERB_ETYPE)cred.tickets[0].enc_part.etype;
             var base64ticket = Convert.ToBase64String(cred.Encode().Encode());
@@ -619,7 +619,7 @@ namespace Rubeus
                         }
                         if (serviceUser.EndsWith("$"))
                         {
-                            serviceUser = String.Format("host{0}.{1}", serviceUser.TrimEnd('$').ToLower(), serviceDomain.ToLower());
+                            serviceUser = $"host{serviceUser.TrimEnd('$').ToLower()}.{serviceDomain.ToLower()}";
                         }
                         Roast.DisplayTGShash(cred, false, serviceUser, serviceDomain);
                     }
@@ -799,11 +799,11 @@ namespace Rubeus
                                         int flags = BitConverter.ToInt32((byte[])(Array)credData.Credentials, 4);
                                         if (flags == 3)
                                         {
-                                            hash = String.Format("{0}:{1}", Helpers.ByteArrayToString(((byte[])(Array)credData.Credentials).Skip(8).Take(16).ToArray()), Helpers.ByteArrayToString(((byte[])(Array)credData.Credentials).Skip(24).Take(16).ToArray()));
+                                            hash = $"{Helpers.ByteArrayToString(((byte[])(Array)credData.Credentials).Skip(8).Take(16).ToArray())}:{Helpers.ByteArrayToString(((byte[])(Array)credData.Credentials).Skip(24).Take(16).ToArray())}";
                                         }
                                         else
                                         {
-                                            hash = String.Format("{0}", Helpers.ByteArrayToString(((byte[])(Array)credData.Credentials).Skip(24).Take(16).ToArray()));
+                                            hash = $"{Helpers.ByteArrayToString(((byte[])(Array)credData.Credentials).Skip(24).Take(16).ToArray())}";
                                         }
                                     }
                                     else
@@ -1310,7 +1310,7 @@ namespace Rubeus
                     Console.WriteLine("[X] Error retrieving current domain controller");
                     return null;
                 }
-                targetSPN = String.Format("cifs/{0}", domainController);
+                targetSPN = $"cifs/{domainController}";
             }
 
             var phCredential = new Interop.SECURITY_HANDLE();

--- a/Rubeus/lib/Networking.cs
+++ b/Rubeus/lib/Networking.cs
@@ -83,7 +83,7 @@ namespace Rubeus
                             {
                                 Console.WriteLine("[*] Using domain controller: {0} ({1})", DCName, dcIP);
                             }
-                            return String.Format("{0}", dcIP);
+                            return $"{dcIP}";
                         }
                     }
                     Console.WriteLine("[X] Error resolving hostname '{0}' to an IP address: no IPv4 or IPv6 address found", DCName);
@@ -192,7 +192,7 @@ namespace Rubeus
             }
             else if (!String.IsNullOrEmpty(domain))
             {
-                ldapOu = String.Format("DC={0}", domain.Replace(".", ",DC="));
+                ldapOu = $"DC={domain.Replace(".", ",DC=")}";
             }
 
             //If no DC, domain, credentials, or OU were specified
@@ -206,17 +206,17 @@ namespace Rubeus
                 string bindPath = "";
                 if (!String.IsNullOrEmpty(ldapPrefix))
                 {
-                    bindPath = String.Format("LDAP://{0}", ldapPrefix);
+                    bindPath = $"LDAP://{ldapPrefix}";
                 }
                 if (!String.IsNullOrEmpty(ldapOu))
                 {
                     if (!String.IsNullOrEmpty(bindPath))
                     {
-                        bindPath = String.Format("{0}/{1}", bindPath, ldapOu);
+                        bindPath = $"{bindPath}/{ldapOu}";
                     }
                     else
                     {
-                        bindPath = String.Format("LDAP://{0}", ldapOu);
+                        bindPath = $"LDAP://{ldapOu}";
                     }
                 }
 
@@ -226,7 +226,7 @@ namespace Rubeus
             if (cred != null)
             {
                 // if we're using alternate credentials for the connection
-                string userDomain = String.Format("{0}\\{1}", cred.Domain, cred.UserName);
+                string userDomain = $"{cred.Domain}\\{cred.UserName}";
                 directoryObject.Username = userDomain;
                 directoryObject.Password = cred.Password;
              
@@ -308,7 +308,7 @@ namespace Rubeus
 
                 if (String.IsNullOrEmpty(OUName))
                 {
-                    OUName = String.Format("DC={0}", domain.Replace(".", ",DC="));
+                    OUName = $"DC={domain.Replace(".", ",DC=")}";
                 }
 
                 try
@@ -435,7 +435,7 @@ namespace Rubeus
         public static Dictionary<string, Dictionary<string, Object>> GetGptTmplContent(string path, string user = null, string password = null)
         {
             Dictionary<string, Dictionary<string, Object>> IniObject = new Dictionary<string, Dictionary<string, Object>>();
-            string sysvolPath = String.Format("\\\\{0}\\SYSVOL", (new System.Uri(path).Host));
+            string sysvolPath = $"\\\\{(new System.Uri(path).Host)}\\SYSVOL";
 
             int result = AddRemoteConnection(null, sysvolPath, user, password);
             if (result != (int)Interop.SystemErrorCodes.ERROR_SUCCESS)
@@ -492,7 +492,7 @@ namespace Rubeus
             if (host != null)
             {
                 string targetComputerName = host.Trim('\\');
-                paths.Add(String.Format("\\\\{0}\\IPC$", targetComputerName));
+                paths.Add($"\\\\{targetComputerName}\\IPC$");
             }
             else
             {
@@ -533,7 +533,7 @@ namespace Rubeus
             if (host != null)
             {
                 string targetComputerName = host.Trim('\\');
-                paths.Add(String.Format("\\\\{0}\\IPC$", targetComputerName));
+                paths.Add($"\\\\{targetComputerName}\\IPC$");
             }
             else
             {

--- a/Rubeus/lib/Networking.cs
+++ b/Rubeus/lib/Networking.cs
@@ -73,9 +73,9 @@ namespace Rubeus
                         Console.WriteLine("[X] Error: No domain controller could be located");
                         return null;
                     }
-                    System.Net.IPAddress[] dcIPs = System.Net.Dns.GetHostAddresses(DCName);
+                    IPAddress[] dcIPs = Dns.GetHostAddresses(DCName);
 
-                    foreach (System.Net.IPAddress dcIP in dcIPs)
+                    foreach (IPAddress dcIP in dcIPs)
                     {
                         if (dcIP.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork || dcIP.AddressFamily == System.Net.Sockets.AddressFamily.InterNetworkV6)
                         {
@@ -104,7 +104,7 @@ namespace Rubeus
             {
                 try
                 {
-                    System.Net.IPHostEntry DC = System.Net.Dns.GetHostEntry(IP);
+                    IPHostEntry DC = Dns.GetHostEntry(IP);
                     return DC.HostName;
                 }
                 catch (Exception e)
@@ -118,7 +118,7 @@ namespace Rubeus
 
         public static byte[] SendBytes(string server, int port, byte[] data)
         {
-            var ipEndPoint = new System.Net.IPEndPoint(System.Net.IPAddress.Parse(server), port);
+            var ipEndPoint = new IPEndPoint(IPAddress.Parse(server), port);
             try
             {
                 using (System.Net.Sockets.TcpClient client = new System.Net.Sockets.TcpClient(ipEndPoint.AddressFamily)) {
@@ -129,10 +129,10 @@ namespace Rubeus
                     BinaryReader socketReader = new BinaryReader(client.GetStream());
                     BinaryWriter socketWriter = new BinaryWriter(client.GetStream());
                     
-                    socketWriter.Write(System.Net.IPAddress.HostToNetworkOrder(data.Length));                   
+                    socketWriter.Write(IPAddress.HostToNetworkOrder(data.Length));                   
                     socketWriter.Write(data);
 
-                    int recordMark = System.Net.IPAddress.NetworkToHostOrder(socketReader.ReadInt32());
+                    int recordMark = IPAddress.NetworkToHostOrder(socketReader.ReadInt32());
                     int recordSize = recordMark & 0x7fffffff;
 
                     if((recordMark & 0x80000000) > 0) {
@@ -165,7 +165,7 @@ namespace Rubeus
             return null;
         }
 
-        public static DirectoryEntry GetLdapSearchRoot(System.Net.NetworkCredential cred, string OUName, string domainController, string domain)
+        public static DirectoryEntry GetLdapSearchRoot(NetworkCredential cred, string OUName, string domainController, string domain)
         {
             DirectoryEntry directoryObject = null;
             string ldapPrefix = "";
@@ -264,12 +264,12 @@ namespace Rubeus
             return directoryObject;
         }
 
-        public static List<IDictionary<string, Object>> GetLdapQuery(System.Net.NetworkCredential cred, string OUName, string domainController, string domain, string filter, bool ldaps = false)
+        public static List<IDictionary<string, Object>> GetLdapQuery(NetworkCredential cred, string OUName, string domainController, string domain, string filter, bool ldaps = false)
         {
             var ActiveDirectoryObjects = new List<IDictionary<string, Object>>();
             if (String.IsNullOrEmpty(domainController))
             {
-                domainController = Networking.GetDCName(domain); //if domain is null, this will try to find a DC in current user's domain
+                domainController = GetDCName(domain); //if domain is null, this will try to find a DC in current user's domain
             }
             if (String.IsNullOrEmpty(domainController))
             {
@@ -347,7 +347,7 @@ namespace Rubeus
                 DirectorySearcher searcher = null;
                 try
                 {
-                    directoryObject = Networking.GetLdapSearchRoot(cred, OUName, domainController, domain);
+                    directoryObject = GetLdapSearchRoot(cred, OUName, domainController, domain);
                     searcher = new DirectorySearcher(directoryObject);
                     // enable LDAP paged search to get all results, by pages of 1000 items
                     searcher.PageSize = 1000;
@@ -435,7 +435,7 @@ namespace Rubeus
         public static Dictionary<string, Dictionary<string, Object>> GetGptTmplContent(string path, string user = null, string password = null)
         {
             Dictionary<string, Dictionary<string, Object>> IniObject = new Dictionary<string, Dictionary<string, Object>>();
-            string sysvolPath = $"\\\\{(new System.Uri(path).Host)}\\SYSVOL";
+            string sysvolPath = $"\\\\{(new Uri(path).Host)}\\SYSVOL";
 
             int result = AddRemoteConnection(null, sysvolPath, user, password);
             if (result != (int)Interop.SystemErrorCodes.ERROR_SUCCESS)
@@ -443,7 +443,7 @@ namespace Rubeus
                 return null;
             }
 
-            if (System.IO.File.Exists(path))
+            if (File.Exists(path))
             {
                 var content = File.ReadAllLines(path);
                 var CommentCount = 0;

--- a/Rubeus/lib/Renew.cs
+++ b/Rubeus/lib/Renew.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.IO;
-using System.Linq;
 using Asn1;
 using Rubeus.lib.Interop;
 

--- a/Rubeus/lib/Renew.cs
+++ b/Rubeus/lib/Renew.cs
@@ -152,7 +152,7 @@ namespace Rubeus
                 if (display)
                 {
                     Console.WriteLine("[*] base64(ticket.kirbi):\r\n", kirbiString);
-                    if (Rubeus.Program.wrapTickets)
+                    if (Program.wrapTickets)
                     {
                         // display the .kirbi base64, columns of 80 chararacters
                         foreach (string line in Helpers.Split(kirbiString, 80))

--- a/Rubeus/lib/Reset.cs
+++ b/Rubeus/lib/Reset.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.IO;
-using System.Linq;
 using System.Net;
 using System.Text;
 using Asn1;

--- a/Rubeus/lib/Roast.cs
+++ b/Rubeus/lib/Roast.cs
@@ -4,8 +4,6 @@ using System.IO;
 using ConsoleTables;
 using System.Text.RegularExpressions;
 using System.Security.Principal;
-using System.DirectoryServices;
-using System.DirectoryServices.AccountManagement;
 using System.Collections.Generic;
 using Rubeus.lib.Interop;
 

--- a/Rubeus/lib/Roast.cs
+++ b/Rubeus/lib/Roast.cs
@@ -153,7 +153,7 @@ namespace Rubeus
                     Console.WriteLine("[*] AS-REP hash:\r\n");
 
                     // display the base64 of a hash, columns of 80 chararacters
-                    if (Rubeus.Program.wrapTickets)
+                    if (Program.wrapTickets)
                     {
                         foreach (string line in Helpers.Split(hashString, 80))
                         {
@@ -672,7 +672,7 @@ namespace Rubeus
                                         }
                                         else
                                         {
-                                            if (Rubeus.Program.wrapTickets)
+                                            if (Program.wrapTickets)
                                             {
                                                 bool header = false;
                                                 foreach (string line in Helpers.Split(hash, 80))
@@ -793,7 +793,7 @@ namespace Rubeus
             else
             {
                 bool header = false;
-                if (Rubeus.Program.wrapTickets)
+                if (Program.wrapTickets)
                 {
                     foreach (string line in Helpers.Split(hash, 80))
                     {

--- a/Rubeus/lib/Roast.cs
+++ b/Rubeus/lib/Roast.cs
@@ -47,11 +47,11 @@ namespace Rubeus
                 }
                 else
                 {
-                    userSearchFilter = String.Format("(&(samAccountType=805306368)(userAccountControl:1.2.840.113556.1.4.803:=4194304)(samAccountName={0}))", userName);
+                    userSearchFilter = $"(&(samAccountType=805306368)(userAccountControl:1.2.840.113556.1.4.803:=4194304)(samAccountName={userName}))";
                 }
                 if (!String.IsNullOrEmpty(ldapFilter))
                 {
-                    userSearchFilter = String.Format("(&{0}({1}))", userSearchFilter, ldapFilter);
+                    userSearchFilter = $"(&{userSearchFilter}({ldapFilter}))";
                 }
                 
                 if (String.IsNullOrEmpty(domain))
@@ -124,11 +124,11 @@ namespace Rubeus
                 string hashString = "";
                 if (format == "john")
                 {
-                    hashString = String.Format("$krb5asrep${0}@{1}:{2}", userName, domain, repHash);
+                    hashString = $"$krb5asrep${userName}@{domain}:{repHash}";
                 }
                 else if (format == "hashcat")
                 {
-                    hashString = String.Format("$krb5asrep$23${0}@{1}:{2}", userName, domain, repHash);
+                    hashString = $"$krb5asrep$23${userName}@{domain}:{repHash}";
                 }
                 else
                 {
@@ -313,7 +313,7 @@ namespace Rubeus
                         }
                         
                         // request a service tickt for LDAP on the target DC
-                        kirbiBytes = Ask.TGS(tgtUserName, ticketDomain, ticket, clientKey, etype, string.Format("ldap/{0}", dc), etype, null, false, dc, false, enterprise, false);
+                        kirbiBytes = Ask.TGS(tgtUserName, ticketDomain, ticket, clientKey, etype, $"ldap/{dc}", etype, null, false, dc, false, enterprise, false);
                     }
                     // otherwise inject the TGT to perform the domain searcher
                     else
@@ -334,14 +334,14 @@ namespace Rubeus
                         string userPart = "";
                         foreach (string user in userName.Split(','))
                         {
-                            userPart += String.Format("(samAccountName={0})", user);
+                            userPart += $"(samAccountName={user})";
                         }
-                        userFilter = String.Format("(&(|{0})(!(UserAccountControl:1.2.840.113556.1.4.803:=2)))", userPart);
+                        userFilter = $"(&(|{userPart})(!(UserAccountControl:1.2.840.113556.1.4.803:=2)))";
                     }
                     else
                     {
                         // searching for a specified user, ensuring it's not a disabled account
-                        userFilter = String.Format("(samAccountName={0})(!(UserAccountControl:1.2.840.113556.1.4.803:=2))", userName);
+                        userFilter = $"(samAccountName={userName})(!(UserAccountControl:1.2.840.113556.1.4.803:=2))";
                     }
                 }
                 else
@@ -393,7 +393,7 @@ namespace Rubeus
                         DateTime timeFromConverted = DateTime.ParseExact(pwdSetAfter, "MM-dd-yyyy", null);
                         DateTime timeUntilConverted = DateTime.ParseExact(pwdSetBefore, "MM-dd-yyyy", null);
                         string timePeriod = "(pwdlastset>=" + timeFromConverted.ToFileTime() + ")(pwdlastset<=" + timeUntilConverted.ToFileTime() + ")";
-                        userSearchFilter = String.Format("(&(samAccountType=805306368)(servicePrincipalName=*){0}{1}{2})", userFilter, encFilter, timePeriod);
+                        userSearchFilter = $"(&(samAccountType=805306368)(servicePrincipalName=*){userFilter}{encFilter}{timePeriod})";
                     }
                     catch
                     {
@@ -403,12 +403,12 @@ namespace Rubeus
                 }
                 else
                 {
-                    userSearchFilter = String.Format("(&(samAccountType=805306368)(servicePrincipalName=*){0}{1})", userFilter, encFilter);
+                    userSearchFilter = $"(&(samAccountType=805306368)(servicePrincipalName=*){userFilter}{encFilter})";
                 }
 
                 if (!String.IsNullOrEmpty(ldapFilter))
                 {
-                    userSearchFilter = String.Format("(&{0}({1}))", userSearchFilter, ldapFilter);
+                    userSearchFilter = $"(&{userSearchFilter}({ldapFilter}))";
                 }
 
                 List<IDictionary<string, Object>> users = Networking.GetLdapQuery(cred, OUName, dc, domain, userSearchFilter, ldaps);
@@ -493,7 +493,7 @@ namespace Rubeus
 
                             if ((!String.IsNullOrEmpty(domain)) && (TGT == null))
                             {
-                                servicePrincipalName = String.Format("{0}@{1}", servicePrincipalName, domain);
+                                servicePrincipalName = $"{servicePrincipalName}@{domain}";
                             }
                             if (TGT != null)
                             {
@@ -517,7 +517,7 @@ namespace Rubeus
                                 if (!result && autoenterprise)
                                 {
                                     Console.WriteLine("\r\n[-] Retrieving service ticket with SPN failed and '/autoenterprise' passed, retrying with the enterprise principal");
-                                    servicePrincipalName = String.Format("{0}@{1}", samAccountName, domain);
+                                    servicePrincipalName = $"{samAccountName}@{domain}";
                                     GetTGSRepHash(TGT, servicePrincipalName, samAccountName, distinguishedName, outFile, simpleOutput, true, dc, etype);
                                     Helpers.RandomDelayWithJitter(delay, jitter);
                                 }
@@ -530,7 +530,7 @@ namespace Rubeus
                                 if (!result && autoenterprise)
                                 {
                                     Console.WriteLine("\r\n[-] Retrieving service ticket with SPN failed and '/autoenterprise' passed, retrying with the enterprise principal");
-                                    servicePrincipalName = String.Format("{0}@{1}", samAccountName, domain);
+                                    servicePrincipalName = $"{samAccountName}@{domain}";
                                     GetTGSRepHash(servicePrincipalName, samAccountName, distinguishedName, cred, outFile, simpleOutput);
                                     Helpers.RandomDelayWithJitter(delay, jitter);
                                 }
@@ -645,12 +645,12 @@ namespace Rubeus
                                             //Ensure checksum is extracted from the end for aes keys
                                             int checksumStart = cipherText.Length - 24;
                                             //Enclose SPN in *s rather than username, realm and SPN. This doesn't impact cracking, but might affect loading into hashcat.
-                                            hash = String.Format("$krb5tgs${0}${1}${2}$*{3}*${4}${5}", encType, userName, domain, spn, cipherText.Substring(checksumStart), cipherText.Substring(0, checksumStart));
+                                            hash = $"$krb5tgs${encType}${userName}${domain}$*{spn}*${cipherText.Substring(checksumStart)}${cipherText.Substring(0, checksumStart)}";
                                         }
                                         //if encType==23
                                         else
                                         {
-                                            hash = String.Format("$krb5tgs${0}$*{1}${2}${3}*${4}${5}", encType, userName, domain, spn, cipherText.Substring(0, 32), cipherText.Substring(32));
+                                            hash = $"$krb5tgs${encType}$*{userName}${domain}${spn}*${cipherText.Substring(0, 32)}${cipherText.Substring(32)}";
                                         }
 
                                         if (!String.IsNullOrEmpty(outFile))
@@ -765,12 +765,12 @@ namespace Rubeus
             {
                 int checksumStart = cipherText.Length - 24;
                 //Enclose SPN in *s rather than username, realm and SPN. This doesn't impact cracking, but might affect loading into hashcat.            
-                hash = String.Format("$krb5tgs${0}${1}${2}$*{3}*${4}${5}", encType, kerberoastUser, kerberoastDomain, sname, cipherText.Substring(checksumStart), cipherText.Substring(0, checksumStart));
+                hash = $"$krb5tgs${encType}${kerberoastUser}${kerberoastDomain}$*{sname}*${cipherText.Substring(checksumStart)}${cipherText.Substring(0, checksumStart)}";
             }
             //if encType==23
             else
             {
-                hash = String.Format("$krb5tgs${0}$*{1}${2}${3}*${4}${5}", encType, kerberoastUser, kerberoastDomain, sname, cipherText.Substring(0, 32), cipherText.Substring(32));
+                hash = $"$krb5tgs${encType}$*{kerberoastUser}${kerberoastDomain}${sname}*${cipherText.Substring(0, 32)}${cipherText.Substring(32)}";
             }
 
             if (!String.IsNullOrEmpty(outFile))

--- a/Rubeus/lib/S4U.cs
+++ b/Rubeus/lib/S4U.cs
@@ -68,7 +68,7 @@ namespace Rubeus
                             requestDomain = targetDomain;
 
 
-                        KRB_CRED localSelf = CrossDomainS4U2Self(string.Format("{0}@{1}", userName, domain), string.Format("{0}@{1}", targetUser, impersonateDomain), domainController, ticket, clientKey, etype, Interop.KERB_ETYPE.subkey_keymaterial, false, altService, s, requestDomain, ptt);
+                        KRB_CRED localSelf = CrossDomainS4U2Self($"{userName}@{domain}", $"{targetUser}@{impersonateDomain}", domainController, ticket, clientKey, etype, Interop.KERB_ETYPE.subkey_keymaterial, false, altService, s, requestDomain, ptt);
                     }
                     else
                     {
@@ -631,12 +631,12 @@ namespace Rubeus
             Interop.KERB_ETYPE etype = (Interop.KERB_ETYPE)kirbi.enc_part.ticket_info[0].key.keytype;
 
             // user variables
-            string user = string.Format("{0}@{1}", userName, domain);
-            string target = string.Format("{0}@{1}", targetUser, targetDomain);
+            string user = $"{userName}@{domain}";
+            string target = $"{targetUser}@{targetDomain}";
 
             // First retrieve our service ticket for the target domains KRBTGT from our DC
             Console.WriteLine("[*] Retrieving referral TGT from {0} for foreign domain, {1}, KRBTGT service", domain, targetDomain);
-            byte[] crossBytes = Ask.TGS(userName, domain, ticket, clientKey, etype, string.Format("krbtgt/{0}", targetDomain), Interop.KERB_ETYPE.subkey_keymaterial, "", false, domainController, true);
+            byte[] crossBytes = Ask.TGS(userName, domain, ticket, clientKey, etype, $"krbtgt/{targetDomain}", Interop.KERB_ETYPE.subkey_keymaterial, "", false, domainController, true);
             KRB_CRED crossTGS = new KRB_CRED(crossBytes);
             Interop.KERB_ETYPE crossEtype = (Interop.KERB_ETYPE)crossTGS.enc_part.ticket_info[0].key.keytype;
             byte[] crossKey = crossTGS.enc_part.ticket_info[0].key.keyvalue;

--- a/Rubeus/lib/S4U.cs
+++ b/Rubeus/lib/S4U.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.IO;
-using System.Linq;
 using System.Net;
-using System.Collections.Generic;
 using Asn1;
 using Rubeus.lib.Interop;
 

--- a/Rubeus/lib/S4U.cs
+++ b/Rubeus/lib/S4U.cs
@@ -305,7 +305,7 @@ namespace Rubeus
 
                         Console.WriteLine("[*] base64(ticket.kirbi) for SPN '{0}/{1}':\r\n", altSname, serverName);
 
-                        if (Rubeus.Program.wrapTickets)
+                        if (Program.wrapTickets)
                         {
                             // display the .kirbi base64, columns of 80 chararacters
                             foreach (string line in Helpers.Split(kirbiString, 80))
@@ -394,7 +394,7 @@ namespace Rubeus
 
                     Console.WriteLine("[*] base64(ticket.kirbi) for SPN '{0}':\r\n", targetSPN);
 
-                    if (Rubeus.Program.wrapTickets)
+                    if (Program.wrapTickets)
                     {
                         // display the .kirbi base64, columns of 80 chararacters
                         foreach (string line in Helpers.Split(kirbiString, 80))
@@ -574,7 +574,7 @@ namespace Rubeus
                 Console.WriteLine("[*] Got a TGS for '{0}' to '{1}@{2}'", info.pname.name_string[0], info.sname.name_string[0], info.srealm);
                 Console.WriteLine("[*] base64(ticket.kirbi):\r\n");
 
-                if (Rubeus.Program.wrapTickets)
+                if (Program.wrapTickets)
                 {
                     // display the .kirbi base64, columns of 80 chararacters
                     foreach (string line in Helpers.Split(kirbiString, 80))
@@ -918,7 +918,7 @@ namespace Rubeus
 
                 Console.WriteLine("[*] base64(ticket.kirbi) for SPN '{0}':\r\n", targetSPN);
 
-                if (Rubeus.Program.wrapTickets)
+                if (Program.wrapTickets)
                 {
                     // display the .kirbi base64, columns of 80 chararacters
                     foreach (string line in Helpers.Split(kirbiString, 80))
@@ -963,7 +963,7 @@ namespace Rubeus
 
             Console.WriteLine("[*] {0}:\r\n", message);
 
-            if (Rubeus.Program.wrapTickets)
+            if (Program.wrapTickets)
             {
                 // display the .kirbi base64, columns of 80 chararacters
                 foreach (string line in Helpers.Split(kirbiString, 80))

--- a/Rubeus/lib/crypto/SafeNativeMethods.cs
+++ b/Rubeus/lib/crypto/SafeNativeMethods.cs
@@ -20,17 +20,17 @@ internal static class SafeNativeMethods {
             var pinBuffer = Encoding.ASCII.GetBytes(pin);
 
             // provider handle is implicitly released when the certificate handle is released.
-            SafeNativeMethods.Execute(() => SafeNativeMethods.CryptAcquireContext(ref providerHandle,
+            Execute(() => CryptAcquireContext(ref providerHandle,
                                             rsaCsp.CspKeyContainerInfo.KeyContainerName,
                                             rsaCsp.CspKeyContainerInfo.ProviderName,
                                             rsaCsp.CspKeyContainerInfo.ProviderType,
-                                            SafeNativeMethods.CryptContextFlags.Silent));
-            SafeNativeMethods.Execute(() => SafeNativeMethods.CryptSetProvParam(providerHandle,
-                                            SafeNativeMethods.CryptParameter.KeyExchangePin,
+                                            CryptContextFlags.Silent));
+            Execute(() => CryptSetProvParam(providerHandle,
+                                            CryptParameter.KeyExchangePin,
                                             pinBuffer, 0));
-            SafeNativeMethods.Execute(() => SafeNativeMethods.CertSetCertificateContextProperty(
+            Execute(() => CertSetCertificateContextProperty(
                                             certificate.Handle,
-                                            SafeNativeMethods.CertificateProperty.CryptoProviderHandle,
+                                            CertificateProperty.CryptoProviderHandle,
                                             0, providerHandle));
         }
         /* Only available in .NET 4.6+

--- a/Rubeus/lib/crypto/dh/DiffieHellmanKey.cs
+++ b/Rubeus/lib/crypto/dh/DiffieHellmanKey.cs
@@ -36,7 +36,7 @@ namespace Kerberos.NET.Crypto
 
         public byte[] EncodePublicKey()            
         {
-            return AsnElt.MakeInteger(this.PublicComponent).Encode();
+            return AsnElt.MakeInteger(PublicComponent).Encode();
         }
 
         public static DiffieHellmanKey ParsePublicKey(byte[] data, int keyLength)

--- a/Rubeus/lib/crypto/dh/ManagedDiffieHellman.cs
+++ b/Rubeus/lib/crypto/dh/ManagedDiffieHellman.cs
@@ -54,34 +54,34 @@ namespace Kerberos.NET.Crypto {
 
         public ManagedDiffieHellman(byte[] prime, byte[] generator, byte[] factor)
         {
-            this.keyLength = prime.Length;
+            keyLength = prime.Length;
 
             this.prime = ParseBigInteger(prime);
             this.generator = ParseBigInteger(generator);
             this.factor = ParseBigInteger(factor);
 
-            this.x = this.GeneratePrime();
+            x = GeneratePrime();
 
-            this.y = this.generator.ModPow(this.x, this.prime);
+            y = this.generator.ModPow(x, this.prime);
 
-            this.PublicKey = new DiffieHellmanKey
+            PublicKey = new DiffieHellmanKey
             {
                 Type = AsymmetricKeyType.Public,
-                Generator = this.Depad(this.generator.GetBytes()),
-                Modulus = this.Depad(this.prime.GetBytes()),
-                PublicComponent = this.Depad(this.y.GetBytes()),
-                Factor = this.Depad(this.factor.GetBytes()),
+                Generator = Depad(this.generator.GetBytes()),
+                Modulus = Depad(this.prime.GetBytes()),
+                PublicComponent = Depad(y.GetBytes()),
+                Factor = Depad(this.factor.GetBytes()),
                 KeyLength = prime.Length
             };
 
-            this.PrivateKey = new DiffieHellmanKey
+            PrivateKey = new DiffieHellmanKey
             {
                 Type = AsymmetricKeyType.Private,
-                Generator = this.Depad(this.generator.GetBytes()),
-                Modulus = this.Depad(this.prime.GetBytes()),
-                PublicComponent = this.Depad(this.y.GetBytes()),
-                Factor = this.Depad(this.factor.GetBytes()),
-                PrivateComponent = this.Depad(this.x.GetBytes()),
+                Generator = Depad(this.generator.GetBytes()),
+                Modulus = Depad(this.prime.GetBytes()),
+                PublicComponent = Depad(y.GetBytes()),
+                Factor = Depad(this.factor.GetBytes()),
+                PrivateComponent = Depad(x.GetBytes()),
                 KeyLength = prime.Length
             };
         }
@@ -95,7 +95,7 @@ namespace Kerberos.NET.Crypto {
             // P in RSA is a safer prime than primes used in DH so it's
             // good enough here, though it's costlier to generate.
 
-            using (var alg = new RSACryptoServiceProvider(this.keyLength * 2 * 8))
+            using (var alg = new RSACryptoServiceProvider(keyLength * 2 * 8))
             {
                 var rsa = alg.ExportParameters(true);
 
@@ -125,13 +125,13 @@ namespace Kerberos.NET.Crypto {
 
         public byte[] GenerateAgreement()
         {
-            var z = this.partnerKey.ModPow(this.x, this.prime);
+            var z = partnerKey.ModPow(x, prime);
 
             var ag = z.GetBytes().ToArray();
 
-            var agreement = this.Depad(ag);
+            var agreement = Depad(ag);
 
-            agreement = Pad(agreement, this.keyLength);
+            agreement = Pad(agreement, keyLength);
 
             return agreement;
         }
@@ -143,7 +143,7 @@ namespace Kerberos.NET.Crypto {
                 throw new ArgumentNullException(nameof(publicKey));
             }
 
-            this.partnerKey = ParseBigInteger(publicKey.PublicComponent);
+            partnerKey = ParseBigInteger(publicKey.PublicComponent);
         }
 
         private byte[] Depad(byte[] data)
@@ -151,7 +151,7 @@ namespace Kerberos.NET.Crypto {
             int leadingZeros;
 
             for(leadingZeros = 0; leadingZeros < data.Length; ++leadingZeros) {                
-                if(!(data[leadingZeros] == 0 && data.Length > this.keyLength)) {
+                if(!(data[leadingZeros] == 0 && data.Length > keyLength)) {
                     break;
                 }
             }
@@ -174,15 +174,15 @@ namespace Kerberos.NET.Crypto {
 
         protected virtual void Dispose(bool disposing)
         {
-            if (!this.disposedValue)
+            if (!disposedValue)
             {
-                this.disposedValue = true;
+                disposedValue = true;
             }
         }
 
         public void Dispose()
         {
-            this.Dispose(disposing: true);
+            Dispose(disposing: true);
             GC.SuppressFinalize(this);
         }
     }

--- a/Rubeus/lib/crypto/dh/Oakley.cs
+++ b/Rubeus/lib/crypto/dh/Oakley.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // -----------------------------------------------------------------------
 
-using System;
-
 namespace Kerberos.NET.Crypto
 {
     public static class Oakley

--- a/Rubeus/lib/krb_structures/ADIfRelevant.cs
+++ b/Rubeus/lib/krb_structures/ADIfRelevant.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Asn1;
 
 namespace Rubeus

--- a/Rubeus/lib/krb_structures/ADWin2KPac.cs
+++ b/Rubeus/lib/krb_structures/ADWin2KPac.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Asn1;
+﻿using Asn1;
 using Rubeus.Kerberos;
 
 namespace Rubeus

--- a/Rubeus/lib/krb_structures/AP_REQ.cs
+++ b/Rubeus/lib/krb_structures/AP_REQ.cs
@@ -1,7 +1,5 @@
 ﻿using Asn1;
 using System;
-using System.Collections.Generic;
-using System.IO;
 
 namespace Rubeus
 {

--- a/Rubeus/lib/krb_structures/AS_REP.cs
+++ b/Rubeus/lib/krb_structures/AS_REP.cs
@@ -1,5 +1,4 @@
 ﻿using Asn1;
-using System;
 using System.Collections.Generic;
 using System.Text;
 

--- a/Rubeus/lib/krb_structures/AS_REP.cs
+++ b/Rubeus/lib/krb_structures/AS_REP.cs
@@ -26,12 +26,12 @@ namespace Rubeus
             //  false == ignore trailing garbage
             AsnElt asn_AS_REP = AsnElt.Decode(data, false);
 
-            this.Decode(asn_AS_REP);
+            Decode(asn_AS_REP);
         }
 
         public AS_REP(AsnElt asn_AS_REP)
         {
-            this.Decode(asn_AS_REP);
+            Decode(asn_AS_REP);
         }
 
         private void Decode(AsnElt asn_AS_REP)

--- a/Rubeus/lib/krb_structures/AS_REQ.cs
+++ b/Rubeus/lib/krb_structures/AS_REQ.cs
@@ -1,7 +1,6 @@
 ﻿using Asn1;
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Net;
 using System.Security.Cryptography.X509Certificates;
 

--- a/Rubeus/lib/krb_structures/AS_REQ.cs
+++ b/Rubeus/lib/krb_structures/AS_REQ.cs
@@ -205,12 +205,12 @@ namespace Rubeus
             //  SEQUENCE
             if (asn_AS_REQ.TagValue != (int)Interop.KERB_MESSAGE_TYPE.AS_REQ)
             {
-                throw new System.Exception("AS-REQ tag value should be 10");
+                throw new Exception("AS-REQ tag value should be 10");
             }
 
             if ((asn_AS_REQ.Sub.Length != 1) || (asn_AS_REQ.Sub[0].TagValue != 16))
             {
-                throw new System.Exception("First AS-REQ sub should be a sequence");
+                throw new Exception("First AS-REQ sub should be a sequence");
             }
 
             // extract the KDC-REP out
@@ -238,7 +238,7 @@ namespace Rubeus
                         req_body = new KDCReqBody(s.Sub[0]);
                         break;
                     default:
-                        throw new System.Exception($"Invalid tag AS-REQ value : {s.TagValue}");
+                        throw new Exception($"Invalid tag AS-REQ value : {s.TagValue}");
                 }
             }
         }

--- a/Rubeus/lib/krb_structures/AS_REQ.cs
+++ b/Rubeus/lib/krb_structures/AS_REQ.cs
@@ -238,7 +238,7 @@ namespace Rubeus
                         req_body = new KDCReqBody(s.Sub[0]);
                         break;
                     default:
-                        throw new System.Exception(String.Format("Invalid tag AS-REQ value : {0}", s.TagValue));
+                        throw new System.Exception($"Invalid tag AS-REQ value : {s.TagValue}");
                 }
             }
         }

--- a/Rubeus/lib/krb_structures/Authenticator.cs
+++ b/Rubeus/lib/krb_structures/Authenticator.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Asn1;
-using System.Text;
 using System.Collections.Generic;
 
 namespace Rubeus

--- a/Rubeus/lib/krb_structures/AuthorizationData.cs
+++ b/Rubeus/lib/krb_structures/AuthorizationData.cs
@@ -1,7 +1,4 @@
 ﻿using Asn1;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Rubeus
 {

--- a/Rubeus/lib/krb_structures/Checksum.cs
+++ b/Rubeus/lib/krb_structures/Checksum.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using Asn1;
-using System.Text;
-using System.Collections.Generic;
 
 namespace Rubeus
 {

--- a/Rubeus/lib/krb_structures/ETYPE_INFO2_ENTRY.cs
+++ b/Rubeus/lib/krb_structures/ETYPE_INFO2_ENTRY.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using Asn1;
 

--- a/Rubeus/lib/krb_structures/EncKDCRepPart.cs
+++ b/Rubeus/lib/krb_structures/EncKDCRepPart.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using Asn1;
 using System.Text;
-using System.Collections.Generic;
 
 namespace Rubeus
 {

--- a/Rubeus/lib/krb_structures/EncKrbCredPart.cs
+++ b/Rubeus/lib/krb_structures/EncKrbCredPart.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Asn1;
+﻿using Asn1;
 using System.Collections.Generic;
 
 namespace Rubeus

--- a/Rubeus/lib/krb_structures/EncKrbPrivPart.cs
+++ b/Rubeus/lib/krb_structures/EncKrbPrivPart.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using Asn1;
-using System.Collections.Generic;
 using System.Text;
-using System.IO;
 
 namespace Rubeus
 {

--- a/Rubeus/lib/krb_structures/EncryptedData.cs
+++ b/Rubeus/lib/krb_structures/EncryptedData.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using Asn1;
-using System.Text;
-using System.Collections.Generic;
 
 namespace Rubeus
 {

--- a/Rubeus/lib/krb_structures/EncryptionKey.cs
+++ b/Rubeus/lib/krb_structures/EncryptionKey.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using Asn1;
-using System.Text;
-using System.Collections.Generic;
 
 namespace Rubeus
 {

--- a/Rubeus/lib/krb_structures/HostAddress.cs
+++ b/Rubeus/lib/krb_structures/HostAddress.cs
@@ -1,6 +1,5 @@
 ﻿using Asn1;
 using System;
-using System.Collections.Generic;
 using System.Text;
 
 namespace Rubeus

--- a/Rubeus/lib/krb_structures/KERB_PA_PAC_REQUEST.cs
+++ b/Rubeus/lib/krb_structures/KERB_PA_PAC_REQUEST.cs
@@ -1,6 +1,4 @@
 ﻿using Asn1;
-using System;
-using System.Text;
 
 namespace Rubeus
 {

--- a/Rubeus/lib/krb_structures/KRB_CRED.cs
+++ b/Rubeus/lib/krb_structures/KRB_CRED.cs
@@ -28,12 +28,12 @@ namespace Rubeus
         {
             RawBytes = bytes;
             AsnElt asn_KRB_CRED = AsnElt.Decode(bytes, false);
-            this.Decode(asn_KRB_CRED.Sub[0]);
+            Decode(asn_KRB_CRED.Sub[0]);
         }
 
         public KRB_CRED(AsnElt body)
         {
-            this.Decode(body);
+            Decode(body);
         }
 
         public void Decode(AsnElt body)

--- a/Rubeus/lib/krb_structures/KRB_PRIV.cs
+++ b/Rubeus/lib/krb_structures/KRB_PRIV.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using Asn1;
-using System.Collections.Generic;
+﻿using Asn1;
 
 namespace Rubeus
 {

--- a/Rubeus/lib/krb_structures/LastReq.cs
+++ b/Rubeus/lib/krb_structures/LastReq.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using Asn1;
-using System.Text;
-using System.Collections.Generic;
 
 namespace Rubeus
 {

--- a/Rubeus/lib/krb_structures/PA_ENC_TS_ENC.cs
+++ b/Rubeus/lib/krb_structures/PA_ENC_TS_ENC.cs
@@ -1,6 +1,5 @@
 ﻿using Asn1;
 using System;
-using System.Text;
 
 namespace Rubeus
 {

--- a/Rubeus/lib/krb_structures/PA_PAC_OPTIONS.cs
+++ b/Rubeus/lib/krb_structures/PA_PAC_OPTIONS.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Collections.Generic;
 using Asn1;
 
 namespace Rubeus

--- a/Rubeus/lib/krb_structures/PA_S4U_X509_USER.cs
+++ b/Rubeus/lib/krb_structures/PA_S4U_X509_USER.cs
@@ -1,7 +1,4 @@
 ﻿using Asn1;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Rubeus
 {

--- a/Rubeus/lib/krb_structures/PrincipalName.cs
+++ b/Rubeus/lib/krb_structures/PrincipalName.cs
@@ -1,5 +1,4 @@
 ﻿using Asn1;
-using System;
 using System.Collections.Generic;
 using System.Text;
 

--- a/Rubeus/lib/krb_structures/S4UUserID.cs
+++ b/Rubeus/lib/krb_structures/S4UUserID.cs
@@ -1,7 +1,6 @@
 ﻿using Asn1;
 using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace Rubeus
 {

--- a/Rubeus/lib/krb_structures/TGS_REP.cs
+++ b/Rubeus/lib/krb_structures/TGS_REP.cs
@@ -1,5 +1,4 @@
 ﻿using Asn1;
-using System;
 using System.Text;
 
 namespace Rubeus

--- a/Rubeus/lib/krb_structures/TGS_REP.cs
+++ b/Rubeus/lib/krb_structures/TGS_REP.cs
@@ -25,12 +25,12 @@ namespace Rubeus
             //  false == ignore trailing garbage
             AsnElt asn_TGS_REP = AsnElt.Decode(data, false);
 
-            this.Decode(asn_TGS_REP);
+            Decode(asn_TGS_REP);
         }
 
         public TGS_REP(AsnElt asn_TGS_REP)
         {
-            this.Decode(asn_TGS_REP);
+            Decode(asn_TGS_REP);
         }
 
         private void Decode(AsnElt asn_TGS_REP)

--- a/Rubeus/lib/krb_structures/TGS_REQ.cs
+++ b/Rubeus/lib/krb_structures/TGS_REQ.cs
@@ -1,7 +1,6 @@
 ﻿using Asn1;
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Net;
 
 namespace Rubeus

--- a/Rubeus/lib/krb_structures/Ticket.cs
+++ b/Rubeus/lib/krb_structures/Ticket.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using Asn1;
 using System.Text;
-using System.Collections.Generic;
-using Rubeus.Kerberos;
 
 namespace Rubeus
 {

--- a/Rubeus/lib/krb_structures/TransitedEncoding.cs
+++ b/Rubeus/lib/krb_structures/TransitedEncoding.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using Asn1;
-using System.Text;
-using System.Collections.Generic;
+﻿using Asn1;
 
 namespace Rubeus
 {

--- a/Rubeus/lib/krb_structures/pac/Attributes.cs
+++ b/Rubeus/lib/krb_structures/pac/Attributes.cs
@@ -11,7 +11,7 @@ namespace Rubeus.Kerberos.PAC
 
         public Attributes(PacInfoBufferType type)
         {
-            this.Type = type;
+            Type = type;
         }
 
         public Attributes()

--- a/Rubeus/lib/krb_structures/pac/Attributes.cs
+++ b/Rubeus/lib/krb_structures/pac/Attributes.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 
 namespace Rubeus.Kerberos.PAC
 {

--- a/Rubeus/lib/krb_structures/pac/ClientName.cs
+++ b/Rubeus/lib/krb_structures/pac/ClientName.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Text;
 
 namespace Rubeus.Kerberos.PAC {

--- a/Rubeus/lib/krb_structures/pac/LogonInfo.cs
+++ b/Rubeus/lib/krb_structures/pac/LogonInfo.cs
@@ -1,8 +1,5 @@
 ﻿using Rubeus.Ndr.Marshal;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using Rubeus.Ndr;
 
 namespace Rubeus.Kerberos.PAC {

--- a/Rubeus/lib/krb_structures/pac/PACTYPE.cs
+++ b/Rubeus/lib/krb_structures/pac/PACTYPE.cs
@@ -1,10 +1,6 @@
 ﻿using Rubeus.Kerberos.PAC;
-using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Runtime.InteropServices;
-using System.Text;
 
 namespace Rubeus.Kerberos {
 

--- a/Rubeus/lib/krb_structures/pac/PacCredentialInfo.cs
+++ b/Rubeus/lib/krb_structures/pac/PacCredentialInfo.cs
@@ -1,10 +1,7 @@
 ﻿using Rubeus.Ndr.Marshal;
 using Rubeus.Ndr;
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
 
 namespace Rubeus.Kerberos.PAC {
     class PacCredentialInfo : PacInfoBuffer {

--- a/Rubeus/lib/krb_structures/pac/PacInfoBuffer.cs
+++ b/Rubeus/lib/krb_structures/pac/PacInfoBuffer.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
+﻿using System.IO;
 
 namespace Rubeus.Kerberos.PAC {
 

--- a/Rubeus/lib/krb_structures/pac/Requestor.cs
+++ b/Rubeus/lib/krb_structures/pac/Requestor.cs
@@ -9,7 +9,7 @@ namespace Rubeus.Kerberos.PAC
 
         public Requestor(PacInfoBufferType type)
         {
-            this.Type = type;
+            Type = type;
         }
 
         public Requestor(SecurityIdentifier sid)

--- a/Rubeus/lib/krb_structures/pac/S4UDelegationInfo.cs
+++ b/Rubeus/lib/krb_structures/pac/S4UDelegationInfo.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
 using Rubeus.Ndr;
 using Rubeus.Ndr.Marshal;
 

--- a/Rubeus/lib/krb_structures/pac/SignatureData.cs
+++ b/Rubeus/lib/krb_structures/pac/SignatureData.cs
@@ -9,7 +9,7 @@ namespace Rubeus.Kerberos.PAC {
 
         public SignatureData(PacInfoBufferType type)
         {
-            this.Type = type;
+            Type = type;
         }
         
         public SignatureData(byte[] data, PacInfoBufferType type) : base(data, type) {

--- a/Rubeus/lib/krb_structures/pac/SignatureData.cs
+++ b/Rubeus/lib/krb_structures/pac/SignatureData.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
+﻿using System.IO;
 
 namespace Rubeus.Kerberos.PAC {
 

--- a/Rubeus/lib/krb_structures/pac/UpnDns.cs
+++ b/Rubeus/lib/krb_structures/pac/UpnDns.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
+﻿using System.IO;
 using System.Text;
 
 namespace Rubeus.Kerberos.PAC {

--- a/Rubeus/lib/math/BigInteger.cs
+++ b/Rubeus/lib/math/BigInteger.cs
@@ -170,27 +170,27 @@ namespace Mono.Math {
 
 		public BigInteger() {
 			data = new uint[DEFAULT_LEN];
-			this.length = DEFAULT_LEN;
+			length = DEFAULT_LEN;
 		}
 
 		public BigInteger(Sign sign, uint len) {
-			this.data = new uint[len];
-			this.length = len;
+			data = new uint[len];
+			length = len;
 		}
 
 		public BigInteger(BigInteger bi) {
-			this.data = (uint[])bi.data.Clone();
-			this.length = bi.length;
+			data = (uint[])bi.data.Clone();
+			length = bi.length;
 		}
 
 		public BigInteger(BigInteger bi, uint len) {
 
-			this.data = new uint[len];
+			data = new uint[len];
 
 			for (uint i = 0; i < bi.length; i++)
-				this.data[i] = bi.data[i];
+				data[i] = bi.data[i];
 
-			this.length = bi.length;
+			length = bi.length;
 		}
 
 		#endregion
@@ -223,7 +223,7 @@ namespace Mono.Math {
 				case 3: data[length - 1] = (uint)((inData[0] << 16) | (inData[1] << 8) | inData[2]); break;
 			}
 
-			this.Normalize();
+			Normalize();
 		}
 
 		public BigInteger(uint[] inData) {
@@ -236,7 +236,7 @@ namespace Mono.Math {
 			for (int i = (int)length - 1, j = 0; i >= 0; i--, j++)
 				data[j] = inData[i];
 
-			this.Normalize();
+			Normalize();
 		}
 
 		public BigInteger(uint ui) {
@@ -247,7 +247,7 @@ namespace Mono.Math {
 			data = new uint[2] { (uint)ul, (uint)(ul >> 32) };
 			length = 2;
 
-			this.Normalize();
+			Normalize();
 		}
 
 		public static implicit operator BigInteger(uint value) {
@@ -501,7 +501,7 @@ namespace Mono.Math {
 			if (this == 0)
 				return;
 
-			int bits = this.BitCount();
+			int bits = BitCount();
 			int dwords = bits >> 5;
 			int remBits = bits & 0x1F;
 
@@ -537,7 +537,7 @@ namespace Mono.Math {
 		#region Bitwise
 
 		public int BitCount() {
-			this.Normalize();
+			Normalize();
 
 			uint value = data[length - 1];
 			uint mask = 0x80000000;
@@ -562,7 +562,7 @@ namespace Mono.Math {
 			byte bitPos = (byte)(bitNum & 0x1F);    // get the lowest 5 bits
 
 			uint mask = (uint)1 << bitPos;
-			return ((this.data[bytePos] & mask) != 0);
+			return ((data[bytePos] & mask) != 0);
 		}
 
 		public bool TestBit(int bitNum) {
@@ -572,7 +572,7 @@ namespace Mono.Math {
 			byte bitPos = (byte)(bitNum & 0x1F);    // get the lowest 5 bits
 
 			uint mask = (uint)1 << bitPos;
-			return ((this.data[bytePos] | mask) == this.data[bytePos]);
+			return ((data[bytePos] | mask) == data[bytePos]);
 		}
 
 		public void SetBit(uint bitNum) {
@@ -586,12 +586,12 @@ namespace Mono.Math {
 		public void SetBit(uint bitNum, bool value) {
 			uint bytePos = bitNum >> 5;             // divide by 32
 
-			if (bytePos < this.length) {
+			if (bytePos < length) {
 				uint mask = (uint)1 << (int)(bitNum & 0x1F);
 				if (value)
-					this.data[bytePos] |= mask;
+					data[bytePos] |= mask;
 				else
-					this.data[bytePos] &= ~mask;
+					data[bytePos] &= ~mask;
 			}
 		}
 
@@ -739,8 +739,8 @@ namespace Mono.Math {
 		public override int GetHashCode() {
 			uint val = 0;
 
-			for (uint i = 0; i < this.length; i++)
-				val ^= this.data[i];
+			for (uint i = 0; i < length; i++)
+				val ^= data[i];
 
 			return (int)val;
 		}
@@ -800,7 +800,7 @@ namespace Mono.Math {
 					return false;
 			}
 			// the last step is to confirm the "large" prime with the SPP or Miller-Rabin test
-			return PrimalityTests.Test(this, Prime.ConfidenceFactor.Medium);
+			return PrimalityTests.Test(this, ConfidenceFactor.Medium);
 		}
 
 		#endregion
@@ -858,7 +858,7 @@ namespace Mono.Math {
 			BigInteger mod, constant;
 
 			public ModulusRing(BigInteger modulus) {
-				this.mod = modulus;
+				mod = modulus;
 
 				// calculate constant = b^ (2k) / m
 				uint i = mod.length << 1;
@@ -1751,7 +1751,7 @@ namespace Mono.Math {
 			#region BigNum
 
 			public static BigInteger[] multiByteDivide(BigInteger bi1, BigInteger bi2) {
-				if (Kernel.Compare(bi1, bi2) == Sign.Negative)
+				if (Compare(bi1, bi2) == Sign.Negative)
 					return new BigInteger[2] { 0, new BigInteger(bi1) };
 
 				bi1.Normalize(); bi2.Normalize();

--- a/Rubeus/lib/math/ConfidenceFactor.cs
+++ b/Rubeus/lib/math/ConfidenceFactor.cs
@@ -30,8 +30,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-using System;
-
 namespace Mono.Math.Prime {
 	/// <summary>
 	/// A factor of confidence.

--- a/Rubeus/lib/math/PrimeGeneratorBase.cs
+++ b/Rubeus/lib/math/PrimeGeneratorBase.cs
@@ -49,9 +49,9 @@ namespace Mono.Math.Prime.Generator {
 			}
 		}
 
-		public virtual Prime.PrimalityTest PrimalityTest {
+		public virtual PrimalityTest PrimalityTest {
 			get {
-				return new Prime.PrimalityTest(PrimalityTests.RabinMillerTest);
+				return new PrimalityTest(PrimalityTests.RabinMillerTest);
 			}
 		}
 
@@ -66,7 +66,7 @@ namespace Mono.Math.Prime.Generator {
 		/// <returns>False if bi is composite, true if it may be prime.</returns>
 		/// <remarks>The speed of this method is dependent on Confidence</remarks>
 		protected bool PostTrialDivisionTests(BigInteger bi) {
-			return PrimalityTest(bi, this.Confidence);
+			return PrimalityTest(bi, Confidence);
 		}
 
 		public abstract BigInteger GenerateNewPrime(int bits);

--- a/Rubeus/lib/math/PrimeGeneratorBase.cs
+++ b/Rubeus/lib/math/PrimeGeneratorBase.cs
@@ -30,8 +30,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-using System;
-
 namespace Mono.Math.Prime.Generator {
 
 #if INSIDE_CORLIB

--- a/Rubeus/lib/math/SequentialSearchPrimeGeneratorBase.cs
+++ b/Rubeus/lib/math/SequentialSearchPrimeGeneratorBase.cs
@@ -63,7 +63,7 @@ namespace Mono.Math.Prime.Generator {
 
 			int DivisionBound = TrialDivisionBounds;
 			uint[] SmallPrimes = BigInteger.smallPrimes;
-			PrimalityTest PostTrialDivisionTest = this.PrimalityTest;
+			PrimalityTest PostTrialDivisionTest = PrimalityTest;
 			//
 			// STEP 2. Search for primes
 			//

--- a/Rubeus/lib/math/SequentialSearchPrimeGeneratorBase.cs
+++ b/Rubeus/lib/math/SequentialSearchPrimeGeneratorBase.cs
@@ -30,8 +30,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-using System;
-
 namespace Mono.Math.Prime.Generator {
 
 #if INSIDE_CORLIB

--- a/Rubeus/lib/ndr/Ndr/Marshal/NdrMarshalBuffer.cs
+++ b/Rubeus/lib/ndr/Ndr/Marshal/NdrMarshalBuffer.cs
@@ -14,7 +14,6 @@
 
 using Rubeus.Utilities.Text;
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Text;
 

--- a/Rubeus/lib/ndr/Ndr/NdrParser.cs
+++ b/Rubeus/lib/ndr/Ndr/NdrParser.cs
@@ -17,14 +17,8 @@
 // the original author James Forshaw to be used under the Apache License for this
 // project.
 
-using Rubeus.Utilities.Memory;
-using Rubeus.Win32;
 //using NtApiDotNet.Win32.Debugger;
 using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
-using System.Runtime.InteropServices;
 
 namespace Rubeus.Ndr
 {


### PR DESCRIPTION
Just a general code cleanup. Better readability and fewer allocations.
- Removed redundant usings and qualifiers
- Use string interpolation instead of string.Format(). Better readability an reduces allocations as it uses StringBuilderPool.
- A little fix for Linux portability specifically due to IndexOf using cultureaware comparisons.
- Removed a bunch of redundant return statements
- Retarget the project to a supported .NET Framework version. 4.0 went out of support in 2016, 4.6.x went out of support a week ago.