### PR TITLE
fix for parsing RODC EncryptedData kvno and display RODC number using…

### DIFF
--- a/Rubeus/lib/LSA.cs
+++ b/Rubeus/lib/LSA.cs
@@ -582,6 +582,13 @@ namespace Rubeus
                 if (asrepKey != null)
                     Console.WriteLine("{0}ASREP (key)              :  {1}", indent, Helpers.ByteArrayToString(asrepKey));
 
+                // Display RODC number, for when a TGT is requested from an RODC
+                if (cred.tickets[0].enc_part.kvno > 65535)
+                {
+                    uint rodcNum = cred.tickets[0].enc_part.kvno >> 16;
+                    Console.WriteLine("{0}RODC Number              :  {1}", indent, rodcNum);
+                }
+
                 if (displayB64ticket)
                 {
                     // if we're displaying the base64 encoding of the ticket

--- a/Rubeus/lib/krb_structures/EncryptedData.cs
+++ b/Rubeus/lib/krb_structures/EncryptedData.cs
@@ -41,7 +41,8 @@ namespace Rubeus
                         etype = Convert.ToInt32(s.Sub[0].GetInteger());
                         break;
                     case 1:
-                        kvno = Convert.ToUInt32(s.Sub[0].GetInteger());
+                        long tmpLong = s.Sub[0].GetInteger();
+                        kvno = Convert.ToUInt32(tmpLong & 0x00000000ffffffff);
                         break;
                     case 2:
                         cipher = s.Sub[0].GetOctetString();


### PR DESCRIPTION
… describe

Requesting a TGT from an RODC was resulting in the following exception:

```
[!] Unhandled Rubeus exception:

System.OverflowException: Value was either too large or too small for a UInt32.
   at System.Convert.ToUInt32(Int64 value)
   at Rubeus.EncryptedData..ctor(AsnElt body)
   at Rubeus.Ticket..ctor(AsnElt body)
   at Rubeus.AS_REP.Decode(AsnElt asn_AS_REP)
   at Rubeus.Ask.HandleASREP(AsnElt responseAsn, KERB_ETYPE etype, String keyString, String outfile, Boolean ptt, LUID luid, Boolean describe, Boolean verbose, AS_REQ asReq, String serviceKey, Boolean getCredentials, String dcIP)
   at Rubeus.Ask.InnerTGT(AS_REQ asReq, KERB_ETYPE etype, String outfile, Boolean ptt, String domainController, LUID luid, Boolean describe, Boolean verbose, Boolean opsec, String serviceKey, Boolean getCredentials, String proxyUrl)
   at Rubeus.Ask.TGT(String userName, String domain, String keyString, KERB_ETYPE etype, String outfile, Boolean ptt, String domainController, LUID luid, Boolean describe, Boolean opsec, String servicekey, Boolean changepw, Boolean pac, String proxyUrl, String service)
   at Rubeus.Commands.Asktgt.Execute(Dictionary`2 arguments)
   at Rubeus.Domain.CommandCollection.ExecuteCommand(String commandName, Dictionary`2 arguments)
   at Rubeus.Program.MainExecute(String commandName, Dictionary`2 parsedArgs)
```

For some reason the top 4 bytes of the `long` returned from `GetInteger()` was 0xffffffff, zero those out and it works fine.

Also added output to `describe` to show the RODC number for these tickets:

```
  RODC Number              :  59542
```