### PR TITLE
PKINIT Authentication Minor Improvements

### DIFF
--- a/Rubeus/lib/Ask.cs
+++ b/Rubeus/lib/Ask.cs
@@ -650,9 +650,19 @@ namespace Rubeus {
 
             // convert the key string to bytes
             byte[] key;
-            if (GetPKInitRequest(asReq, out PA_PK_AS_REQ pkAsReq)) {      
+            if (GetPKInitRequest(asReq, out PA_PK_AS_REQ pkAsReq)) {
                 // generate the decryption key using Diffie Hellman shared secret 
-                PA_PK_AS_REP pkAsRep = (PA_PK_AS_REP)rep.padata[0].value;                    
+                // First find the padata type that is PK_AS_REP. Certain authentications can have multiple.
+                int i;
+                for (i = 0; i < rep.padata.Count; i++)
+                {
+                    if (rep.padata[i].type == Interop.PADATA_TYPE.PK_AS_REP)
+                    {
+                        break;
+                    }
+                }
+                // Use the found padata type and convert to PK_AS_REP
+                PA_PK_AS_REP pkAsRep = (PA_PK_AS_REP)rep.padata[i].value;
                 key = pkAsReq.Agreement.GenerateKey(pkAsRep.DHRepInfo.KDCDHKeyInfo.SubjectPublicKey.DepadLeft(), new byte[0], 
                     pkAsRep.DHRepInfo.ServerDHNonce, GetKeySize(etype));
             } else {

--- a/Rubeus/lib/krb_structures/AS_REP.cs
+++ b/Rubeus/lib/krb_structures/AS_REP.cs
@@ -64,9 +64,11 @@ namespace Rubeus
                         break;
                     case 2:
                         // sequence of pa-data
-                        foreach(AsnElt pad in s.Sub) {
-                            padata.Add(new PA_DATA(pad.Sub[0]));
-                        }                                                   
+                        int i;
+                        for (i = 0; i < s.Sub[0].Sub.Length; i++)
+                        {
+                            padata.Add(new PA_DATA(s.Sub[0].Sub[i]));
+                        }                                          
                         break;
                     case 3:
                         crealm = Encoding.UTF8.GetString(s.Sub[0].GetOctetString());

--- a/Rubeus/lib/krb_structures/KrbPkAuthenticator.cs
+++ b/Rubeus/lib/krb_structures/KrbPkAuthenticator.cs
@@ -27,6 +27,7 @@ namespace Rubeus {
         
             AsnElt asnCTime = AsnElt.MakeString(AsnElt.GeneralizedTime, CTime.ToString("yyyyMMddHHmmssZ"));
 
+            Console.WriteLine("PAChecksum is hit!");
             return AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] {
                     AsnElt.Make(AsnElt.CONTEXT,0, new AsnElt[] { AsnElt.MakeInteger(CuSec) }),
                     AsnElt.Make(AsnElt.CONTEXT,1, new AsnElt[]{ asnCTime } ),

--- a/Rubeus/lib/krb_structures/KrbPkAuthenticator.cs
+++ b/Rubeus/lib/krb_structures/KrbPkAuthenticator.cs
@@ -27,7 +27,6 @@ namespace Rubeus {
         
             AsnElt asnCTime = AsnElt.MakeString(AsnElt.GeneralizedTime, CTime.ToString("yyyyMMddHHmmssZ"));
 
-            Console.WriteLine("PAChecksum is hit!");
             return AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] {
                     AsnElt.Make(AsnElt.CONTEXT,0, new AsnElt[] { AsnElt.MakeInteger(CuSec) }),
                     AsnElt.Make(AsnElt.CONTEXT,1, new AsnElt[]{ asnCTime } ),

--- a/Rubeus/lib/krb_structures/PA_DATA.cs
+++ b/Rubeus/lib/krb_structures/PA_DATA.cs
@@ -108,6 +108,7 @@ namespace Rubeus {
             byte[] pubKeyInfo = AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] {
                 AsnElt.MakeInteger(agreement.P),
                 AsnElt.MakeInteger(agreement.G),
+                AsnElt.MakeInteger(agreement.Q),
             }).Encode();
      
             authPack.ClientPublicValue = new KrbSubjectPublicKeyInfo(new KrbAlgorithmIdentifier(DiffieHellman, pubKeyInfo),            

--- a/Rubeus/lib/krb_structures/PA_PK_AS_REQ.cs
+++ b/Rubeus/lib/krb_structures/PA_PK_AS_REQ.cs
@@ -36,10 +36,8 @@ namespace Rubeus {
             signed.ComputeSignature(signer, silent: false);
 
             return AsnElt.Make(AsnElt.SEQUENCE, new AsnElt[] {
-                AsnElt.Make(AsnElt.CONTEXT, 0, new AsnElt[]{
-                    AsnElt.MakeBlob(signed.Encode())
-                    //AsnElt.Decode(signed.Encode())
-                })
+                // SignedAuthPack must be implict for wireshark
+                AsnElt.MakeImplicit(AsnElt.CONTEXT, 0, AsnElt.MakeBlob(signed.Encode()))
             });
         }
     }


### PR DESCRIPTION
This PR was formed from the troubleshooting on #196 

The main reason for this PR is to include fix an issue we have where Windows Server 2025 Domain Controllers reply with two PA_DATA structures (ETYPE-INFO2 and PK-AS-REP) and Rubeus only expects a single structure and the first option is always ETYP-INFO2 meaning that the TGT request is successful but an error occurs when forming the AS-REP.

The other changes are exetremely minor and were made to get Wireshark to show better data when decoding:
* Adding the Q agreement was something I noticed was in the spec but not in the product
* Making the SignedAuthPack Implicit alligned with the protocol spec and allowed Wireshark to mostly decode it except for the EncapsContentInfo section.

