### PR TITLE
Search certificates in User and Computer store

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Rubeus is licensed under the BSD 3-Clause license.
         Retrieve a TGT using a PCKS12 certificate, start a /netonly process, and to apply the ticket to the new process/logon session:
             Rubeus.exe asktgt /user:USER /certificate:C:\temp\leaked.pfx </password:STOREPASSWORD> /createnetonly:C:\Windows\System32\cmd.exe [/getcredentials] [/servicekey:KRBTGTKEY] [/show] [/domain:DOMAIN] [/dc:DOMAIN_CONTROLLER] [/nowrap] [/proxyurl:https://KDC_PROXY/kdcproxy] [/suppenctype:DES|RC4|AES128|AES256]
 
-        Retrieve a TGT using a certificate from the users keystore (Smartcard) specifying certificate thumbprint or subject, start a /netonly process, and to apply the ticket to the new process/logon session:
+        Retrieve a TGT using a certificate from the users or (if readable) computers keystore (Smartcard) specifying certificate thumbprint or subject, start a /netonly process, and to apply the ticket to the new process/logon session:
             Rubeus.exe asktgt /user:USER /certificate:f063e6f4798af085946be6cd9d82ba3999c7ebac /createnetonly:C:\Windows\System32\cmd.exe [/show] [/domain:DOMAIN] [/dc:DOMAIN_CONTROLLER] [/suppenctype:DES|RC4|AES128|AES256] [/nowrap]
 
         Retrieve a TGT suitable for changing an account with an expired password using the changepw command

--- a/Rubeus/lib/Ask.cs
+++ b/Rubeus/lib/Ask.cs
@@ -165,18 +165,12 @@ namespace Rubeus {
                 return new X509Certificate2(certificate, storePassword);
             } else {
 
-                X509Store store = new X509Store(StoreName.My, StoreLocation.CurrentUser);
-                store.Open(OpenFlags.ReadOnly);
-                X509Certificate2 result = null;
+                // first try to find certificate in user's store
+                X509Certificate2 result = FindCertificateInStore(certificate, StoreLocation.CurrentUser);
 
-                foreach (var cert in store.Certificates) {
-                    if (string.Equals(certificate, cert.Subject, StringComparison.InvariantCultureIgnoreCase)) {
-                        result = cert;
-                        break;
-                    } else if (string.Equals(certificate, cert.Thumbprint, StringComparison.InvariantCultureIgnoreCase)) {
-                        result = cert;
-                        break;
-                    }
+                // also search for certificate in computer's store. May be readable if missconfigured.
+                if (result == null ) { 
+                    result = FindCertificateInStore(certificate, StoreLocation.LocalMachine);
                 }
 
                 if (result != null && !String.IsNullOrEmpty(storePassword)) {
@@ -185,6 +179,29 @@ namespace Rubeus {
 
                 return result;
             }
+        }
+
+        private static X509Certificate2 FindCertificateInStore(string certificate, StoreLocation location)
+        {
+            X509Store store = new X509Store(StoreName.My, location);
+            store.Open(OpenFlags.ReadOnly);
+            X509Certificate2 result = null;
+
+            foreach (var cert in store.Certificates)
+            {
+                if (string.Equals(certificate, cert.Subject, StringComparison.InvariantCultureIgnoreCase))
+                {
+                    result = cert;
+                    break;
+                }
+                else if (string.Equals(certificate, cert.Thumbprint, StringComparison.InvariantCultureIgnoreCase))
+                {
+                    result = cert;
+                    break;
+                }
+            }
+
+            return result;
         }
 
         public static byte[] TGT(string userName, string domain, string certFile, string certPass, Interop.KERB_ETYPE etype, string outfile, bool ptt, string domainController = "", LUID luid = new LUID(), bool describe = false, bool verifyCerts = false, string servicekey = "", bool getCredentials = false, string proxyUrl = null, string service = null, bool changepw = false, string principalType="principal") {


### PR DESCRIPTION
During a recent penetration test we discovered that the customer had given end user's the permission to read the private keys of several certificates within the computer store. As some could be used for authentication we tried to use /asktgt on them. However, because only the user's store is searched in the current release this failed.

Hence, we updated the sourcecode to not only check the user's, but also the computer store. 