### PR TITLE
Remove Environment Exit from Harvester

### DIFF
--- a/Rubeus/lib/Harvest.cs
+++ b/Rubeus/lib/Harvest.cs
@@ -88,7 +88,8 @@ namespace Rubeus
                     if (collectionStart.AddSeconds(this.runFor) < DateTime.Now)
                     {
                         Console.WriteLine("[*] Completed running for {0} seconds, exiting\r\n", runFor);
-                        System.Environment.Exit(0);
+                        // break out of loop will exit Rubeus 
+                        break;
                     }
                 }
 


### PR DESCRIPTION
When running from something  like 'execute-assembly', Environment.Exit can be problematic.

In my code I had something like the following in place: https://www.mdsec.co.uk/2020/08/massaging-your-clr-preventing-environment-exit-in-in-process-net-assemblies/
But you can imagine that when Environment.Exit is used to break an infinite loop, this will get interesting 😄 In this case the monitor action became an infinite loop until negative time remaining gave exceptions.

There are some more uses of Environment.Exit() but they seem less problematic (need to be careful with correct parameters though).