### PR TITLE
Fix integer overflow issue when describing ticket

### DIFF
--- a/Rubeus/lib/krb_structures/KrbCredInfo.cs
+++ b/Rubeus/lib/krb_structures/KrbCredInfo.cs
@@ -52,9 +52,9 @@ namespace Rubeus
                         pname = new PrincipalName(s.Sub[0]);
                         break;
                     case 3:
-                        UInt32 temp = Convert.ToUInt32(s.Sub[0].GetInteger());
+                        UInt64 temp = Convert.ToUInt64(s.Sub[0].GetInteger());
                         byte[] tempBytes = BitConverter.GetBytes(temp);
-                        flags = (Interop.TicketFlags)BitConverter.ToInt32(tempBytes, 0);
+                        flags = (Interop.TicketFlags)BitConverter.ToInt64(tempBytes, 0);
                         break;
                     case 4:
                         authtime = s.Sub[0].GetTime();


### PR DESCRIPTION
Fix integer overflow issue when describing ticket
![image](https://github.com/GhostPack/Rubeus/assets/96878659/dd2fc045-597a-4d02-8017-173442abd8c1)
