### PR TITLE
UserPrincipalNames and AES Authentication

### DIFF
--- a/Rubeus/Commands/Asktgt.cs
+++ b/Rubeus/Commands/Asktgt.cs
@@ -42,6 +42,12 @@ namespace Rubeus.Commands
                     domain = parts[0];
                     user = parts[1];
                 }
+                else if (arguments["/user"].Contains("@"))
+                {
+                    string[] upnParts = arguments["/user"].Split('@');
+                    domain = upnParts[1];
+                    user = upnParts[0];
+                }
                 else
                 {
                     user = arguments["/user"];

--- a/Rubeus/Commands/Asktgt.cs
+++ b/Rubeus/Commands/Asktgt.cs
@@ -84,8 +84,8 @@ namespace Rubeus.Commands
             if (arguments.ContainsKey("/password"))
             {
                 password = arguments["/password"];
-
-                string salt = String.Format("{0}{1}", domain.ToUpper(), user);
+                
+                string salt = String.Format("{0}{1}", domain.ToUpper(), user.Replace("/", ""));
 
                 // special case for computer account salts
                 if (user.EndsWith("$"))

--- a/Rubeus/lib/Ask.cs
+++ b/Rubeus/lib/Ask.cs
@@ -309,7 +309,9 @@ namespace Rubeus {
             // display          = true to display the ticket
 
             // extract out the info needed for the TGS-REQ request
-            string userName = kirbi.enc_part.ticket_info[0].pname.name_string[0];
+   
+            // Rebuild the username parts to an actual username by joining with / so it can later be reverted. May be able to just do string[] but who knows.
+            string userName = String.Join("/",kirbi.enc_part.ticket_info[0].pname.name_string);
             string domain = kirbi.enc_part.ticket_info[0].prealm;
             Ticket ticket = kirbi.tickets[0];
             byte[] clientKey = kirbi.enc_part.ticket_info[0].key.keyvalue;

--- a/Rubeus/lib/krb_structures/AS_REQ.cs
+++ b/Rubeus/lib/krb_structures/AS_REQ.cs
@@ -75,7 +75,20 @@ namespace Rubeus
             // req.padata.Add()
 
             // set the username to request a TGT for
-            req.req_body.cname.name_string.Add(userName);
+            // Windows Automatically Splits UPNs when / present
+            if (userName.Contains("/"))
+            {
+                string[] partsUsername = userName.Split('/');
+                foreach (string part in partsUsername)
+                {
+                    req.req_body.cname.name_string.Add(part);
+                }
+            }
+            else
+            {
+                req.req_body.cname.name_string.Add(userName);
+            }
+
 
             // the realm (domain) the user exists in
             req.req_body.realm = domain;

--- a/Rubeus/lib/krb_structures/TGS_REQ.cs
+++ b/Rubeus/lib/krb_structures/TGS_REQ.cs
@@ -23,6 +23,7 @@ namespace Rubeus
         public static byte[] NewTGSReq(string userName, string domain, string sname, Ticket providedTicket, byte[] clientKey, Interop.KERB_ETYPE paEType, Interop.KERB_ETYPE requestEType = Interop.KERB_ETYPE.subkey_keymaterial, bool renew = false, string s4uUser = "", bool enterprise = false, bool roast = false, bool opsec = false, bool unconstrained = false, KRB_CRED tgs = null, string targetDomain = "", bool u2u = false)
         {
             TGS_REQ req;
+            string[] partsUsername;
             if (u2u)
                 req = new TGS_REQ(!u2u);
             else
@@ -31,7 +32,18 @@ namespace Rubeus
             if (!opsec && !u2u)
             {
                 // set the username
-                req.req_body.cname.name_string.Add(userName);
+                if (userName.Contains("/"))
+                {
+                    partsUsername = userName.Split('/');
+                    foreach (string part in partsUsername)
+                    {
+                        req.req_body.cname.name_string.Add(part);
+                    }
+                }
+                else
+                {
+                    req.req_body.cname.name_string.Add(userName);
+                }
             }
 
             // get domain from service for cross domain requests

--- a/Rubeus/lib/krb_structures/TGS_REQ.cs
+++ b/Rubeus/lib/krb_structures/TGS_REQ.cs
@@ -53,15 +53,18 @@ namespace Rubeus
             {
                 if (!(roast) && (parts.Length > 1) && (parts[0] != "krbtgt") && (tgs == null) && parts[0] != "kadmin")
                 {
-                    if (parts[1].Split('.').Length > 2)
+                    if (parts[1].Contains("."))
                     {
-                        targetDomain = parts[1].Substring(parts[1].IndexOf('.') + 1);
-
-                        // remove port when SPN is in format 'svc/domain.com:1234'
-                        string[] targetParts = targetDomain.Split(':');
-                        if (targetParts.Length > 1)
+                        if (parts[1].Split('.').Length > 2)
                         {
-                            targetDomain = targetParts[0];
+                            targetDomain = parts[1].Substring(parts[1].IndexOf('.') + 1);
+
+                            // remove port when SPN is in format 'svc/domain.com:1234'
+                            string[] targetParts = targetDomain.Split(':');
+                            if (targetParts.Length > 1)
+                            {
+                                targetDomain = targetParts[0];
+                            }
                         }
                     }
                     if (String.IsNullOrEmpty(targetDomain))
@@ -211,7 +214,15 @@ namespace Rubeus
                 string targetHostName;
                 if (parts.Length > 1)
                 {
-                    targetHostName = parts[1].Substring(0, parts[1].IndexOf('.')).ToUpper();
+                    if (parts[1].Contains("."))
+                    {
+                        targetHostName = parts[1].Substring(0, parts[1].IndexOf('.')).ToUpper();
+                    }
+                    else
+                    {
+                        targetHostName = parts[1].ToUpper();
+                    }
+                 
                 }
                 else
                 {


### PR DESCRIPTION
I happened across some weirdness with UserPrincipalNames, especially ones which contain a forward slash, and AES authentication with UserPrincipalNames and thought I would try and implement the findings in asktgt and asktgs as it may save someone a couple of hours of debugging in the future.

Here are some notes from research on this as well as what this PR will help with:
* If a userPrincipalName (full with @) is used in AskTGT the left hand side is used for username and right hand side is used as domain
* When using a UserPrincipalName with a forward slash there is some different behavior that occurs:
    *  The cname-string is an array split by the forward slash
    * The password salt does not include the forward slash
    * When using /opsec the name is normalized to DOMAIN\SAMACCOUNTNAME in the AS_REP but when not using /opsec. I think its the hostname that does this, I believe the KDC looks up the account in AD and if Windows will 'upgrade' the ticket but I have not fully tested this theory. 
    * When not using /opsec with a name with a forward slash the name is returned in the cname-string array, TGS_REQ in rubeus was using cname-string[0] which resulted in bad match errors as the username was only half complete.
* Fixed TGS_REQ with /opsec using a short SPN such as "cifs/DC", prior to this only SPNs with FQDN would would with /opsec I believe.


This PR does result in the userName at [this line](https://github.com/GhostPack/Rubeus/blob/a818fd000d80df97d55490c1fdb0d4ff0a6d816e/Rubeus/lib/LSA.cs#L533) being incorrect when using a UserPrincipalName with a forward / that has been split. I was unsure what the specifics were across different kerberos scenarios here so seeking advise on what to do on this display of username.