### PR TITLE
updated UpnDns PAC info buffer to support extended

### DIFF
--- a/Rubeus/lib/Interop.cs
+++ b/Rubeus/lib/Interop.cs
@@ -265,6 +265,14 @@ namespace Rubeus
             SIGN_REPLY = 0x20000000
         }
 
+        [Flags]
+        public enum UpnDnsFlags : int
+        {
+            UPN_SET = 0,
+            NO_UPN_SET = 1,
+            EXTENDED = 2
+        }
+
         // adapted from https://github.com/skelsec/minikerberos/blob/master/minikerberos/kerberoserror.py#L18-L76
         public enum KERBEROS_ERROR : UInt32
         {

--- a/Rubeus/lib/LSA.cs
+++ b/Rubeus/lib/LSA.cs
@@ -664,7 +664,9 @@ namespace Rubeus
                             Console.WriteLine("{0}  UpnDns                 :", indent);
                             Console.WriteLine("{0}    DNS Domain Name      : {1}", indent, upnDns.DnsDomainName);
                             Console.WriteLine("{0}    UPN                  : {1}", indent, upnDns.Upn);
-                            Console.WriteLine("{0}    Flags                : {1}", indent, upnDns.Flags);
+                            Console.WriteLine("{0}    Flags                : ({1}) {2}", indent, (int)upnDns.Flags, upnDns.Flags);
+                            Console.WriteLine("{0}    SamName              : {1}", indent, upnDns.SamName);
+                            Console.WriteLine("{0}    Sid                  : {1}", indent, upnDns.Sid.Value);
                         }
                         else if (pacInfoBuffer is SignatureData sigData)
                         {

--- a/Rubeus/lib/krb_structures/EncTicketPart.cs
+++ b/Rubeus/lib/krb_structures/EncTicketPart.cs
@@ -274,85 +274,61 @@ namespace Rubeus
 
         public Tuple<bool, bool, bool> ValidatePac(byte[] serviceKey, byte[] krbKey = null)
         {
-            byte[] pacBytes = null;
-            if (authorization_data != null)
+            Tuple<bool, bool, bool> ret = null;
+            PACTYPE pt = GetPac(null);
+            SignatureData oldSvcSig = new SignatureData(PacInfoBufferType.ServerChecksum);
+            SignatureData oldKdcSig = new SignatureData(PacInfoBufferType.KDCChecksum);
+
+            foreach (var pacInfoBuffer in pt.PacInfoBuffers)
             {
-                foreach (var addata in authorization_data)
+                if (pacInfoBuffer is SignatureData sigData)
                 {
-                    foreach (var ifrelevant in ((ADIfRelevant)addata).ADData)
+                    if (sigData.Type == PacInfoBufferType.ServerChecksum)
                     {
-                        if (ifrelevant is ADWin2KPac win2k_pac)
-                        {
-                            pacBytes = win2k_pac.ad_data;
-                        }
+                        oldSvcSig.Signature = sigData.Signature;
+                        oldSvcSig.SignatureType = sigData.SignatureType;
+                        sigData.Signature = new byte[sigData.Signature.Length];
+                        Array.Clear(sigData.Signature, 0, sigData.Signature.Length);
+                    }
+                    else if (sigData.Type == PacInfoBufferType.KDCChecksum)
+                    {
+                        oldKdcSig.Signature = sigData.Signature;
+                        oldKdcSig.SignatureType = sigData.SignatureType;
+                        sigData.Signature = new byte[sigData.Signature.Length];
+                        Array.Clear(sigData.Signature, 0, sigData.Signature.Length);
                     }
                 }
             }
-            if (pacBytes == null)
-            {
-                return null;
-            }
-            BinaryReader br = new BinaryReader(new MemoryStream(pacBytes));
-            int cBuffers = br.ReadInt32();
-            int Version = br.ReadInt32();
-            long offset = 0, svrOffset = 0, kdcOffset = 0;
-            Interop.KERB_CHECKSUM_ALGORITHM svrSigType = Interop.KERB_CHECKSUM_ALGORITHM.KERB_CHECKSUM_HMAC_SHA1_96_AES256;
-            Interop.KERB_CHECKSUM_ALGORITHM kdcSigType = Interop.KERB_CHECKSUM_ALGORITHM.KERB_CHECKSUM_HMAC_SHA1_96_AES256;
-            int svrLength = 12, kdcLength = 12;
-            byte[] oldSvrSig = null, oldKdcSig = null;
 
-            for (int idx = 0; idx < cBuffers; ++idx)
-            {
-
-                var type = (PacInfoBufferType)br.ReadInt32();
-                var bufferSize = br.ReadInt32();
-                offset = br.ReadInt64();
-
-                long oldPostion = br.BaseStream.Position;
-                br.BaseStream.Position = offset;
-                var pacData = br.ReadBytes(bufferSize);
-                br.BaseStream.Position = oldPostion;
-                BinaryReader brPacData = new BinaryReader(new MemoryStream(pacData));
-
-                switch (type)
-                {
-                    case PacInfoBufferType.KDCChecksum:
-                        kdcOffset = offset + 4;
-                        kdcSigType = (Interop.KERB_CHECKSUM_ALGORITHM)brPacData.ReadInt32();
-                        if (kdcSigType == Interop.KERB_CHECKSUM_ALGORITHM.KERB_CHECKSUM_HMAC_MD5)
-                        {
-                            kdcLength = 16;
-                        }
-                        oldKdcSig = brPacData.ReadBytes(kdcLength);
-                        break;
-                    case PacInfoBufferType.ServerChecksum:
-                        svrOffset = offset + 4;
-                        svrSigType = (Interop.KERB_CHECKSUM_ALGORITHM)brPacData.ReadInt32();
-                        if (svrSigType == Interop.KERB_CHECKSUM_ALGORITHM.KERB_CHECKSUM_HMAC_MD5)
-                        {
-                            svrLength = 16;
-                        }
-                        oldSvrSig = brPacData.ReadBytes(svrLength);
-                        break;
-
-                }
-            }
-
-            byte[] svrZeros = new byte[svrLength], kdcZeros = new byte[kdcLength];
-            Array.Clear(svrZeros, 0, svrLength);
-            Array.Clear(kdcZeros, 0, kdcLength);
-            Array.Copy(svrZeros, 0, pacBytes, svrOffset, svrLength);
-            Array.Copy(kdcZeros, 0, pacBytes, kdcOffset, kdcLength);
-
-            byte[] svrSig = Crypto.KerberosChecksum(serviceKey, pacBytes, svrSigType);
+            byte[] ptBytes = pt.Encode();
+            byte[] svrSig = Crypto.KerberosChecksum(serviceKey, ptBytes, oldSvcSig.SignatureType);
 
             if (krbKey == null)
             {
-                return Tuple.Create((Helpers.ByteArrayToString(oldSvrSig) == Helpers.ByteArrayToString(svrSig)), false, false);
+                ret = Tuple.Create((Helpers.ByteArrayToString(oldSvcSig.Signature) == Helpers.ByteArrayToString(svrSig)), false, false);
+            }
+            else
+            {
+                byte[] kdcSig = Crypto.KerberosChecksum(krbKey, svrSig, oldKdcSig.SignatureType);
+                ret = Tuple.Create((Helpers.ByteArrayToString(oldSvcSig.Signature) == Helpers.ByteArrayToString(svrSig)), (Helpers.ByteArrayToString(oldKdcSig.Signature) == Helpers.ByteArrayToString(kdcSig)), ValidateTicketChecksum(krbKey));
             }
 
-            byte[] kdcSig = Crypto.KerberosChecksum(krbKey, oldSvrSig, kdcSigType);
-            return Tuple.Create((Helpers.ByteArrayToString(oldSvrSig) == Helpers.ByteArrayToString(svrSig)), (Helpers.ByteArrayToString(oldKdcSig) == Helpers.ByteArrayToString(kdcSig)), ValidateTicketChecksum(krbKey));
+            foreach (var pacInfoBuffer in pt.PacInfoBuffers)
+            {
+                if (pacInfoBuffer is SignatureData sigData)
+                {
+                    if (sigData.Type == PacInfoBufferType.ServerChecksum)
+                    {
+                        sigData.Signature = oldSvcSig.Signature;
+                    }
+                    else if (sigData.Type == PacInfoBufferType.KDCChecksum)
+                    {
+                        sigData.Signature = oldKdcSig.Signature;
+                    }
+                }
+            }
+
+            return ret;
         }
 
         public byte[] CalculateTicketChecksum(byte[] krbKey, Interop.KERB_CHECKSUM_ALGORITHM krbChecksumType)

--- a/Rubeus/lib/krb_structures/KRB_ERROR.cs
+++ b/Rubeus/lib/krb_structures/KRB_ERROR.cs
@@ -80,7 +80,7 @@ namespace Rubeus
                                 e_data.Add(new PA_DATA(tmp));
                             }
                         }
-                        catch (NullReferenceException ex)
+                        catch (NullReferenceException)
                         {
                             e_data = null;
                         }


### PR DESCRIPTION
Added new SamName and SID values to UpnDns PAC info buffer and modified EncTicketPart.ValidatePac to fully decode the PAC, replace the signatures, reencode and calculate the signatures, which now works properly after fixing the UpnDns info buffer.