### PR TITLE
added fix for TGS-REQ checksum and S4UUserID domain encoding

### DIFF
--- a/Rubeus/lib/Interop.cs
+++ b/Rubeus/lib/Interop.cs
@@ -17,8 +17,10 @@ namespace Rubeus
         public const int KRB_KEY_USAGE_AS_REP_TGS_REP = 2;
         public const int KRB_KEY_USAGE_AS_REP_EP_SESSION_KEY = 3;
         public const int KRB_KEY_USAGE_TGS_REQ_ENC_AUTHOIRZATION_DATA = 4;
+        public const int KRB_KEY_USAGE_TGS_REQ_CHECKSUM = 6;
         public const int KRB_KEY_USAGE_TGS_REQ_PA_AUTHENTICATOR = 7;
         public const int KRB_KEY_USAGE_TGS_REP_EP_SESSION_KEY = 8;
+        public const int KRB_KEY_USAGE_TGS_REQ_AUTHENTICATOR_CHECKSUM = 10;
         public const int KRB_KEY_USAGE_AP_REQ_AUTHENTICATOR = 11;
         public const int KRB_KEY_USAGE_KRB_PRIV_ENCRYPTED_PART = 13;
         public const int KRB_KEY_USAGE_KRB_CRED_ENCRYPTED_PART = 14;

--- a/Rubeus/lib/krb_structures/S4UUserID.cs
+++ b/Rubeus/lib/krb_structures/S4UUserID.cs
@@ -46,7 +46,7 @@ namespace Rubeus
             allNodes.Add(cnameElt);
 
             // crealm                  [2] Realm
-            AsnElt realmAsn = AsnElt.MakeString(AsnElt.IA5String, crealm);
+            AsnElt realmAsn = AsnElt.MakeString(AsnElt.UTF8String, crealm);
             realmAsn = AsnElt.MakeImplicit(AsnElt.UNIVERSAL, AsnElt.GeneralString, realmAsn);
             AsnElt realmSeq = AsnElt.Make(AsnElt.SEQUENCE, new[] { realmAsn });
             realmSeq = AsnElt.MakeImplicit(AsnElt.CONTEXT, 2, realmSeq);

--- a/Rubeus/lib/krb_structures/TGS_REQ.cs
+++ b/Rubeus/lib/krb_structures/TGS_REQ.cs
@@ -239,7 +239,8 @@ namespace Rubeus
                 AsnElt req_Body_ASNSeq = AsnElt.Make(AsnElt.SEQUENCE, new[] { req_Body_ASN });
                 req_Body_ASNSeq = AsnElt.MakeImplicit(AsnElt.CONTEXT, 4, req_Body_ASNSeq);
                 byte[] req_Body_Bytes = req_Body_ASNSeq.CopyValue();
-                cksum_Bytes = Crypto.KerberosChecksum(clientKey, req_Body_Bytes, Interop.KERB_CHECKSUM_ALGORITHM.KERB_CHECKSUM_RSA_MD5);
+                Interop.KERB_CHECKSUM_ALGORITHM checkSumType = Interop.KERB_CHECKSUM_ALGORITHM.KERB_CHECKSUM_RSA_MD5;
+                cksum_Bytes = Crypto.KerberosChecksum(clientKey, req_Body_Bytes, checkSumType, Interop.KRB_KEY_USAGE_TGS_REQ_CHECKSUM);
             }
 
             // create the PA-DATA that contains the AP-REQ w/ appropriate authenticator/etc.


### PR DESCRIPTION
TGS-REQ checksum was incorrect when using `/opsec` for `s4u` and the domain encoding for S4UUserInfo incorrectly handled unicode characters