### PR TITLE
Fix for unicode domains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.1]
+
+### Fixed
+
+* Unicode characters in domain names
+* Changed till dates within s4u /opsec requests to UTC to work on anything -UTC
+
 ## [2.2.1]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Rubeus is licensed under the BSD 3-Clause license.
       | |  \ \| |_| | |_) ) ____| |_| |___ |
       |_|   |_|____/|____/|_____)____/(___/
 
-      v2.3.0
+      v2.3.1
 
 
      Ticket requests and renewals:

--- a/Rubeus/Commands/Asktgt.cs
+++ b/Rubeus/Commands/Asktgt.cs
@@ -95,13 +95,13 @@ namespace Rubeus.Commands
                 // special case for computer account salts
                 if (user.EndsWith("$"))
                 {
-                    salt = String.Format("{0}host{1}.{2}", domain.ToUpperInvariant(), user.TrimEnd('$').ToLower(), domain.ToLower());
+                    salt = String.Format("{0}host{1}.{2}", domain.ToUpperInvariant(), user.TrimEnd('$').ToLowerInvariant(), domain.ToLowerInvariant());
                 }
 
                 // special case for samaccountname spoofing to support Kerberos AES Encryption
                 if (arguments.ContainsKey("/oldsam"))
                 {
-                    salt = String.Format("{0}host{1}.{2}", domain.ToUpperInvariant(), arguments["/oldsam"].TrimEnd('$').ToLower(), domain.ToLower());
+                    salt = String.Format("{0}host{1}.{2}", domain.ToUpperInvariant(), arguments["/oldsam"].TrimEnd('$').ToLowerInvariant(), domain.ToLowerInvariant());
 
                 }
 

--- a/Rubeus/Domain/Info.cs
+++ b/Rubeus/Domain/Info.cs
@@ -12,7 +12,7 @@ namespace Rubeus.Domain
             Console.WriteLine("  |  __  /| | | |  _ \\| ___ | | | |/___)");
             Console.WriteLine("  | |  \\ \\| |_| | |_) ) ____| |_| |___ |");
             Console.WriteLine("  |_|   |_|____/|____/|_____)____/(___/\r\n");
-            Console.WriteLine("  v2.3.0 \r\n");
+            Console.WriteLine("  v2.3.1 \r\n");
         }
 
         public static void ShowUsage()

--- a/Rubeus/Program.cs
+++ b/Rubeus/Program.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
 
 namespace Rubeus
 {
@@ -44,6 +45,9 @@ namespace Rubeus
 
             try
             {
+                // print unicode char properly
+                Console.OutputEncoding = Encoding.UTF8;
+
                 var commandFound = new CommandCollection().ExecuteCommand(commandName, parsedArgs);
 
                 // show the usage if no commands were found for the command name

--- a/Rubeus/lib/Crypto.cs
+++ b/Rubeus/lib/Crypto.cs
@@ -14,12 +14,12 @@ namespace Rubeus
 
             Console.WriteLine("[*] Input password             : {0}", password);
 
-            string salt = String.Format("{0}{1}", domainName.ToUpper(), userName);
+            string salt = String.Format("{0}{1}", domainName.ToUpperInvariant(), userName);
 
             // special case for computer account salts
             if (userName.EndsWith("$"))
             {
-                salt = String.Format("{0}host{1}.{2}", domainName.ToUpper(), userName.TrimEnd('$').ToLower(), domainName.ToLower());
+                salt = String.Format("{0}host{1}.{2}", domainName.ToUpperInvariant(), userName.TrimEnd('$').ToLowerInvariant(), domainName.ToLowerInvariant());
             }
 
             if (!String.IsNullOrEmpty(userName) && !String.IsNullOrEmpty(domainName))

--- a/Rubeus/lib/ForgeTicket.cs
+++ b/Rubeus/lib/ForgeTicket.cs
@@ -187,7 +187,7 @@ namespace Rubeus
             }
             if (String.IsNullOrEmpty(netbiosName))
             {
-                kvi.LogonDomainName = new Ndr._RPC_UNICODE_STRING(domain.Substring(0, domain.IndexOf('.')).ToUpper());
+                kvi.LogonDomainName = new Ndr._RPC_UNICODE_STRING(domain.Substring(0, domain.IndexOf('.')).ToUpperInvariant());
             }
 
             // if /ldap was passed make the LDAP queries
@@ -766,7 +766,7 @@ namespace Rubeus
 
             // output some ticket information relevent to all tickets generated
             Console.WriteLine("");
-            Console.WriteLine("[*] Domain         : {0} ({1})", domain.ToUpper(), kvi.LogonDomainName);
+            Console.WriteLine("[*] Domain         : {0} ({1})", domain.ToUpperInvariant(), kvi.LogonDomainName);
             Console.WriteLine("[*] SID            : {0}", kvi.LogonDomainId?.GetValue());
             Console.WriteLine("[*] UserId         : {0}", kvi.UserId);
             if (kvi.GroupCount > 0)
@@ -799,14 +799,14 @@ namespace Rubeus
 
                 ClientName cn = null;
                 if (parts[0].Equals("krbtgt") && !cRealm.Equals(domain))
-                    cn = new ClientName((DateTime)startTime, String.Format("{0}@{1}@{1}", user, domain.ToUpper()));
+                    cn = new ClientName((DateTime)startTime, String.Format("{0}@{1}@{1}", user, domain.ToUpperInvariant()));
                 else
                     cn = new ClientName((DateTime)startTime, user);
 
-                UpnDns upnDns = new UpnDns(upnFlags, domain.ToUpper(), String.Format("{0}@{1}", user, domain.ToLower()));
+                UpnDns upnDns = new UpnDns(upnFlags, domain.ToUpperInvariant(), String.Format("{0}@{1}", user, domain.ToLowerInvariant()));
                 if (extendedUpnDns)
                 {
-                    upnDns = new UpnDns(upnFlags + 2, domain.ToUpper(), String.Format("{0}@{1}", user, domain.ToLower()), user, new SecurityIdentifier(String.Format("{0}-{1}", li.KerbValidationInfo.LogonDomainId?.GetValue(), li.KerbValidationInfo.UserId)));
+                    upnDns = new UpnDns(upnFlags + 2, domain.ToUpperInvariant(), String.Format("{0}@{1}", user, domain.ToLowerInvariant()), user, new SecurityIdentifier(String.Format("{0}-{1}", li.KerbValidationInfo.LogonDomainId?.GetValue(), li.KerbValidationInfo.UserId)));
                 }
 
                 S4UDelegationInfo s4u = null;
@@ -817,7 +817,7 @@ namespace Rubeus
 
                 Console.WriteLine("[*] Generating EncTicketPart");
 
-                EncTicketPart decTicketPart = new EncTicketPart(randKeyBytes, etype, cRealm.ToUpper(), cName, flags, cn.ClientId);
+                EncTicketPart decTicketPart = new EncTicketPart(randKeyBytes, etype, cRealm.ToUpperInvariant(), cName, flags, cn.ClientId);
 
                 // set other times in EncTicketPart
                 DateTime? check = null;
@@ -971,7 +971,7 @@ namespace Rubeus
 
                 // initialize the ticket and add the enc_part
                 Console.WriteLine("[*] Generating Ticket");
-                Ticket ticket = new Ticket(domain.ToUpper(), sname);
+                Ticket ticket = new Ticket(domain.ToUpperInvariant(), sname);
                 // when performing keylist attack the kvnum is shifted left 16 bits
                 if (rodcNumber == 0)
                 {
@@ -1345,7 +1345,7 @@ namespace Rubeus
                                 sid = new SecurityIdentifier(String.Format("{0}-{1}", sid.Value.Substring(0, sid.Value.LastIndexOf('-')), ticketUserId));
                             }
                         }
-                        upnDns = new UpnDns((int)upnDns.Flags,upnDns.DnsDomainName,string.Format("{0}@{1}", ticketUser, upnDns.DnsDomainName.ToLower()), samName, sid);
+                        upnDns = new UpnDns((int)upnDns.Flags,upnDns.DnsDomainName,string.Format("{0}@{1}", ticketUser, upnDns.DnsDomainName.ToLowerInvariant()), samName, sid);
 
                     }
                 }

--- a/Rubeus/lib/S4U.cs
+++ b/Rubeus/lib/S4U.cs
@@ -146,7 +146,7 @@ namespace Rubeus
 
                 // 15 minutes in the future like genuine requests
                 DateTime till = DateTime.Now;
-                till = till.AddMinutes(15);
+                till = till.AddMinutes(15).ToUniversalTime();
                 s4u2proxyReq.req_body.till = till;
 
                 // extra etypes
@@ -154,11 +154,11 @@ namespace Rubeus
                 s4u2proxyReq.req_body.etypes.Add(Interop.KERB_ETYPE.old_exp);
 
                 // get hostname and hostname of SPN
-                string hostName = Dns.GetHostName().ToUpper();
+                string hostName = Dns.GetHostName().ToUpperInvariant();
                 string targetHostName;
                 if (parts.Length > 1)
                 {
-                    targetHostName = parts[1].Split('.')[0].ToUpper();
+                    targetHostName = parts[1].Split('.')[0].ToUpperInvariant();
                 }
                 else
                 {

--- a/Rubeus/lib/krb_structures/AS_REP.cs
+++ b/Rubeus/lib/krb_structures/AS_REP.cs
@@ -69,7 +69,7 @@ namespace Rubeus
                         }                                                   
                         break;
                     case 3:
-                        crealm = Encoding.ASCII.GetString(s.Sub[0].GetOctetString());
+                        crealm = Encoding.UTF8.GetString(s.Sub[0].GetOctetString());
                         break;
                     case 4:
                         cname = new PrincipalName(s.Sub[0]);

--- a/Rubeus/lib/krb_structures/ETYPE_INFO2_ENTRY.cs
+++ b/Rubeus/lib/krb_structures/ETYPE_INFO2_ENTRY.cs
@@ -26,7 +26,7 @@ namespace Rubeus
                         etype = Convert.ToInt32(s.Sub[0].GetInteger());
                         break;
                     case 1:
-                        salt = Encoding.ASCII.GetString(s.Sub[0].GetOctetString());
+                        salt = Encoding.UTF8.GetString(s.Sub[0].GetOctetString());
                         break;
                     default:
                         break;

--- a/Rubeus/lib/krb_structures/EncKDCRepPart.cs
+++ b/Rubeus/lib/krb_structures/EncKDCRepPart.cs
@@ -59,7 +59,7 @@ namespace Rubeus
                         renew_till = s.Sub[0].GetTime();
                         break;
                     case 9:
-                        realm = Encoding.ASCII.GetString(s.Sub[0].GetOctetString());
+                        realm = Encoding.UTF8.GetString(s.Sub[0].GetOctetString());
                         break;
                     case 10:
                         // sname (optional)

--- a/Rubeus/lib/krb_structures/EncKrbPrivPart.cs
+++ b/Rubeus/lib/krb_structures/EncKrbPrivPart.cs
@@ -74,7 +74,7 @@ namespace Rubeus
             AsnElt hostAddressTypeSeq = AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] { hostAddressTypeAsn });
             hostAddressTypeSeq = AsnElt.MakeImplicit(AsnElt.CONTEXT, 0, hostAddressTypeSeq);
 
-            byte[] hostAddressAddressBytes = Encoding.ASCII.GetBytes(host_name);
+            byte[] hostAddressAddressBytes = Encoding.UTF8.GetBytes(host_name);
             AsnElt hostAddressAddressAsn = AsnElt.MakeBlob(hostAddressAddressBytes);
             AsnElt hostAddressAddressSeq = AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] { hostAddressAddressAsn });
             hostAddressAddressSeq = AsnElt.MakeImplicit(AsnElt.CONTEXT, 1, hostAddressAddressSeq);

--- a/Rubeus/lib/krb_structures/EncTicketPart.cs
+++ b/Rubeus/lib/krb_structures/EncTicketPart.cs
@@ -67,7 +67,7 @@ namespace Rubeus
                         key = new EncryptionKey(s);
                         break;
                     case 2:
-                        crealm = Encoding.ASCII.GetString(s.Sub[0].GetOctetString());
+                        crealm = Encoding.UTF8.GetString(s.Sub[0].GetOctetString());
                         break;
                     case 3:
                         cname = new PrincipalName(s.Sub[0]);
@@ -135,7 +135,7 @@ namespace Rubeus
 
             // crealm                   [2] Realm
             //                          -- clients realm
-            AsnElt realmAsn = AsnElt.MakeString(AsnElt.IA5String, crealm);
+            AsnElt realmAsn = AsnElt.MakeString(AsnElt.UTF8String, crealm);
             realmAsn = AsnElt.MakeImplicit(AsnElt.UNIVERSAL, AsnElt.GeneralString, realmAsn);
             AsnElt realmSeq = AsnElt.Make(AsnElt.SEQUENCE, new[] { realmAsn });
             realmSeq = AsnElt.MakeImplicit(AsnElt.CONTEXT, 2, realmSeq);

--- a/Rubeus/lib/krb_structures/HostAddress.cs
+++ b/Rubeus/lib/krb_structures/HostAddress.cs
@@ -56,7 +56,7 @@ namespace Rubeus
                         addr_type = (Interop.HostAddressType)s.Sub[0].GetInteger();
                         break;
                     case 1:
-                        addr_string = Encoding.ASCII.GetString(s.Sub[0].GetOctetString());
+                        addr_string = Encoding.UTF8.GetString(s.Sub[0].GetOctetString());
                         break;
                     default:
                         break;

--- a/Rubeus/lib/krb_structures/KDC_PROXY_MESSAGE.cs
+++ b/Rubeus/lib/krb_structures/KDC_PROXY_MESSAGE.cs
@@ -44,7 +44,7 @@ namespace Rubeus
                         kerb_message = s.Sub[0].GetOctetString();
                         break;
                     case 1:
-                        target_domain = Encoding.ASCII.GetString(s.Sub[0].GetOctetString());
+                        target_domain = Encoding.UTF8.GetString(s.Sub[0].GetOctetString());
                         break;
                     case 2:
                         dclocator_hint = Convert.ToUInt32(s.Sub[0].GetInteger());
@@ -68,7 +68,7 @@ namespace Rubeus
             // target-domain [1] KerberosString OPTIONAL,
             if (target_domain != null)
             {
-                AsnElt domainAsn = AsnElt.MakeString(AsnElt.IA5String, target_domain);
+                AsnElt domainAsn = AsnElt.MakeString(AsnElt.UTF8String, target_domain);
                 domainAsn = AsnElt.MakeImplicit(AsnElt.UNIVERSAL, AsnElt.GeneralString, domainAsn);
                 AsnElt domainSeq = AsnElt.Make(AsnElt.SEQUENCE, new[] { domainAsn });
                 domainSeq = AsnElt.MakeImplicit(AsnElt.CONTEXT, 1, domainSeq);

--- a/Rubeus/lib/krb_structures/KDC_REQ_BODY.cs
+++ b/Rubeus/lib/krb_structures/KDC_REQ_BODY.cs
@@ -76,7 +76,7 @@ namespace Rubeus
                         cname = new PrincipalName(s.Sub[0]);
                         break;
                     case 2:
-                        realm = Encoding.ASCII.GetString(s.Sub[0].GetOctetString());
+                        realm = Encoding.UTF8.GetString(s.Sub[0].GetOctetString());
                         break;
                     case 3:
                         // optional

--- a/Rubeus/lib/krb_structures/KRB_ERROR.cs
+++ b/Rubeus/lib/krb_structures/KRB_ERROR.cs
@@ -56,19 +56,19 @@ namespace Rubeus
                         error_code = Convert.ToUInt32(s.Sub[0].GetInteger());
                         break;
                     case 7:
-                        crealm = Encoding.ASCII.GetString(s.Sub[0].GetOctetString());
+                        crealm = Encoding.UTF8.GetString(s.Sub[0].GetOctetString());
                         break;
                     case 8:
                         cname = new PrincipalName(s.Sub[0]);
                         break;
                     case 9:
-                        realm = Encoding.ASCII.GetString(s.Sub[0].GetOctetString());
+                        realm = Encoding.UTF8.GetString(s.Sub[0].GetOctetString());
                         break;
                     case 10:
                         sname = new PrincipalName(s.Sub[0]);
                         break;
                     case 11:
-                        e_text = Encoding.ASCII.GetString(s.Sub[0].GetOctetString());
+                        e_text = Encoding.UTF8.GetString(s.Sub[0].GetOctetString());
                         break;
                     case 12:
                         try

--- a/Rubeus/lib/krb_structures/KrbCredInfo.cs
+++ b/Rubeus/lib/krb_structures/KrbCredInfo.cs
@@ -46,7 +46,7 @@ namespace Rubeus
                         key = new EncryptionKey(s);
                         break;
                     case 1:
-                        prealm = Encoding.ASCII.GetString(s.Sub[0].GetOctetString());
+                        prealm = Encoding.UTF8.GetString(s.Sub[0].GetOctetString());
                         break;
                     case 2:
                         pname = new PrincipalName(s.Sub[0]);
@@ -69,7 +69,7 @@ namespace Rubeus
                         renew_till = s.Sub[0].GetTime();
                         break;
                     case 8:
-                        srealm = Encoding.ASCII.GetString(s.Sub[0].GetOctetString());
+                        srealm = Encoding.UTF8.GetString(s.Sub[0].GetOctetString());
                         break;
                     case 9:
                         sname = new PrincipalName(s.Sub[0]);
@@ -93,7 +93,7 @@ namespace Rubeus
             // prealm          [1] Realm OPTIONAL
             if (!String.IsNullOrEmpty(prealm))
             {
-                AsnElt prealmAsn = AsnElt.MakeString(AsnElt.IA5String, prealm);
+                AsnElt prealmAsn = AsnElt.MakeString(AsnElt.UTF8String, prealm);
                 prealmAsn = AsnElt.MakeImplicit(AsnElt.UNIVERSAL, AsnElt.GeneralString, prealmAsn);
                 AsnElt prealmAsnSeq = AsnElt.Make(AsnElt.SEQUENCE, prealmAsn);
                 prealmAsnSeq = AsnElt.MakeImplicit(AsnElt.CONTEXT, 1, prealmAsnSeq);
@@ -166,7 +166,7 @@ namespace Rubeus
             // srealm          [8] Realm OPTIONAL
             if (!String.IsNullOrEmpty(srealm))
             {
-                AsnElt srealmAsn = AsnElt.MakeString(AsnElt.IA5String, srealm);
+                AsnElt srealmAsn = AsnElt.MakeString(AsnElt.UTF8String, srealm);
                 srealmAsn = AsnElt.MakeImplicit(AsnElt.UNIVERSAL, AsnElt.GeneralString, srealmAsn);
                 AsnElt srealmAsnSeq = AsnElt.Make(AsnElt.SEQUENCE, srealmAsn);
                 srealmAsnSeq = AsnElt.MakeImplicit(AsnElt.CONTEXT, 8, srealmAsnSeq);

--- a/Rubeus/lib/krb_structures/TGS_REP.cs
+++ b/Rubeus/lib/krb_structures/TGS_REP.cs
@@ -65,7 +65,7 @@ namespace Rubeus
                         padata = new PA_DATA(s.Sub[0]);
                         break;
                     case 3:
-                        crealm = Encoding.ASCII.GetString(s.Sub[0].GetOctetString());
+                        crealm = Encoding.UTF8.GetString(s.Sub[0].GetOctetString());
                         break;
                     case 4:
                         cname = new PrincipalName(s.Sub[0]);

--- a/Rubeus/lib/krb_structures/TGS_REQ.cs
+++ b/Rubeus/lib/krb_structures/TGS_REQ.cs
@@ -66,7 +66,7 @@ namespace Rubeus
             }
 
             // the realm (domain) the user exists in
-            req.req_body.realm = targetDomain.ToUpper();
+            req.req_body.realm = targetDomain.ToUpperInvariant();
 
             // add in our encryption types
             if (requestEType == Interop.KERB_ETYPE.subkey_keymaterial)
@@ -200,11 +200,11 @@ namespace Rubeus
                     req.req_body.kdcOptions = req.req_body.kdcOptions | Interop.KdcOptions.FORWARDED;
 
                 // get hostname and hostname of SPN
-                string hostName = Dns.GetHostName().ToUpper();
+                string hostName = Dns.GetHostName().ToUpperInvariant();
                 string targetHostName;
                 if (parts.Length > 1)
                 {
-                    targetHostName = parts[1].Substring(0, parts[1].IndexOf('.')).ToUpper();
+                    targetHostName = parts[1].Substring(0, parts[1].IndexOf('.')).ToUpperInvariant();
                 }
                 else
                 {
@@ -230,7 +230,7 @@ namespace Rubeus
                 if (!String.IsNullOrEmpty(s4uUser))
                 {
                     DateTime till = DateTime.Now;
-                    till = till.AddMinutes(15);
+                    till = till.AddMinutes(15).ToUniversalTime();
                     req.req_body.till = till;
                 }
 
@@ -260,7 +260,7 @@ namespace Rubeus
             if (opsec && (!String.IsNullOrEmpty(s4uUser)))
             {
                 // real packets seem to lowercase the domain in these 2 PA_DATA's
-                domain = domain.ToLower();
+                domain = domain.ToLowerInvariant();
 
                 // PA_S4U_X509_USER commented out until we get the checksum working
                 PA_DATA s4upadata = new PA_DATA(clientKey, s4uUser, domain, req.req_body.nonce, paEType);

--- a/Rubeus/lib/krb_structures/Ticket.cs
+++ b/Rubeus/lib/krb_structures/Ticket.cs
@@ -39,7 +39,7 @@ namespace Rubeus
                         tkt_vno = Convert.ToInt32(s.Sub[0].GetInteger());
                         break;
                     case 1:
-                        realm = Encoding.ASCII.GetString(s.Sub[0].GetOctetString());
+                        realm = Encoding.UTF8.GetString(s.Sub[0].GetOctetString());
                         break;
                     case 2:
                         sname = new PrincipalName(s.Sub[0]);
@@ -62,7 +62,7 @@ namespace Rubeus
 
 
             // realm           [1] Realm
-            AsnElt realmAsn = AsnElt.MakeString(AsnElt.IA5String, realm);
+            AsnElt realmAsn = AsnElt.MakeString(AsnElt.UTF8String, realm);
             realmAsn = AsnElt.MakeImplicit(AsnElt.UNIVERSAL, AsnElt.GeneralString, realmAsn);
             AsnElt realmAsnSeq = AsnElt.Make(AsnElt.SEQUENCE, realmAsn);
             realmAsnSeq = AsnElt.MakeImplicit(AsnElt.CONTEXT, 1, realmAsnSeq);


### PR DESCRIPTION
Unicode characters in domain names broke much functionality in Rubeus, this PR fixes that along with a small fix to the `till` value for `s4u /opsec` which was using local time and resulted in a `KDC_ERR_NEVER_VALID` in any timezone -UTC