### PR TITLE
Support Delegated Managed Service Account Kerberos Processes

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Rubeus is licensed under the BSD 3-Clause license.
       | |  \ \| |_| | |_) ) ____| |_| |___ |
       |_|   |_|____/|____/|_____)____/(___/
 
-      v2.3.1
+      v2.3.3
 
 
      Ticket requests and renewals:

--- a/README.md
+++ b/README.md
@@ -114,6 +114,12 @@ Rubeus is licensed under the BSD 3-Clause license.
 
        Retrieve a service ticket for one or more SPNs, optionally saving or applying the ticket:
             Rubeus.exe asktgs </ticket:BASE64 | /ticket:FILE.KIRBI> </service:SPN1,SPN2,...> [/enctype:DES|RC4|AES128|AES256] [/dc:DOMAIN_CONTROLLER] [/outfile:FILENAME] [/ptt] [/nowrap] [/enterprise] [/opsec] </tgs:BASE64 | /tgs:FILE.KIRBI> [/targetdomain] [/u2u] [/targetuser] [/servicekey:PASSWORDHASH] [/asrepkey:ASREPKEY] [/proxyurl:https://KDC_PROXY/kdcproxy]
+	
+	Retrieve a service ticket using the Kerberos Key List Request options:
+        	Rubeus.exe asktgs /keyList /service:KRBTGT_SPN </ticket:BASE64 | /ticket:FILE.KIRBI> [/enctype:DES|RC4|AES128|AES256] [/dc:DOMAIN_CONTROLLER] [/outfile:FILENAME] [/ptt] [/nowrap] [/enterprise] [/opsec] </tgs:BASE64 | /tgs:FILE.KIRBI> [/targetdomain] [/u2u] [/targetuser] [/servicekey:PASSWORDHASH] [/asrepkey:ASREPKEY] [/proxyurl:https://KDC_PROXY/kdcproxy]
+
+	Retrieve a delegated managed service account ticket:
+        	Rubeus.exe asktgs /dmsa /opsec /service:KRBTGT_SPN /targetuser:DMSA_ACCOUNT$ </ticket:BASE64 | /ticket:FILE.KIRBI> [/dc:DOMAIN_CONTROLLER_Win2025] [/outfile:FILENAME] [/ptt] [/nowrap] [/servicekey:PASSWORDHASH] [/asrepkey:ASREPKEY] [/proxyurl:https://KDC_PROXY/kdcproxy]
 
         Renew a TGT, optionally applying the ticket, saving it, or auto-renewing the ticket up to its renew-till limit:
             Rubeus.exe renew </ticket:BASE64 | /ticket:FILE.KIRBI> [/dc:DOMAIN_CONTROLLER] [/outfile:FILENAME] [/ptt] [/autorenew] [/nowrap]

--- a/Rubeus/Commands/Asktgs.cs
+++ b/Rubeus/Commands/Asktgs.cs
@@ -29,6 +29,7 @@ namespace Rubeus.Commands
             bool printargs = false;
             bool keyList = false;
             string proxyUrl = null;
+            bool dmsa = false;
 
             if (arguments.ContainsKey("/keyList"))
             {
@@ -160,6 +161,11 @@ namespace Rubeus.Commands
                 proxyUrl = arguments["/proxyurl"];
             }
 
+            if (arguments.ContainsKey("/dmsa"))
+            {
+                dmsa = true;
+            }
+
             if (arguments.ContainsKey("/ticket"))
             {
                 string kirbi64 = arguments["/ticket"];
@@ -168,14 +174,14 @@ namespace Rubeus.Commands
                 {
                     byte[] kirbiBytes = Convert.FromBase64String(kirbi64);
                     KRB_CRED kirbi = new KRB_CRED(kirbiBytes);
-                    Ask.TGS(kirbi, service, requestEnctype, outfile, ptt, dc, true, enterprise, false, opsec, tgs, targetDomain, servicekey, asrepkey, u2u, targetUser, printargs, proxyUrl, keyList);
+                    Ask.TGS(kirbi, service, requestEnctype, outfile, ptt, dc, true, enterprise, false, opsec, tgs, targetDomain, servicekey, asrepkey, u2u, targetUser, printargs, proxyUrl, keyList, dmsa);
                     return;
                 }
                 else if (File.Exists(kirbi64))
                 {
                     byte[] kirbiBytes = File.ReadAllBytes(kirbi64);
                     KRB_CRED kirbi = new KRB_CRED(kirbiBytes);
-                    Ask.TGS(kirbi, service, requestEnctype, outfile, ptt, dc, true, enterprise, false, opsec, tgs, targetDomain, servicekey, asrepkey, u2u, targetUser, printargs, proxyUrl, keyList);
+                    Ask.TGS(kirbi, service, requestEnctype, outfile, ptt, dc, true, enterprise, false, opsec, tgs, targetDomain, servicekey, asrepkey, u2u, targetUser, printargs, proxyUrl, keyList, dmsa);
                     return;
                 }
                 else

--- a/Rubeus/Domain/Info.cs
+++ b/Rubeus/Domain/Info.cs
@@ -44,6 +44,9 @@ namespace Rubeus.Domain
     Retrieve a service ticket using the Kerberos Key List Request options:
         Rubeus.exe asktgs /keyList /service:KRBTGT_SPN </ticket:BASE64 | /ticket:FILE.KIRBI> [/enctype:DES|RC4|AES128|AES256] [/dc:DOMAIN_CONTROLLER] [/outfile:FILENAME] [/ptt] [/nowrap] [/enterprise] [/opsec] </tgs:BASE64 | /tgs:FILE.KIRBI> [/targetdomain] [/u2u] [/targetuser] [/servicekey:PASSWORDHASH] [/asrepkey:ASREPKEY] [/proxyurl:https://KDC_PROXY/kdcproxy]
 
+    Retrieve a delegated managed service account ticket:
+        Rubeus.exe asktgs /dmsa /opsec /service:KRBTGT_SPN /targetuser:DMSA_ACCOUNT$ </ticket:BASE64 | /ticket:FILE.KIRBI> [/dc:DOMAIN_CONTROLLER_Win2025] [/outfile:FILENAME] [/ptt] [/nowrap] [/servicekey:PASSWORDHASH] [/asrepkey:ASREPKEY] [/proxyurl:https://KDC_PROXY/kdcproxy]
+
     Renew a TGT, optionally applying the ticket, saving it, or auto-renewing the ticket up to its renew-till limit:
         Rubeus.exe renew </ticket:BASE64 | /ticket:FILE.KIRBI> [/dc:DOMAIN_CONTROLLER] [/outfile:FILENAME] [/ptt] [/autorenew] [/nowrap]
 

--- a/Rubeus/Domain/Info.cs
+++ b/Rubeus/Domain/Info.cs
@@ -12,7 +12,7 @@ namespace Rubeus.Domain
             Console.WriteLine("  |  __  /| | | |  _ \\| ___ | | | |/___)");
             Console.WriteLine("  | |  \\ \\| |_| | |_) ) ____| |_| |___ |");
             Console.WriteLine("  |_|   |_|____/|____/|_____)____/(___/\r\n");
-            Console.WriteLine("  v2.3.2 \r\n");
+            Console.WriteLine("  v2.3.3 \r\n");
         }
 
         public static void ShowUsage()

--- a/Rubeus/Rubeus.csproj
+++ b/Rubeus/Rubeus.csproj
@@ -135,6 +135,8 @@
     <Compile Include="lib\krb_structures\Authenticator.cs" />
     <Compile Include="lib\krb_structures\AuthorizationData.cs" />
     <Compile Include="lib\krb_structures\Checksum.cs" />
+    <Compile Include="lib\krb_structures\PA_DMSA_KEY_PACKAGE.cs" />
+    <Compile Include="lib\krb_structures\PA_SUPERSEDED_BY_USER.cs" />
     <Compile Include="lib\krb_structures\PA_KEY_LIST_REP.cs" />
     <Compile Include="lib\krb_structures\EncryptedPAData.cs" />
     <Compile Include="lib\krb_structures\EncKDCRepPart.cs" />

--- a/Rubeus/lib/Ask.cs
+++ b/Rubeus/lib/Ask.cs
@@ -368,7 +368,7 @@ namespace Rubeus {
                 if (keyList)
                     Console.WriteLine("[*] Building KeyList TGS-REQ request for: '{0}'", userName);
                 else if (dmsa)
-                    Console.WriteLine("[*] Building DMSA TGS-REQ request for: '{0}'", userName);
+                    Console.WriteLine("[*] Building DMSA TGS-REQ request for '{0}' from '{1}'", targetUser, userName);
                 else if (!String.IsNullOrEmpty(service))
                     Console.WriteLine("[*] Building TGS-REQ request for: '{0}'", service);
                 else if (u2u)

--- a/Rubeus/lib/Ask.cs
+++ b/Rubeus/lib/Ask.cs
@@ -435,11 +435,11 @@ namespace Rubeus {
                     keyListHash = Helpers.ByteArrayToString(encRepPart.encryptedPaData.PA_KEY_LIST_REP.encryptionKey.keyvalue);
                 }
 
-                // extract current-keys and previous-keys from DMSA_KEY_PACKAGE 
-                string dmsaCurrentKeys = null;
+                // extract DMSA_KEY_PACKAGE for parsing to displayTicket.
+                PA_DMSA_KEY_PACKAGE dmsaCurrentKeys = null;
                 if (dmsa)
                 {
-                    dmsaCurrentKeys = Helpers.ByteArrayToString(encRepPart.encryptedPaData.PA_DMSA_KEY_PACKAGE.currentKeys.encryptionKey.keyvalue);
+                    dmsaCurrentKeys = encRepPart.encryptedPaData.PA_DMSA_KEY_PACKAGE;
                 }
 
                 // if using /opsec and the ticket is for a server configuration for unconstrained delegation, request a forwardable TGT
@@ -539,7 +539,7 @@ namespace Rubeus {
 
                     LSA.DisplayTicket(kirbi, 2, false, false, false, false, 
                         string.IsNullOrEmpty(servicekey) ? null : Helpers.StringToByteArray(servicekey), string.IsNullOrEmpty(asrepkey) ? null : Helpers.StringToByteArray(asrepkey),
-                        null,null,null,string.IsNullOrEmpty(keyListHash) ? null : Helpers.StringToByteArray(keyListHash), null, string.IsNullOrEmpty(dmsaCurrentKeys) ? null : Helpers.StringToByteArray(dmsaCurrentKeys));
+                        null,null,null,string.IsNullOrEmpty(keyListHash) ? null : Helpers.StringToByteArray(keyListHash), null, dmsaCurrentKeys);
                 }
 
                 if (!String.IsNullOrEmpty(outfile))

--- a/Rubeus/lib/Interop.cs
+++ b/Rubeus/lib/Interop.cs
@@ -260,14 +260,18 @@ namespace Rubeus
             PK_AS_09_BINDING = 132,
             CLIENT_CANONICALIZED = 133,
             KEY_LIST_REQ = 161,
-            KEY_LIST_REP = 162
+            KEY_LIST_REP = 162,
+            SUPERSEDED_BY_USER = 170,
+            DMSA_KEY_PACKAGE = 171
         }
 
         // from https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-sfu/cd9d5ca7-ce20-4693-872b-2f5dd41cbff6
         public enum PA_S4U_X509_USER_OPTIONS : Int32
         {
             CHECK_LOGON_RESTRICTIONS = 0x40000000,
-            SIGN_REPLY = 0x20000000
+            SIGN_REPLY = 0x20000000,
+            NT_AUTH_POLICY_NOT_REQUIRED = 0x10000000,
+            UNCONDITIONAL_DELEGATION = 0x08000000
         }
 
         [Flags]

--- a/Rubeus/lib/LSA.cs
+++ b/Rubeus/lib/LSA.cs
@@ -478,7 +478,7 @@ namespace Rubeus
             }
         }
 
-        public static void DisplayTicket(KRB_CRED cred, int indentLevel = 2, bool displayTGT = false, bool displayB64ticket = false, bool extractKerberoastHash = true, bool nowrap = false, byte[] serviceKey = null, byte[] asrepKey = null, string serviceUser = "", string serviceDomain = "", byte[] krbKey = null, byte[] keyList = null, string desPlainText = "", byte[] dmsaCurrentKeys = null)
+        public static void DisplayTicket(KRB_CRED cred, int indentLevel = 2, bool displayTGT = false, bool displayB64ticket = false, bool extractKerberoastHash = true, bool nowrap = false, byte[] serviceKey = null, byte[] asrepKey = null, string serviceUser = "", string serviceDomain = "", byte[] krbKey = null, byte[] keyList = null, string desPlainText = "", PA_DMSA_KEY_PACKAGE dmsaCurrentKeys = null)
         {
             // displays a given .kirbi (KRB_CRED) object, with display options
 
@@ -544,7 +544,11 @@ namespace Rubeus
 
                 if(dmsaCurrentKeys != null)
                 {
-                    Console.WriteLine("{0}Dmsa Current Key for {1}: {2}", indent, userName, Helpers.ByteArrayToString(dmsaCurrentKeys));
+                    string etypeName = Enum.GetName(typeof(Interop.KERB_ETYPE), dmsaCurrentKeys.currentKeys.encryptionKey.keytype);
+                    string cKeyValue = Helpers.ByteArrayToString(dmsaCurrentKeys.currentKeys.encryptionKey.keyvalue);
+
+
+                    Console.WriteLine("{0}Current Keys for {1}: ({2}) {3}", indent, userName, etypeName, cKeyValue);
                 }
 
 

--- a/Rubeus/lib/LSA.cs
+++ b/Rubeus/lib/LSA.cs
@@ -478,7 +478,7 @@ namespace Rubeus
             }
         }
 
-        public static void DisplayTicket(KRB_CRED cred, int indentLevel = 2, bool displayTGT = false, bool displayB64ticket = false, bool extractKerberoastHash = true, bool nowrap = false, byte[] serviceKey = null, byte[] asrepKey = null, string serviceUser = "", string serviceDomain = "", byte[] krbKey = null, byte[] keyList = null, string desPlainText = "")
+        public static void DisplayTicket(KRB_CRED cred, int indentLevel = 2, bool displayTGT = false, bool displayB64ticket = false, bool extractKerberoastHash = true, bool nowrap = false, byte[] serviceKey = null, byte[] asrepKey = null, string serviceUser = "", string serviceDomain = "", byte[] krbKey = null, byte[] keyList = null, string desPlainText = "", byte[] dmsaCurrentKeys = null)
         {
             // displays a given .kirbi (KRB_CRED) object, with display options
 
@@ -541,6 +541,12 @@ namespace Rubeus
                 {
                     Console.WriteLine("{0}Password Hash            :  {2}", indent, userName, Helpers.ByteArrayToString(keyList));
                 }
+
+                if(dmsaCurrentKeys != null)
+                {
+                    Console.WriteLine("{0}Dmsa Current Key for {1}: {2}", indent, userName, Helpers.ByteArrayToString(dmsaCurrentKeys));
+                }
+
 
                 //We display the ASREP decryption key as this is needed for decrypting
                 //PAC_CREDENTIAL_INFO inside both the AS-REP and TGS-REP Tickets when

--- a/Rubeus/lib/krb_structures/EncryptedPAData.cs
+++ b/Rubeus/lib/krb_structures/EncryptedPAData.cs
@@ -39,6 +39,12 @@ namespace Rubeus
                 PA_KEY_LIST_REP = new PA_KEY_LIST_REP(ae);
             }
 
+            // Decode the DMSA_KEY_PACKAGE
+            if (keytype == (Int32)Interop.PADATA_TYPE.DMSA_KEY_PACKAGE)
+            {
+                AsnElt ae = AsnElt.Decode(keyvalue);
+                PA_DMSA_KEY_PACKAGE = new PA_DMSA_KEY_PACKAGE(ae);
+            }
         }
 
         public Int32 keytype { get; set; }
@@ -46,5 +52,7 @@ namespace Rubeus
         public byte[] keyvalue { get; set; }
 
         public PA_KEY_LIST_REP PA_KEY_LIST_REP { get; set; }
+
+        public PA_DMSA_KEY_PACKAGE PA_DMSA_KEY_PACKAGE { get; set; }
     }
 }

--- a/Rubeus/lib/krb_structures/PA_DATA.cs
+++ b/Rubeus/lib/krb_structures/PA_DATA.cs
@@ -56,12 +56,12 @@ namespace Rubeus {
             value = new PA_FOR_USER(key, name, realm);
         }
 
-        public PA_DATA(byte[] key, string name, string realm, uint nonce, Interop.KERB_ETYPE eType = Interop.KERB_ETYPE.aes256_cts_hmac_sha1)
+        public PA_DATA(byte[] key, string name, string realm, uint nonce, Interop.KERB_ETYPE eType = Interop.KERB_ETYPE.aes256_cts_hmac_sha1, bool dmsa = false)
         {
             // used for constrained delegation
             type = Interop.PADATA_TYPE.PA_S4U_X509_USER;
 
-            value = new PA_S4U_X509_USER(key, name, realm, nonce, eType);
+            value = new PA_S4U_X509_USER(key, name, realm, nonce, eType, dmsa);
         }
 
         public PA_DATA(Interop.KERB_ETYPE eTYPE)
@@ -148,6 +148,12 @@ namespace Rubeus {
                     break;
                 case Interop.PADATA_TYPE.ETYPE_INFO2:
                     value = new ETYPE_INFO2_ENTRY(AsnElt.Decode(body.Sub[1].Sub[0].CopyValue()));
+                    break;
+                case Interop.PADATA_TYPE.SUPERSEDED_BY_USER:
+                    value = new PA_SUPERSEDED_BY_USER(AsnElt.Decode(body.Sub[1].Sub[0].CopyValue()));
+                    break;
+                case Interop.PADATA_TYPE.DMSA_KEY_PACKAGE:
+                    value = new PA_DMSA_KEY_PACKAGE(AsnElt.Decode(body.Sub[1].Sub[0].CopyValue()));
                     break;
             }
         }

--- a/Rubeus/lib/krb_structures/PA_DMSA_KEY_PACKAGE.cs
+++ b/Rubeus/lib/krb_structures/PA_DMSA_KEY_PACKAGE.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Asn1;
+
+namespace Rubeus
+{
+	public class PA_DMSA_KEY_PACKAGE
+	{
+		// KERB-DMSA-KEY-PACKAGE::= SEQUENCE {
+		//	current-keys[0] SEQUENCE OF EncryptionKey,
+		//  previous-keys[1] SEQUENCE OF EncryptionKey OPTIONAL,
+		//  expiration-interval[2] KerberosTime,
+		// fetch-interval[4] KerberosTime,
+		// }
+
+
+		public PA_DMSA_KEY_PACKAGE()
+		{
+			currentKeys = new PA_KEY_LIST_REP();
+			previousKeys = new PA_KEY_LIST_REP();
+			expirationInterval = DateTime.UtcNow;
+			fetchInterval = DateTime.UtcNow;
+        }
+
+		public PA_DMSA_KEY_PACKAGE(AsnElt body) 
+		{
+			currentKeys = new PA_KEY_LIST_REP(body.Sub[0].Sub[0]);
+			previousKeys = new PA_KEY_LIST_REP(body.Sub[1].Sub[0]);
+			expirationInterval = body.Sub[2].Sub[0].GetTime();
+			fetchInterval = body.Sub[3].Sub[0].GetTime();
+		}
+
+		public AsnElt Encode()
+		{
+
+			AsnElt currentKeysAsn = currentKeys.Encode();
+			AsnElt currentKeysSeq = AsnElt.Make(AsnElt.SEQUENCE, new[] { currentKeysAsn });
+
+			AsnElt previousKeysAsn = previousKeys.Encode();
+			AsnElt previousKeysSeq = AsnElt.Make(AsnElt.SEQUENCE, new[] { previousKeysAsn });
+
+			AsnElt expirationIntervalAsn = AsnElt.MakeTime(AsnElt.GeneralizedTime, expirationInterval);
+			AsnElt fetchIntervalAsn = AsnElt.MakeTime(AsnElt.GeneralizedTime, fetchInterval);
+
+			
+			AsnElt dmsaKeyPackageSeq = AsnElt.Make(AsnElt.SEQUENCE, new[] { currentKeysSeq, previousKeysSeq, expirationIntervalAsn, fetchIntervalAsn });
+			return dmsaKeyPackageSeq;
+		}
+
+		public PA_KEY_LIST_REP currentKeys { get; set; }
+		public PA_KEY_LIST_REP previousKeys { get; set; }
+		public DateTime expirationInterval { get; set; }
+		public DateTime fetchInterval { get; set; }
+	}
+}
+

--- a/Rubeus/lib/krb_structures/PA_KEY_LIST_REP.cs
+++ b/Rubeus/lib/krb_structures/PA_KEY_LIST_REP.cs
@@ -16,6 +16,13 @@ namespace Rubeus
             encryptionKey = new EncryptionKey(body);
         }
 
+        public AsnElt Encode()
+        {
+            AsnElt encryptionKeyAsn = encryptionKey.Encode();
+            AsnElt encryptionKeySeq = AsnElt.Make(AsnElt.SEQUENCE, new[] { encryptionKeyAsn });
+            return encryptionKeySeq;
+        }
+
         public EncryptionKey encryptionKey { get; set; }
 
     }

--- a/Rubeus/lib/krb_structures/PA_S4U_X509_USER.cs
+++ b/Rubeus/lib/krb_structures/PA_S4U_X509_USER.cs
@@ -13,9 +13,9 @@ namespace Rubeus
     
     public class PA_S4U_X509_USER
     {
-        public PA_S4U_X509_USER(byte[] key, string name, string realm, uint nonce, Interop.KERB_ETYPE eType = Interop.KERB_ETYPE.aes256_cts_hmac_sha1)
+        public PA_S4U_X509_USER(byte[] key, string name, string realm, uint nonce, Interop.KERB_ETYPE eType = Interop.KERB_ETYPE.aes256_cts_hmac_sha1, bool dmsa = false)
         {
-            user_id = new S4UUserID(name, realm, nonce);
+            user_id = new S4UUserID(name, realm, nonce, dmsa);
 
             AsnElt userIDAsn = user_id.Encode();
             AsnElt userIDSeq = AsnElt.Make(AsnElt.SEQUENCE, userIDAsn);

--- a/Rubeus/lib/krb_structures/PA_SUPERSEDED_BY_USER.cs
+++ b/Rubeus/lib/krb_structures/PA_SUPERSEDED_BY_USER.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Asn1;
+
+namespace Rubeus
+{
+	class PA_SUPERSEDED_BY_USER
+	{
+		// KERB-SUPERSEDED-BY-USER::= SEQUENCE {
+		//	name[0] PrincipalName,
+		// realm[1] Realm
+		//
+
+		public PA_SUPERSEDED_BY_USER()
+		{
+			name = new PrincipalName();
+			realm = null;
+		}
+
+		
+		public PA_SUPERSEDED_BY_USER(AsnElt body)
+		{
+			name = new PrincipalName(body.Sub[0].Sub[0]);
+			realm = Encoding.UTF8.GetString(body.Sub[1].Sub[0].GetOctetString());
+		}
+
+		public PrincipalName name { get; set; }
+		public  string realm { get; set; }
+	}
+}

--- a/Rubeus/lib/krb_structures/S4UUserID.cs
+++ b/Rubeus/lib/krb_structures/S4UUserID.cs
@@ -17,17 +17,33 @@ namespace Rubeus
 
     public class S4UUserID
     {
-        public S4UUserID(string name, string realm, uint n)
+        public S4UUserID(string name, string realm, uint n, bool dmsa = false)
         {
             nonce = n;
 
             cname = new PrincipalName(name);
-            cname.name_type = Interop.PRINCIPAL_TYPE.NT_ENTERPRISE;
+            if (dmsa)
+            {
+                cname.name_type = Interop.PRINCIPAL_TYPE.NT_PRINCIPAL;
+            }
+            else
+            {
+                cname.name_type = Interop.PRINCIPAL_TYPE.NT_ENTERPRISE;
+            }
+
 
             crealm = realm;
 
             // default for creation
             options = Interop.PA_S4U_X509_USER_OPTIONS.SIGN_REPLY;
+
+            if (dmsa)
+            {
+                // add unconditional_delegation
+                options |= Interop.PA_S4U_X509_USER_OPTIONS.UNCONDITIONAL_DELEGATION;
+            }
+            
+            
         }
 
         public AsnElt Encode()

--- a/Rubeus/lib/krb_structures/S4UUserID.cs
+++ b/Rubeus/lib/krb_structures/S4UUserID.cs
@@ -22,6 +22,7 @@ namespace Rubeus
             nonce = n;
 
             cname = new PrincipalName(name);
+            // DMSA Requests do not work with NT_ENTERPRISE, force NT_PRINCIPAL.
             if (dmsa)
             {
                 cname.name_type = Interop.PRINCIPAL_TYPE.NT_PRINCIPAL;

--- a/Rubeus/lib/krb_structures/TGS_REQ.cs
+++ b/Rubeus/lib/krb_structures/TGS_REQ.cs
@@ -104,7 +104,6 @@ namespace Rubeus
                 }
                 else if (dmsa)
                 {
-                    Console.WriteLine("sname_string");
                     req.req_body.sname.name_string.Add(parts[0]);
                     req.req_body.sname.name_string.Add(parts[1]);
                     req.req_body.sname.name_type = Interop.PRINCIPAL_TYPE.NT_SRV_INST;

--- a/Rubeus/lib/krb_structures/TGS_REQ.cs
+++ b/Rubeus/lib/krb_structures/TGS_REQ.cs
@@ -104,8 +104,11 @@ namespace Rubeus
                 }
                 else if (dmsa)
                 {
-                    req.req_body.sname.name_string.Add(parts[0]);
-                    req.req_body.sname.name_string.Add(parts[1]);
+                    // Add each part to the namestring. Format should be KRBTGT/DomainFQDN.
+                    foreach (string part in parts)
+                    {
+                        req.req_body.sname.name_string.Add(part);
+                    }
                     req.req_body.sname.name_type = Interop.PRINCIPAL_TYPE.NT_SRV_INST;
                 }
                 else
@@ -232,7 +235,7 @@ namespace Rubeus
                 }
 
                 // S4U requests have a till time of 15 minutes in the future
-                if (!String.IsNullOrEmpty(s4uUser) && !dmsa)
+                if (!String.IsNullOrEmpty(s4uUser))
                 {
                     DateTime till = DateTime.Now;
                     till = till.AddMinutes(15).ToUniversalTime();
@@ -272,7 +275,7 @@ namespace Rubeus
                 req.padata.Add(s4upadata);
             }
 
-            // add final S4U PA-DATA when not a DMSA request
+            // add final S4U PA-DATA when not a DMSA request as DMSA only uses the PA_S4U_X509_USER
             if (!String.IsNullOrEmpty(s4uUser) && !dmsa)
             {
                 // constrained delegation yo'
@@ -281,16 +284,8 @@ namespace Rubeus
             }
             else if (opsec)
             {
-                if (dmsa)
-                {
-                    PA_DATA padataoptions = new PA_DATA(true, false, false, false);
-                    req.padata.Add(padataoptions);
-                }
-                else
-                {
-                    PA_DATA padataoptions = new PA_DATA(false, true, false, false);
-                    req.padata.Add(padataoptions);
-                }
+                PA_DATA padataoptions = new PA_DATA(false, true, false, false);
+                req.padata.Add(padataoptions);
             }
             else if ((tgs != null) && !u2u)
             {


### PR DESCRIPTION
Added support for [Delegated Managed Service Accounts](https://learn.microsoft.com/en-us/windows-server/identity/ad-ds/manage/delegated-managed-service-accounts/delegated-managed-service-accounts-overview).

New Kerberos Structures:
* [KERB-SUPERSEDED-BY-USER](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-kile/79170b21-ad15-4a1b-99c4-84b3992d9e70)
* [KERB-DMSA-KEY-PACKAGE](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-kile/87f5f362-e53c-4949-9a6c-bc9184054517)

Commands Amended:
* AskTGS
  * New /dmsa switch

Example Usage:

```shell
# Get TGT of Windows 2025/24H2 system with a delegated MSA setup and migration finished.
.\Rubeus.exe dump /luid:0x3e4 /service:krbtgt /nowrap
# Take the ticket
.\Rubeus.exe asktgs /ticket:TICKET_FROM_ABOVE /targetuser:dMSA_1$ /service:krbtgt/domain.local /dmsa /dc:DC2025 /opsec /nowrap
```

![image](https://github.com/user-attachments/assets/ba8efb95-0c39-49d0-982f-6b3c6bc1d9ff)

Notes:
* Updated readme and info.cs with example and version update to 2.3.3.
* From testing so far DMSA requires the /opsec to work properly.
* DMSA only work on Windows Server 2025 DC / Windows 24H2 + Systems.
* Fixed an issue in HostAddresses with opsec



