### PR TITLE
Fix substring issue in S4U.cs

### DIFF
--- a/Rubeus/lib/S4U.cs
+++ b/Rubeus/lib/S4U.cs
@@ -158,7 +158,7 @@ namespace Rubeus
                 string targetHostName;
                 if (parts.Length > 1)
                 {
-                    targetHostName = parts[1].Substring(0, parts[1].IndexOf('.')).ToUpper();
+                    targetHostName = parts[1].Split('.')[0].ToUpper();
                 }
                 else
                 {


### PR DESCRIPTION
Fix substring issue

When using the following command `Rubeus.exe s4u /nowrap /msdsspn:HOST/target /domain:domain.local /user:computer$ /aes256:xxxx /impersonateuser:administrator`, the following error occured.

![image](https://github.com/GhostPack/Rubeus/assets/96878659/89017b8c-8cc6-4164-874b-8b57625d1bdc)

This is because the Substring is expecting a `target` string like `target.domain.local` instead of `target`. 

Fix: changed Substring to Split instead. 
 