### PR TITLE
Fix for asktgt: /opsec flag is not respected when using PKINIT with /certificate

### DIFF
--- a/Rubeus/Commands/Asktgt.cs
+++ b/Rubeus/Commands/Asktgt.cs
@@ -255,8 +255,8 @@ namespace Rubeus.Commands
                 else if (String.IsNullOrEmpty(certificate))
                     Ask.TGT(user, domain, hash, encType, outfile, ptt, dc, luid, true, opsec, servicekey, changepw, pac, proxyUrl, service);
                 else
-                    // Caution: Ask.TGT is overloaded!!! This is another function implementation than the one above.
-                    Ask.TGT(user, domain, certificate, password, encType, outfile, ptt, dc, luid, true, verifyCerts, servicekey, getCredentials, proxyUrl, service, changepw);
+                    // Ask.TGT is overloaded! This is another function implementation than the one above
+                    Ask.TGT(user, domain, certificate, password, encType, outfile, ptt, dc, luid, true, opsec, verifyCerts, servicekey, getCredentials, proxyUrl, service, changepw);
 
                 return;
             }

--- a/Rubeus/Commands/Asktgt.cs
+++ b/Rubeus/Commands/Asktgt.cs
@@ -255,6 +255,7 @@ namespace Rubeus.Commands
                 else if (String.IsNullOrEmpty(certificate))
                     Ask.TGT(user, domain, hash, encType, outfile, ptt, dc, luid, true, opsec, servicekey, changepw, pac, proxyUrl, service);
                 else
+                    // Caution: Ask.TGT is overloaded!!! This is another function implementation than the one above.
                     Ask.TGT(user, domain, certificate, password, encType, outfile, ptt, dc, luid, true, verifyCerts, servicekey, getCredentials, proxyUrl, service, changepw);
 
                 return;

--- a/Rubeus/lib/krb_structures/AS_REQ.cs
+++ b/Rubeus/lib/krb_structures/AS_REQ.cs
@@ -160,6 +160,7 @@ namespace Rubeus
 
         //TODO: Insert DHKeyPair parameter also.
         public static AS_REQ NewASReq(string userName, string domain, X509Certificate2 cert, KDCKeyAgreement agreement, Interop.KERB_ETYPE etype, bool verifyCerts = false, string service = null, bool changepw = false) {
+            // TODO implement opsec flag
 
             // build a new AS-REQ for the given userName, domain, and etype, w/ PA-ENC-TIMESTAMP
             //  used for "legit" AS-REQs w/ pre-auth
@@ -247,14 +248,15 @@ namespace Rubeus
         }
 
         public AS_REQ(X509Certificate2 pkCert, KDCKeyAgreement agreement, bool verifyCerts = false) {
+            // TODO add opsec flag
 
             // default, for creation
             pvno = 5;
-            msg_type = 10;
+            msg_type = (long)Interop.KERB_MESSAGE_TYPE.AS_REQ;
 
             padata = new List<PA_DATA>();
 
-            req_body = new KDCReqBody();
+            req_body = new KDCReqBody(true, true /* TODO implement as paramter */);
 
             // add the include-pac == true
             padata.Add(new PA_DATA());

--- a/Rubeus/lib/krb_structures/AS_REQ.cs
+++ b/Rubeus/lib/krb_structures/AS_REQ.cs
@@ -62,26 +62,10 @@ namespace Rubeus
                 req.req_body.sname.name_string.Add(domain);
             }
 
-            // try to build a realistic request
             if (opsec)
-            {
-                string hostName = Dns.GetHostName();
-                List<HostAddress> addresses = new List<HostAddress>();
-                addresses.Add(new HostAddress(hostName));
-                req.req_body.addresses = addresses;
-                req.req_body.kdcOptions = req.req_body.kdcOptions | Interop.KdcOptions.CANONICALIZE;
-                req.req_body.etypes.Add(Interop.KERB_ETYPE.aes256_cts_hmac_sha1);
-                req.req_body.etypes.Add(Interop.KERB_ETYPE.aes128_cts_hmac_sha1);
-                req.req_body.etypes.Add(Interop.KERB_ETYPE.rc4_hmac);
-                req.req_body.etypes.Add(Interop.KERB_ETYPE.rc4_hmac_exp);
-                req.req_body.etypes.Add(Interop.KERB_ETYPE.old_exp);
-                req.req_body.etypes.Add(Interop.KERB_ETYPE.des_cbc_md5);
-            }
-            else
-            {
-                // add in our encryption type
+                ApplyOpsecChanges(req.req_body);
+            else // add in our encryption type
                 req.req_body.etypes.Add(etype);
-            }
 
             return req;
         }
@@ -133,26 +117,10 @@ namespace Rubeus
                 req.req_body.sname.name_string.Add("changepw");
             }
 
-            // try to build a realistic request
             if (opsec)
-            {
-                string hostName = Dns.GetHostName();
-                List<HostAddress> addresses = new List<HostAddress>();
-                addresses.Add(new HostAddress(hostName));
-                req.req_body.addresses = addresses;
-                req.req_body.kdcOptions = req.req_body.kdcOptions | Interop.KdcOptions.CANONICALIZE;
-                req.req_body.etypes.Add(Interop.KERB_ETYPE.aes256_cts_hmac_sha1);
-                req.req_body.etypes.Add(Interop.KERB_ETYPE.aes128_cts_hmac_sha1);
-                req.req_body.etypes.Add(Interop.KERB_ETYPE.rc4_hmac);
-                req.req_body.etypes.Add(Interop.KERB_ETYPE.rc4_hmac_exp);
-                req.req_body.etypes.Add(Interop.KERB_ETYPE.old_exp);
-                req.req_body.etypes.Add(Interop.KERB_ETYPE.des_cbc_md5);
-            }
-            else
-            {
-                // add in our encryption type
+                ApplyOpsecChanges(req.req_body);
+            else // add in our encryption type
                 req.req_body.etypes.Add(etype);
-            }
 
             return req; 
         }
@@ -207,26 +175,10 @@ namespace Rubeus
                 req.req_body.sname.name_string.Add("changepw");
             }
 
-            // try to build a realistic request
             if (opsec)
-            {
-                string hostName = Dns.GetHostName();
-                List<HostAddress> addresses = new List<HostAddress>();
-                addresses.Add(new HostAddress(hostName));
-                req.req_body.addresses = addresses;
-                req.req_body.kdcOptions = req.req_body.kdcOptions | Interop.KdcOptions.CANONICALIZE;
-                req.req_body.etypes.Add(Interop.KERB_ETYPE.aes256_cts_hmac_sha1);
-                req.req_body.etypes.Add(Interop.KERB_ETYPE.aes128_cts_hmac_sha1);
-                req.req_body.etypes.Add(Interop.KERB_ETYPE.rc4_hmac);
-                req.req_body.etypes.Add(Interop.KERB_ETYPE.rc4_hmac_exp);
-                req.req_body.etypes.Add(Interop.KERB_ETYPE.old_exp);
-                req.req_body.etypes.Add(Interop.KERB_ETYPE.des_cbc_md5);
-            }
-            else
-            {
-                // add in our encryption type
+                ApplyOpsecChanges(req.req_body);
+            else // add in our encryption type
                 req.req_body.etypes.Add(etype);
-            }
 
             return req;
         }
@@ -328,6 +280,25 @@ namespace Rubeus
                         throw new System.Exception(String.Format("Invalid tag AS-REQ value : {0}", s.TagValue));
                 }
             }
+        }
+        /// <summary>
+        /// Applies opsec changes in-place to an existing, initialized KDCReqBody including 
+        /// common etypes, the optional addresses field and the "canonicalize" kdc_option.
+        /// </summary>
+        /// <param name="req_body"></param>
+        private static void ApplyOpsecChanges(KDCReqBody req_body)
+        {
+            string hostName = Dns.GetHostName();
+            List<HostAddress> addresses = new List<HostAddress>();
+            addresses.Add(new HostAddress(hostName));
+            req_body.addresses = addresses;
+            req_body.kdcOptions = req_body.kdcOptions | Interop.KdcOptions.CANONICALIZE;
+            req_body.etypes.Add(Interop.KERB_ETYPE.aes256_cts_hmac_sha1);
+            req_body.etypes.Add(Interop.KERB_ETYPE.aes128_cts_hmac_sha1);
+            req_body.etypes.Add(Interop.KERB_ETYPE.rc4_hmac);
+            req_body.etypes.Add(Interop.KERB_ETYPE.rc4_hmac_exp);
+            req_body.etypes.Add(Interop.KERB_ETYPE.old_exp);
+            req_body.etypes.Add(Interop.KERB_ETYPE.des_cbc_md5);
         }
 
         public AsnElt Encode()


### PR DESCRIPTION
This MR implements the `/opsec` flag in all overloaded functions used for asktgt with PKINIT. Previously, the `/opsec` flag only had an effect when using password authentication.

This has the effect that the Defender for Identity alert "Suspicious certificate usage over Kerberos protocol (PKINIT)" will not be triggered (ref: https://techcommunity.microsoft.com/t5/microsoft-365-defender-blog/microsoft-defender-for-identity-now-detects-suspicious/ba-p/3743335).

Closes #161 