### PR TITLE
Fix Netbios address padding: 16 bytes instead of 8

### DIFF
--- a/Rubeus/lib/krb_structures/HostAddress.cs
+++ b/Rubeus/lib/krb_structures/HostAddress.cs
@@ -28,7 +28,7 @@ namespace Rubeus
             addr_type = Interop.HostAddressType.ADDRTYPE_NETBIOS;
 
             // setup padding
-            Int32 numSpaces = 8 - (hostName.Length % 8);
+            Int32 numSpaces = 16 - (hostName.Length % 16);
             hostName = hostName.PadRight(hostName.Length + numSpaces);
 
             addr_string = hostName.ToUpper();
@@ -40,7 +40,7 @@ namespace Rubeus
             addr_type = atype;
 
             // setup padding
-            Int32 numSpaces = 8 - (address.Length % 8);
+            Int32 numSpaces = 16 - (address.Length % 16);
             address = address.PadRight(address.Length + numSpaces);
 
             addr_string = address.ToUpper();


### PR DESCRIPTION
Hi!

Rubeus currently pads Netbios addresses to the nearest 8 byte. This is incorrect according to RFC4120, and to the behaviour observed on a Windows machine.

[RFC4120, section 7.1](https://datatracker.ietf.org/doc/html/rfc4120#section-7.1):
```
   Netbios Addresses

      Netbios addresses are 16-octet addresses typically composed of 1
      to 15 alphanumeric characters and padded with the US-ASCII SPC
      character (code 32).  The 16th octet MUST be the US-ASCII NUL
      character (code 0).  The type of Netbios addresses is twenty (20).
```

This leads to a divergence between network traffic generated by a normal Windows AS-REQ, and by Rubeus' `asktgt /opsec` method.  This also leads to a dissection error in Wireshark when the requesting machine's hostname is shorter than 8 bytes.

Note that contrary to the RFC, I observed that Windows doesn't set the 16th byte to 0 and instead uses another space character.

Cheers!