### PR TITLE
(For review)Clearer messaging when working with Credential Guard blobs

### DIFF
--- a/Rubeus/lib/Crypto.cs
+++ b/Rubeus/lib/Crypto.cs
@@ -124,6 +124,10 @@ namespace Rubeus
         {
             Interop.KERB_ECRYPT pCSystem;
             IntPtr pCSystemPtr;
+
+            if (eType == Interop.KERB_ETYPE.credGuard_blob)
+                throw new throw new ArgumentException("Cannot encrypt Credential Guard blobs");
+
             
             // locate the crypto system
             int status = Interop.CDLocateCSystem(eType, out pCSystemPtr);
@@ -162,6 +166,9 @@ namespace Rubeus
         {
             Interop.KERB_ECRYPT pCSystem;
             IntPtr pCSystemPtr;
+
+            if (eType == Interop.KERB_ETYPE.credGuard_blob)
+                throw new throw new ArgumentException("Cannot encrypt Credential Guard blobs");
 
             // locate the crypto system
             int status = Interop.CDLocateCSystem(eType, out pCSystemPtr);

--- a/Rubeus/lib/Crypto.cs
+++ b/Rubeus/lib/Crypto.cs
@@ -126,7 +126,7 @@ namespace Rubeus
             IntPtr pCSystemPtr;
 
             if (eType == Interop.KERB_ETYPE.credGuard_blob)
-                throw new throw new ArgumentException("Cannot decrypt Credential Guard blobs");
+                throw new ArgumentException("Cannot decrypt Credential Guard blobs");
 
             
             // locate the crypto system
@@ -168,7 +168,7 @@ namespace Rubeus
             IntPtr pCSystemPtr;
 
             if (eType == Interop.KERB_ETYPE.credGuard_blob)
-                throw new throw new ArgumentException("Cannot encrypt Credential Guard blobs");
+                throw new ArgumentException("Cannot encrypt Credential Guard blobs");
 
             // locate the crypto system
             int status = Interop.CDLocateCSystem(eType, out pCSystemPtr);

--- a/Rubeus/lib/Crypto.cs
+++ b/Rubeus/lib/Crypto.cs
@@ -126,7 +126,7 @@ namespace Rubeus
             IntPtr pCSystemPtr;
 
             if (eType == Interop.KERB_ETYPE.credGuard_blob)
-                throw new throw new ArgumentException("Cannot encrypt Credential Guard blobs");
+                throw new throw new ArgumentException("Cannot decrypt Credential Guard blobs");
 
             
             // locate the crypto system

--- a/Rubeus/lib/Interop.cs
+++ b/Rubeus/lib/Interop.cs
@@ -141,6 +141,7 @@ namespace Rubeus
             rc4_hmac_exp = 24,
             subkey_keymaterial = 65,
             old_exp = -135
+            credGuard_blob = -180
         }
 
         [Flags]

--- a/Rubeus/lib/Interop.cs
+++ b/Rubeus/lib/Interop.cs
@@ -140,7 +140,7 @@ namespace Rubeus
             rc4_hmac = 23,
             rc4_hmac_exp = 24,
             subkey_keymaterial = 65,
-            old_exp = -135
+            old_exp = -135,
             credGuard_blob = -180
         }
 


### PR DESCRIPTION
After some running into issues playing around with S4U, I think some messaging around Credential Guard can be clearer. Eventually after tracking it down I found the following statement from CCob:

```We have been meaning to update Rubeus to change -180 to indicate CredGuard instead of lets say AES256 for normal keys```

So thought I'd give it a try or get the ball rolling. but I suspect this is far more complicated than this patch addresses and someone can point out the problems I'd be causing, but on the surface this addresses what I ran into.

To be honest I was hoping I might trigger some automating testing so haven't really thought it through.

