### PR TITLE
Fix  crash due empty attribute values

### DIFF
--- a/Rubeus/lib/Helpers.cs
+++ b/Rubeus/lib/Helpers.cs
@@ -532,7 +532,16 @@ namespace Rubeus
                     // default action convert to string
                     else
                     {
-                        ActiveDirectoryObject.Add(attribute, result.Attributes[attribute].GetValues(typeof(string))[0]);
+                        var values = result.Attributes[attribute].GetValues(typeof(string));
+                        string attributeValue;
+                        // check if property has empty value
+                        if(values.length > 0) {
+                            attributeValue = values[0];
+                        } else {
+                            // if so, return empty string
+                            attributeValue = "";
+                        }
+                        ActiveDirectoryObject.Add(attribute, attributeValue);
                     }
                 }
 
@@ -587,7 +596,16 @@ namespace Rubeus
                     // default action convert to string
                     else
                     {
-                        ActiveDirectoryObject.Add(attribute, result.Properties[attribute][0].ToString());
+                        var values = result.Properties[attribute];
+                        string attributeValue;
+                        // check if property has empty value
+                        if(values.length > 0) {
+                            attributeValue = values[0].ToString();
+                        } else {
+                            // if so, return empty string
+                            attributeValue = "";
+                        }
+                        ActiveDirectoryObject.Add(attribute, attributeValue);
                     }
                 }
 


### PR DESCRIPTION
This PR fixes #205.
 It's a very minimal patch to check for empty attributes in the string conversion block and replace it with an empty string, instead of skipping the property altogether, as I imagine that could ripple through other components depending on the specific property.